### PR TITLE
Improve topic detail interaction UX and stats

### DIFF
--- a/native/ios-app/App/FireComponents.swift
+++ b/native/ios-app/App/FireComponents.swift
@@ -550,6 +550,7 @@ struct FlowLayout: Layout {
         cache: inout ()
     ) -> CGSize {
         let maxWidth = resolvedMaxWidth(for: proposal)
+        let hasExplicitWidth = proposal.width.map { $0.isFinite && $0 > 0 } ?? false
         var lineWidth: CGFloat = 0
         var lineHeight: CGFloat = 0
         var totalHeight: CGFloat = 0
@@ -571,7 +572,8 @@ struct FlowLayout: Layout {
         totalHeight += lineHeight
         maxLineWidth = max(maxLineWidth, lineWidth)
 
-        return CGSize(width: maxLineWidth, height: totalHeight)
+        let reportedWidth = hasExplicitWidth ? maxWidth : maxLineWidth
+        return CGSize(width: reportedWidth, height: totalHeight)
     }
 
     func placeSubviews(

--- a/native/ios-app/App/FireProfileView.swift
+++ b/native/ios-app/App/FireProfileView.swift
@@ -31,6 +31,9 @@ struct FireProfileView: View {
                     settingsSection
                 }
             }
+            .refreshable {
+                await profileViewModel.refreshProfile()
+            }
             .background(FireTheme.canvasTop)
             .navigationTitle("我的")
             .toolbar {

--- a/native/ios-app/App/FireProfileViewModel.swift
+++ b/native/ios-app/App/FireProfileViewModel.swift
@@ -168,6 +168,23 @@ final class FireProfileViewModel: ObservableObject {
         loadActions(reset: true)
     }
 
+    func refreshProfile() async {
+        guard let username = normalizedCurrentUsername(), loadedUsername == username else { return }
+
+        do {
+            async let profileResult = appViewModel.fetchUserProfile(username: username)
+            async let summaryResult = appViewModel.fetchUserSummary(username: username)
+            let (fetchedProfile, fetchedSummary) = try await (profileResult, summaryResult)
+            guard loadedUsername == username else { return }
+            self.profile = fetchedProfile
+            self.summary = fetchedSummary
+            self.errorMessage = nil
+        } catch is CancellationError {
+        } catch {
+            self.errorMessage = error.localizedDescription
+        }
+    }
+
     func retry() {
         loadProfile(force: true)
     }

--- a/native/ios-app/App/FireTheme.swift
+++ b/native/ios-app/App/FireTheme.swift
@@ -112,6 +112,21 @@ enum FireTheme {
         UIColor(white: 1, alpha: 0.10)
     )
 
+    // MARK: - Chips
+
+    static let tagChipBackground = adaptive(
+        UIColor(red: 0.46, green: 0.46, blue: 0.50, alpha: 0.08),
+        UIColor(white: 1, alpha: 0.10)
+    )
+    static let tagChipForeground = adaptive(
+        UIColor(red: 0.30, green: 0.30, blue: 0.33, alpha: 1),
+        UIColor(red: 0.85, green: 0.84, blue: 0.82, alpha: 1)
+    )
+
+    static func categoryChipBackground(accent: Color, isDark: Bool) -> Color {
+        accent.opacity(isDark ? 0.22 : 0.14)
+    }
+
     // MARK: - Tab Bar
 
     static let tabBarBackground = adaptive(

--- a/native/ios-app/App/FireTopicDetailView.swift
+++ b/native/ios-app/App/FireTopicDetailView.swift
@@ -366,21 +366,25 @@ struct FireTopicDetailView: View {
             }
 
             if let originalPost {
-                FirePostRow(
-                    post: originalPost,
-                    depth: 0,
-                    replyContext: nil,
-                    showsThreadLine: false,
-                    baseURLString: baseURLString,
-                    reactionOptions: reactionOptions,
-                    canWriteInteractions: canWriteInteractions,
-                    isMutating: viewModel.isMutatingPost(postId: originalPost.id),
-                    onReply: { openComposer(replyToPost: $0) },
-                    onToggleLike: { toggleLike(for: $0) },
-                    onSelectReaction: { post, reactionId in
-                        toggleReaction(reactionId, for: post)
-                    }
-                )
+                FireSwipeToReplyContainer(enabled: canWriteInteractions) {
+                    openComposer(replyToPost: originalPost)
+                } content: {
+                    FirePostRow(
+                        post: originalPost,
+                        depth: 0,
+                        replyContext: nil,
+                        showsThreadLine: false,
+                        baseURLString: baseURLString,
+                        reactionOptions: reactionOptions,
+                        canWriteInteractions: canWriteInteractions,
+                        isMutating: viewModel.isMutatingPost(postId: originalPost.id),
+                        onReply: { openComposer(replyToPost: $0) },
+                        onToggleLike: { toggleLike(for: $0) },
+                        onSelectReaction: { post, reactionId in
+                            toggleReaction(reactionId, for: post)
+                        }
+                    )
+                }
                 .id(originalPost.postNumber)
                 .background(FireVisiblePostFrameReporter(postNumber: originalPost.postNumber))
             } else if let excerpt = row.excerptText {
@@ -509,21 +513,25 @@ struct FireTopicDetailView: View {
     @ViewBuilder
     private func replyPostRows(_ displayPosts: [FireTopicFlatPostPresentation]) -> some View {
         ForEach(Array(displayPosts.enumerated()), id: \.element.post.id) { index, flatPost in
-            FirePostRow(
-                post: flatPost.post,
-                depth: Int(flatPost.depth),
-                replyContext: flatPost.parentPostNumber.map { "回复 #\($0)" },
-                showsThreadLine: flatPost.showsThreadLine,
-                baseURLString: baseURLString,
-                reactionOptions: reactionOptions,
-                canWriteInteractions: canWriteInteractions,
-                isMutating: viewModel.isMutatingPost(postId: flatPost.post.id),
-                onReply: { openComposer(replyToPost: $0) },
-                onToggleLike: { toggleLike(for: $0) },
-                onSelectReaction: { post, reactionId in
-                    toggleReaction(reactionId, for: post)
-                }
-            )
+            FireSwipeToReplyContainer(enabled: canWriteInteractions) {
+                openComposer(replyToPost: flatPost.post)
+            } content: {
+                FirePostRow(
+                    post: flatPost.post,
+                    depth: Int(flatPost.depth),
+                    replyContext: flatPost.parentPostNumber.map { "回复 #\($0)" },
+                    showsThreadLine: flatPost.showsThreadLine,
+                    baseURLString: baseURLString,
+                    reactionOptions: reactionOptions,
+                    canWriteInteractions: canWriteInteractions,
+                    isMutating: viewModel.isMutatingPost(postId: flatPost.post.id),
+                    onReply: { openComposer(replyToPost: $0) },
+                    onToggleLike: { toggleLike(for: $0) },
+                    onSelectReaction: { post, reactionId in
+                        toggleReaction(reactionId, for: post)
+                    }
+                )
+            }
             .id(flatPost.post.postNumber)
             .background(FireVisiblePostFrameReporter(postNumber: flatPost.post.postNumber))
 
@@ -569,25 +577,23 @@ struct FireTopicDetailView: View {
 
             if let composerContext, let targetPost = composerTargetPost {
                 let canChangeTargetReaction = canChangeReaction(for: targetPost)
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
+                FlowLayout(spacing: 8, fallbackWidth: max(UIScreen.main.bounds.width - 32, 200)) {
+                    Button {
+                        toggleLike(for: targetPost)
+                    } label: {
+                        composerReactionPill(symbol: "❤️", label: "赞")
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(!canChangeTargetReaction)
+
+                    ForEach(nonHeartReactionOptions) { option in
                         Button {
-                            toggleLike(for: targetPost)
+                            toggleReaction(option.id, for: targetPost)
                         } label: {
-                            composerReactionPill(symbol: "❤️", label: "赞")
+                            composerReactionPill(symbol: option.symbol, label: option.label)
                         }
                         .buttonStyle(.plain)
                         .disabled(!canChangeTargetReaction)
-
-                        ForEach(nonHeartReactionOptions) { option in
-                            Button {
-                                toggleReaction(option.id, for: targetPost)
-                            } label: {
-                                composerReactionPill(symbol: option.symbol, label: option.label)
-                            }
-                            .buttonStyle(.plain)
-                            .disabled(!canChangeTargetReaction)
-                        }
                     }
                 }
 
@@ -1118,6 +1124,88 @@ private struct FirePostMetaAction: View {
         }
         .font(.caption2)
         .foregroundStyle(tint)
+    }
+}
+
+private struct FireSwipeToReplyContainer<Content: View>: View {
+    let enabled: Bool
+    let onSwipeReply: () -> Void
+    @ViewBuilder let content: () -> Content
+
+    @State private var offset: CGFloat = 0
+    @State private var gestureDirection: GestureAxis? = nil
+    @State private var replyTriggered = false
+
+    private enum GestureAxis { case horizontal, vertical }
+
+    private let triggerThreshold: CGFloat = 55
+    private let maxOffset: CGFloat = 75
+
+    var body: some View {
+        if enabled {
+            swipeableContent
+        } else {
+            content()
+        }
+    }
+
+    private var swipeableContent: some View {
+        content()
+            .offset(x: offset)
+            .background(alignment: .leading) {
+                if offset > 4 {
+                    replyIndicator
+                }
+            }
+            .clipped()
+            .contentShape(Rectangle())
+            .simultaneousGesture(swipeGesture)
+    }
+
+    private var replyIndicator: some View {
+        Image(systemName: "arrowshape.turn.up.left.fill")
+            .font(.system(size: 18, weight: .medium))
+            .foregroundStyle(replyTriggered ? FireTheme.accent : FireTheme.tertiaryInk)
+            .scaleEffect(min(offset / triggerThreshold, 1.0))
+            .opacity(Double(min(offset / (triggerThreshold * 0.5), 1.0)))
+            .frame(width: 32, height: 32)
+            .padding(.leading, 4)
+    }
+
+    private var swipeGesture: some Gesture {
+        DragGesture(minimumDistance: 18)
+            .onChanged { value in
+                let dx = value.translation.width
+                let dy = value.translation.height
+
+                if gestureDirection == nil {
+                    gestureDirection = abs(dx) > abs(dy) * 1.2 ? .horizontal : .vertical
+                }
+
+                guard gestureDirection == .horizontal, dx > 0 else { return }
+
+                let dampened = dx > triggerThreshold
+                    ? triggerThreshold + (dx - triggerThreshold) * 0.25
+                    : dx
+                withAnimation(.interactiveSpring()) {
+                    offset = min(dampened, maxOffset)
+                }
+
+                if offset >= triggerThreshold && !replyTriggered {
+                    replyTriggered = true
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                }
+            }
+            .onEnded { _ in
+                if replyTriggered {
+                    onSwipeReply()
+                }
+                withAnimation(.spring(response: 0.25, dampingFraction: 0.7)) {
+                    offset = 0
+                }
+                gestureDirection = nil
+                replyTriggered = false
+            }
     }
 }
 

--- a/native/ios-app/App/FireTopicDetailView.swift
+++ b/native/ios-app/App/FireTopicDetailView.swift
@@ -153,8 +153,8 @@ struct FireTopicDetailView: View {
         return max(detail.postStream.posts.count - 1, 0)
     }
 
-    private var displayedLikeCount: UInt32 {
-        detail?.likeCount ?? topic.likeCount
+    private var displayedInteractionCount: UInt32? {
+        detail?.interactionCount
     }
 
     private var displayedViewsCount: UInt32 {
@@ -397,7 +397,7 @@ struct FireTopicDetailView: View {
             HStack(spacing: 20) {
                 statLabel(value: "\(displayedReplyCount)", label: "回复")
                 statLabel(value: "\(displayedViewsCount)", label: "浏览")
-                statLabel(value: "\(displayedLikeCount)", label: "互动")
+                statLabel(value: displayedInteractionCount.map(String.init) ?? "…", label: "互动")
             }
             .padding(.vertical, 4)
         }

--- a/native/ios-app/App/FireTopicDetailView.swift
+++ b/native/ios-app/App/FireTopicDetailView.swift
@@ -375,10 +375,8 @@ struct FireTopicDetailView: View {
                         replyContext: nil,
                         showsThreadLine: false,
                         baseURLString: baseURLString,
-                        reactionOptions: reactionOptions,
                         canWriteInteractions: canWriteInteractions,
                         isMutating: viewModel.isMutatingPost(postId: originalPost.id),
-                        onReply: { openComposer(replyToPost: $0) },
                         onToggleLike: { toggleLike(for: $0) },
                         onSelectReaction: { post, reactionId in
                             toggleReaction(reactionId, for: post)
@@ -399,7 +397,7 @@ struct FireTopicDetailView: View {
             HStack(spacing: 20) {
                 statLabel(value: "\(displayedReplyCount)", label: "回复")
                 statLabel(value: "\(displayedViewsCount)", label: "浏览")
-                statLabel(value: "\(displayedLikeCount)", label: "赞")
+                statLabel(value: "\(displayedLikeCount)", label: "互动")
             }
             .padding(.vertical, 4)
         }
@@ -522,10 +520,8 @@ struct FireTopicDetailView: View {
                     replyContext: flatPost.parentPostNumber.map { "回复 #\($0)" },
                     showsThreadLine: flatPost.showsThreadLine,
                     baseURLString: baseURLString,
-                    reactionOptions: reactionOptions,
                     canWriteInteractions: canWriteInteractions,
                     isMutating: viewModel.isMutatingPost(postId: flatPost.post.id),
-                    onReply: { openComposer(replyToPost: $0) },
                     onToggleLike: { toggleLike(for: $0) },
                     onSelectReaction: { post, reactionId in
                         toggleReaction(reactionId, for: post)
@@ -904,10 +900,8 @@ private struct FirePostRow: View {
     let replyContext: String?
     let showsThreadLine: Bool
     let baseURLString: String
-    let reactionOptions: [FireReactionOption]
     let canWriteInteractions: Bool
     let isMutating: Bool
-    let onReply: (TopicPostState) -> Void
     let onToggleLike: (TopicPostState) -> Void
     let onSelectReaction: (TopicPostState, String) -> Void
 
@@ -919,28 +913,6 @@ private struct FirePostRow: View {
 
     private var imageAttachments: [FireCookedImage] {
         FireTopicPresentation.imageAttachments(from: post.cooked, baseURLString: baseURLString)
-    }
-
-    private var currentReactionOption: FireReactionOption? {
-        guard let currentReaction = post.currentUserReaction, currentReaction.id != "heart" else {
-            return nil
-        }
-        return FireTopicPresentation.reactionOption(for: currentReaction.id)
-    }
-
-    private var nonHeartReactionOptions: [FireReactionOption] {
-        reactionOptions.filter { $0.id != "heart" }
-    }
-
-    private var isHeartSelected: Bool {
-        post.currentUserReaction?.id == "heart"
-    }
-
-    private var totalReactionCount: UInt32 {
-        let total = post.reactions.reduce(UInt32(0)) { partialResult, reaction in
-            partialResult + reaction.count
-        }
-        return total > 0 ? total : post.likeCount
     }
 
     private var canChangeReaction: Bool {
@@ -1050,80 +1022,9 @@ private struct FirePostRow: View {
                         }
                     }
                 }
-
-                HStack(spacing: 12) {
-                    if canWriteInteractions {
-                        Button {
-                            onToggleLike(post)
-                        } label: {
-                            FirePostMetaAction(
-                                systemImage: isHeartSelected ? "heart.fill" : "heart",
-                                value: totalReactionCount > 0 ? "\(totalReactionCount)" : nil,
-                                tint: isHeartSelected ? .red : FireTheme.tertiaryInk
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(!canChangeReaction)
-
-                        if !nonHeartReactionOptions.isEmpty {
-                            Menu {
-                                ForEach(nonHeartReactionOptions) { option in
-                                    Button("\(option.symbol) \(option.label)") {
-                                        onSelectReaction(post, option.id)
-                                    }
-                                }
-                            } label: {
-                                FirePostMetaAction(
-                                    systemImage: "face.smiling",
-                                    value: currentReactionOption.map { "\($0.symbol)" },
-                                    tint: currentReactionOption == nil ? FireTheme.tertiaryInk : FireTheme.accent
-                                )
-                            }
-                            .disabled(!canChangeReaction)
-                        }
-
-                        Button {
-                            onReply(post)
-                        } label: {
-                            FirePostMetaAction(
-                                systemImage: "arrowshape.turn.up.left",
-                                value: post.replyCount > 0 ? "\(post.replyCount)" : nil,
-                                tint: FireTheme.tertiaryInk
-                            )
-                        }
-                        .buttonStyle(.plain)
-                        .disabled(isMutating)
-                    } else if post.replyCount > 0 {
-                        FirePostMetaAction(
-                            systemImage: "arrowshape.turn.up.left",
-                            value: "\(post.replyCount)",
-                            tint: FireTheme.tertiaryInk
-                        )
-                    }
-
-                    Spacer()
-                }
             }
             .padding(.vertical, 8)
         }
-    }
-}
-
-private struct FirePostMetaAction: View {
-    let systemImage: String
-    let value: String?
-    let tint: Color
-
-    var body: some View {
-        HStack(spacing: 4) {
-            Image(systemName: systemImage)
-            if let value {
-                Text(value)
-                    .font(.caption.monospacedDigit())
-            }
-        }
-        .font(.caption2)
-        .foregroundStyle(tint)
     }
 }
 

--- a/native/ios-app/App/FireTopicDetailView.swift
+++ b/native/ios-app/App/FireTopicDetailView.swift
@@ -36,6 +36,7 @@ struct FireTopicDetailView: View {
     let scrollToPostNumber: UInt32?
 
     @Environment(\.scenePhase) private var scenePhase
+    @Environment(\.colorScheme) private var colorScheme
     @State private var composerContext: FireReplyComposerContext?
     @State private var replyDraft = ""
     @State private var composerNotice: String?
@@ -330,8 +331,8 @@ struct FireTopicDetailView: View {
                     } label: {
                         FireTopicPill(
                             label: category.displayName,
-                            backgroundColor: accent.opacity(0.12),
-                            foregroundColor: Color(fireHex: category.textColorHex) ?? accent
+                            backgroundColor: FireTheme.categoryChipBackground(accent: accent, isDark: colorScheme == .dark),
+                            foregroundColor: accent
                         )
                     }
                     .buttonStyle(.plain)
@@ -350,10 +351,10 @@ struct FireTopicDetailView: View {
                     } label: {
                         Text("#\(tagName)")
                             .font(.caption2.weight(.medium))
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(FireTheme.tagChipForeground)
                             .padding(.horizontal, 6)
                             .padding(.vertical, 3)
-                            .background(Color(.tertiarySystemFill))
+                            .background(FireTheme.tagChipBackground)
                             .clipShape(Capsule())
                     }
                     .buttonStyle(.plain)

--- a/native/ios-app/App/FireTopicPresentation.swift
+++ b/native/ios-app/App/FireTopicPresentation.swift
@@ -219,7 +219,22 @@ enum FireTopicPresentation {
         let composition = composeThread(posts: detail.postStream.posts)
         detail.thread = composition.thread
         detail.flatPosts = composition.flatPosts
+        detail.interactionCount = interactionCount(for: detail)
         return detail
+    }
+
+    static func interactionCount(for detail: TopicDetailState) -> UInt32 {
+        let extraReactionCount = detail.postStream.posts
+            .flatMap(\.reactions)
+            .filter { $0.id.caseInsensitiveCompare("heart") != .orderedSame }
+            .reduce(0 as UInt32) { partialResult, reaction in
+                partialResult > UInt32.max - reaction.count
+                    ? UInt32.max
+                    : partialResult + reaction.count
+            }
+        return detail.likeCount > UInt32.max - extraReactionCount
+            ? UInt32.max
+            : detail.likeCount + extraReactionCount
     }
 
     static func loadedWindowCount(detail: TopicDetailState) -> Int {

--- a/native/ios-app/App/FireTopicRow.swift
+++ b/native/ios-app/App/FireTopicRow.swift
@@ -4,6 +4,8 @@ struct FireTopicRow: View {
     let row: FireTopicRowPresentation
     let category: FireTopicCategoryPresentation?
 
+    @Environment(\.colorScheme) private var colorScheme
+
     private var accentColor: Color {
         Color(fireHex: category?.colorHex) ?? FireTheme.accent
     }
@@ -126,10 +128,10 @@ struct FireTopicRow: View {
     private func categoryChip(_ category: FireTopicCategoryPresentation) -> some View {
         Text(category.displayName)
             .font(.caption2.weight(.medium))
-            .foregroundStyle(Color(fireHex: category.textColorHex) ?? accentColor)
+            .foregroundStyle(accentColor)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(accentColor.opacity(0.12))
+            .background(FireTheme.categoryChipBackground(accent: accentColor, isDark: colorScheme == .dark))
             .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
             .lineLimit(1)
             .truncationMode(.tail)
@@ -138,10 +140,10 @@ struct FireTopicRow: View {
     private func tagChip(_ tagName: String) -> some View {
         Text("#\(tagName)")
             .font(.caption2)
-            .foregroundStyle(FireTheme.subtleInk)
+            .foregroundStyle(FireTheme.tagChipForeground)
             .padding(.horizontal, 6)
             .padding(.vertical, 2)
-            .background(Color(.tertiarySystemFill))
+            .background(FireTheme.tagChipBackground)
             .clipShape(RoundedRectangle(cornerRadius: 4, style: .continuous))
             .lineLimit(1)
             .truncationMode(.tail)

--- a/native/ios-app/App/FireTopicRow.swift
+++ b/native/ios-app/App/FireTopicRow.swift
@@ -48,7 +48,6 @@ struct FireTopicRow: View {
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .fixedSize(horizontal: false, vertical: true)
 
                 HStack(alignment: .center, spacing: 6) {
                     Text(displayUsername)

--- a/native/ios-app/Tests/Unit/FireTopicPresentationTests.swift
+++ b/native/ios-app/Tests/Unit/FireTopicPresentationTests.swift
@@ -185,6 +185,35 @@ final class FireTopicPresentationTests: XCTestCase {
         XCTAssertEqual(recomposed.flatPosts[2].parentPostNumber, 2)
     }
 
+    func testRecomposedDetailRecomputesInteractionCountFromNonHeartReactions() {
+        let detail = makeTopicDetail(
+            posts: [
+                makePost(
+                    postNumber: 1,
+                    replyToPostNumber: nil,
+                    username: "author",
+                    reactions: [
+                        TopicReactionState(id: "heart", kind: "emoji", count: 4, canUndo: nil),
+                        TopicReactionState(id: "clap", kind: "emoji", count: 2, canUndo: nil),
+                    ]
+                ),
+                makePost(
+                    postNumber: 2,
+                    replyToPostNumber: 1,
+                    username: "reply",
+                    reactions: [
+                        TopicReactionState(id: "TADA", kind: "emoji", count: 1, canUndo: nil),
+                    ]
+                ),
+            ],
+            stream: [1, 2]
+        )
+
+        let recomposed = FireTopicPresentation.recomposedDetail(detail)
+
+        XCTAssertEqual(recomposed.interactionCount, 12)
+    }
+
     func testLoadedWindowCountStopsAtFirstGap() {
         let loadedWindowCount = FireTopicPresentation.loadedWindowCount(
             orderedPostIDs: [1, 2, 3, 4, 5],
@@ -333,7 +362,9 @@ final class FireTopicPresentationTests: XCTestCase {
     private func makePost(
         postNumber: UInt32,
         replyToPostNumber: UInt32?,
-        username: String
+        username: String,
+        likeCount: UInt32 = 0,
+        reactions: [TopicReactionState] = []
     ) -> TopicPostState {
         TopicPostState(
             id: UInt64(postNumber),
@@ -345,12 +376,12 @@ final class FireTopicPresentationTests: XCTestCase {
             postType: 1,
             createdAt: "2026-03-28T10:00:00Z",
             updatedAt: "2026-03-28T10:00:00Z",
-            likeCount: 0,
+            likeCount: likeCount,
             replyCount: 0,
             replyToPostNumber: replyToPostNumber,
             bookmarked: false,
             bookmarkId: nil,
-            reactions: [],
+            reactions: reactions,
             currentUserReaction: nil,
             acceptedAnswer: false,
             canEdit: false,
@@ -373,6 +404,7 @@ final class FireTopicPresentationTests: XCTestCase {
             tags: [],
             views: 128,
             likeCount: 9,
+            interactionCount: 9,
             createdAt: "2026-03-28T10:00:00Z",
             lastReadPostNumber: nil,
             bookmarks: [],

--- a/rust/crates/fire-models/src/lib.rs
+++ b/rust/crates/fire-models/src/lib.rs
@@ -1194,15 +1194,16 @@ pub struct TopicDetail {
 
 impl TopicDetail {
     pub fn interaction_count(&self) -> u32 {
-        self.like_count
-            .saturating_add(
-                self.post_stream
-                    .posts
-                    .iter()
-                    .flat_map(|post| post.reactions.iter())
-                    .filter(|reaction| !reaction.id.eq_ignore_ascii_case("heart"))
-                    .fold(0_u32, |total, reaction| total.saturating_add(reaction.count)),
-            )
+        self.like_count.saturating_add(
+            self.post_stream
+                .posts
+                .iter()
+                .flat_map(|post| post.reactions.iter())
+                .filter(|reaction| !reaction.id.eq_ignore_ascii_case("heart"))
+                .fold(0_u32, |total, reaction| {
+                    total.saturating_add(reaction.count)
+                }),
+        )
     }
 }
 
@@ -1896,13 +1897,11 @@ mod tests {
                         ..TopicPost::default()
                     },
                     TopicPost {
-                        reactions: vec![
-                            TopicReaction {
-                                id: "TADA".into(),
-                                count: 3,
-                                ..TopicReaction::default()
-                            },
-                        ],
+                        reactions: vec![TopicReaction {
+                            id: "TADA".into(),
+                            count: 3,
+                            ..TopicReaction::default()
+                        }],
                         ..TopicPost::default()
                     },
                 ],

--- a/rust/crates/fire-models/src/lib.rs
+++ b/rust/crates/fire-models/src/lib.rs
@@ -1192,6 +1192,20 @@ pub struct TopicDetail {
     pub details: TopicDetailMeta,
 }
 
+impl TopicDetail {
+    pub fn interaction_count(&self) -> u32 {
+        self.like_count
+            .saturating_add(
+                self.post_stream
+                    .posts
+                    .iter()
+                    .flat_map(|post| post.reactions.iter())
+                    .filter(|reaction| !reaction.id.eq_ignore_ascii_case("heart"))
+                    .fold(0_u32, |total, reaction| total.saturating_add(reaction.count)),
+            )
+    }
+}
+
 fn merge_string_patch(slot: &mut Option<String>, patch: Option<String>) {
     if let Some(value) = patch {
         if value.is_empty() {
@@ -1520,7 +1534,8 @@ pub struct UserActionResponse {
 mod tests {
     use super::{
         BootstrapArtifacts, CookieSnapshot, LoginPhase, PlatformCookie, SessionSnapshot,
-        TopicCategory, TopicListKind, TopicListQuery, TopicPost, TopicThread, TopicThreadFlatPost,
+        TopicCategory, TopicDetail, TopicListKind, TopicListQuery, TopicPost, TopicPostStream,
+        TopicReaction, TopicThread, TopicThreadFlatPost,
     };
 
     #[test]
@@ -1857,6 +1872,46 @@ mod tests {
         assert!(bootstrap.can_tag_topics);
         assert_eq!(bootstrap.categories.len(), 1);
         assert!(bootstrap.has_preloaded_data);
+    }
+
+    #[test]
+    fn topic_detail_interaction_count_adds_non_heart_reactions_to_topic_likes() {
+        let detail = TopicDetail {
+            like_count: 21,
+            post_stream: TopicPostStream {
+                posts: vec![
+                    TopicPost {
+                        reactions: vec![
+                            TopicReaction {
+                                id: "heart".into(),
+                                count: 5,
+                                ..TopicReaction::default()
+                            },
+                            TopicReaction {
+                                id: "clap".into(),
+                                count: 2,
+                                ..TopicReaction::default()
+                            },
+                        ],
+                        ..TopicPost::default()
+                    },
+                    TopicPost {
+                        reactions: vec![
+                            TopicReaction {
+                                id: "TADA".into(),
+                                count: 3,
+                                ..TopicReaction::default()
+                            },
+                        ],
+                        ..TopicPost::default()
+                    },
+                ],
+                ..TopicPostStream::default()
+            },
+            ..TopicDetail::default()
+        };
+
+        assert_eq!(detail.interaction_count(), 26);
     }
 
     #[test]

--- a/rust/crates/fire-uniffi/src/lib.rs
+++ b/rust/crates/fire-uniffi/src/lib.rs
@@ -1715,6 +1715,7 @@ pub struct TopicDetailState {
     pub tags: Vec<TopicTagState>,
     pub views: u32,
     pub like_count: u32,
+    pub interaction_count: u32,
     pub created_at: Option<String>,
     pub last_read_post_number: Option<u32>,
     pub bookmarks: Vec<u64>,
@@ -1735,6 +1736,7 @@ pub struct TopicDetailState {
 
 impl From<TopicDetail> for TopicDetailState {
     fn from(value: TopicDetail) -> Self {
+        let interaction_count = value.interaction_count();
         Self {
             id: value.id,
             title: value.title,
@@ -1744,6 +1746,7 @@ impl From<TopicDetail> for TopicDetailState {
             tags: value.tags.into_iter().map(Into::into).collect(),
             views: value.views,
             like_count: value.like_count,
+            interaction_count,
             created_at: value.created_at,
             last_read_post_number: value.last_read_post_number,
             bookmarks: value.bookmarks,
@@ -3109,6 +3112,27 @@ mod tests {
             FireUniFfiError::Storage { details }
                 if details.contains("/tmp/session.json") && details.contains("denied")
         ));
+    }
+
+    #[test]
+    fn topic_detail_state_carries_interaction_count() {
+        let state = TopicDetailState::from(TopicDetail {
+            like_count: 8,
+            post_stream: TopicPostStream {
+                posts: vec![TopicPost {
+                    reactions: vec![TopicReaction {
+                        id: "clap".into(),
+                        count: 2,
+                        ..TopicReaction::default()
+                    }],
+                    ..TopicPost::default()
+                }],
+                ..TopicPostStream::default()
+            },
+            ..TopicDetail::default()
+        });
+
+        assert_eq!(state.interaction_count, 10);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- improve topic detail interaction UX with wrapped reactions and swipe-to-reply flow changes already on this branch
- keep the current chip styling and profile pull-to-refresh scope as intentional product decisions for this iteration
- fix the topic detail 互动 metric to derive from shared topic likes plus non-heart reactions instead of reusing likes-only data

## Testing
- `cargo test -p fire-models tests::topic_detail_interaction_count_adds_non_heart_reactions_to_topic_likes -- --exact`
- `cargo test -p fire-uniffi tests::topic_detail_state_carries_interaction_count -- --exact`
- `xcodebuild test -project Fire.xcodeproj -scheme Fire -destination "platform=iOS Simulator,id=D733CCB1-7B2A-49B5-B3F8-36CB6D0CB2BF" -only-testing:FireTests/FireTopicPresentationTests`