### PR TITLE
fix: stabilize iOS UniFFI cargo env

### DIFF
--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -99,7 +99,8 @@ Verified local commands:
 Current build note:
 
 - The simulator/unit-test path above is verified locally after the diagnostics addition.
-- The device `Release` Xcode path currently still depends on the host UniFFI cargo build inheriting a clean macOS SDK environment inside the pre-build script; the Rust release host build itself is verified separately with `SDKROOT="$(xcrun --sdk macosx --show-sdk-path)" RUSTFLAGS="-C linker=$(xcrun --sdk macosx --find clang) -C link-arg=-isysroot -C link-arg=$(xcrun --sdk macosx --show-sdk-path)" cargo build -p fire-uniffi --lib --release`.
+- The device `Release` Xcode path is also verified locally.
+- The UniFFI pre-build script now sanitizes host and iOS-target cargo environments separately: host cargo invocations keep the macOS SDK and library search path, while iOS target cargo invocations keep the macOS `SDKROOT` needed for host build scripts without leaking the macOS `LIBRARY_PATH` into iPhoneOS/iPhoneSimulator links.
 
 Planned responsibilities beyond the current wiring:
 

--- a/native/ios-app/scripts/sync_uniffi_bindings.sh
+++ b/native/ios-app/scripts/sync_uniffi_bindings.sh
@@ -169,10 +169,22 @@ run_host_cargo() {
 
 run_target_cargo() {
   if [[ "$(uname -s)" == "Darwin" ]]; then
+    local sdk_root
+    local iphoneos_deployment_target
+
+    sdk_root="$(xcrun --sdk macosx --show-sdk-path)"
+    iphoneos_deployment_target="${IPHONEOS_DEPLOYMENT_TARGET:-17.0}"
+
     env -i \
       HOME="$HOME" \
       PATH="$PATH" \
-      IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET:-17.0}" \
+      SDKROOT="$sdk_root" \
+      PLATFORM_NAME= \
+      EFFECTIVE_PLATFORM_NAME= \
+      ARCHS= \
+      IPHONEOS_DEPLOYMENT_TARGET="$iphoneos_deployment_target" \
+      TVOS_DEPLOYMENT_TARGET= \
+      WATCHOS_DEPLOYMENT_TARGET= \
       "$@"
   else
     "$@"


### PR DESCRIPTION
## Summary
- keep a clean macOS `SDKROOT` for iOS target cargo invocations in the UniFFI pre-build script
- continue clearing Xcode-injected platform env vars for target cargo builds without leaking the macOS `LIBRARY_PATH` into iOS links
- update the iOS README to reflect that both simulator tests and device Release builds are now verified locally

## Verification
- `xcodegen generate --spec native/ios-app/project.yml`
- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination "id=..." -derivedDataPath /tmp/fire-ios-tests CODE_SIGNING_ALLOWED=NO test`
- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -configuration Release -destination 'generic/platform=iOS' -derivedDataPath /tmp/fire-ios-release CODE_SIGNING_ALLOWED=NO build`

## Root cause
The previous iOS CI fix sanitized target cargo invocations so aggressively that `SDKROOT` disappeared entirely, which broke Rust host build-scripts on macOS with `ld: library 'System' not found`. The older behavior of carrying the macOS `LIBRARY_PATH` into target builds fixed that symptom but polluted iOS links with macOS libraries. This patch keeps the macOS `SDKROOT` for target cargo builds while omitting the macOS `LIBRARY_PATH`, so host build-scripts and iOS target links both resolve correctly.
