### PR TITLE
Fix stuck in-progress network traces

### DIFF
--- a/docs/architecture/fire-native-workspace.md
+++ b/docs/architecture/fire-native-workspace.md
@@ -82,6 +82,7 @@ fire/
   - defines the shared login/session snapshot, notification models, and topic-facing models
 - `fire-core`
   - owns session sync, bootstrap parsing, auth refresh/logout, persistence, diagnostics, one shared `openwire` client for API and MessageBus transport, topic list/detail reads (including category and tag scoped lists), the current reply/reaction write path, the Rust MessageBus poll/subscription runtime, notification fetch/state/mark-read reconciliation, topic-reply presence, and `/topics/timings` request shaping
+  - finalizes network traces in Rust with terminal outcomes (`Succeeded`, `Failed`, or `Cancelled`); hosts should treat timeline events as intermediate diagnostics instead of completion signals
 - `fire-uniffi`
   - exports the shared async API surface, notification list/state APIs, MessageBus callback interface, and error model to Swift/Kotlin
 - `native/ios-app` and `native/android-app`

--- a/native/android-app/src/main/java/com/fire/app/DiagnosticsActivity.kt
+++ b/native/android-app/src/main/java/com/fire/app/DiagnosticsActivity.kt
@@ -128,6 +128,7 @@ class DiagnosticsActivity : AppCompatActivity() {
                                 uniffi.fire_uniffi.NetworkTraceOutcomeState.IN_PROGRESS -> "In Progress"
                                 uniffi.fire_uniffi.NetworkTraceOutcomeState.SUCCEEDED -> "Succeeded"
                                 uniffi.fire_uniffi.NetworkTraceOutcomeState.FAILED -> "Failed"
+                                uniffi.fire_uniffi.NetworkTraceOutcomeState.CANCELLED -> "Cancelled"
                             },
                         )
                         trace.statusCode?.let { append(" · HTTP ${it.toInt()}") }

--- a/native/android-app/src/main/java/com/fire/app/RequestTraceDetailActivity.kt
+++ b/native/android-app/src/main/java/com/fire/app/RequestTraceDetailActivity.kt
@@ -61,6 +61,7 @@ class RequestTraceDetailActivity : AppCompatActivity() {
                                 uniffi.fire_uniffi.NetworkTraceOutcomeState.IN_PROGRESS -> "In Progress"
                                 uniffi.fire_uniffi.NetworkTraceOutcomeState.SUCCEEDED -> "Succeeded"
                                 uniffi.fire_uniffi.NetworkTraceOutcomeState.FAILED -> "Failed"
+                                uniffi.fire_uniffi.NetworkTraceOutcomeState.CANCELLED -> "Cancelled"
                             }
                         }",
                     )

--- a/native/ios-app/App/FireDiagnosticsView.swift
+++ b/native/ios-app/App/FireDiagnosticsView.swift
@@ -373,10 +373,15 @@ private struct FireRequestTraceRow: View {
 
     private var statusColor: Color {
         if trace.outcome == .failed { return .red }
+        if trace.outcome == .cancelled { return .secondary }
         guard let code = trace.statusCode else { return .secondary }
         if code < 300 { return .green }
         if code < 400 { return .orange }
         return .red
+    }
+
+    private var errorColor: Color {
+        trace.outcome == .cancelled ? .secondary : .red
     }
 
     private var methodColor: Color {
@@ -423,7 +428,7 @@ private struct FireRequestTraceRow: View {
             if let errorMessage = trace.errorMessage {
                 Text(errorMessage)
                     .font(.caption2)
-                    .foregroundStyle(.red)
+                    .foregroundStyle(errorColor)
                     .lineLimit(1)
             }
         }
@@ -439,6 +444,9 @@ private struct FireRequestTraceRow: View {
             case .failed:
                 Image(systemName: "xmark.circle.fill")
                     .foregroundStyle(.red)
+            case .cancelled:
+                Image(systemName: "minus.circle.fill")
+                    .foregroundStyle(.secondary)
             case .inProgress:
                 ProgressView()
                     .controlSize(.mini)
@@ -1089,6 +1097,8 @@ private enum FireDiagnosticsPresentation {
             return "成功"
         case .failed:
             return "失败"
+        case .cancelled:
+            return "已取消"
         }
     }
 }

--- a/rust/crates/fire-core/src/core/messagebus.rs
+++ b/rust/crates/fire-core/src/core/messagebus.rs
@@ -28,8 +28,8 @@ use url::{form_urlencoded::Serializer, Url};
 
 use super::{
     network::{
-        classify_http_status_error, header_value, request_origin, FireCallProfile,
-        FireNetworkLayer, FireRequestProfile, TracedRequest,
+        classify_http_status_error, header_value, request_origin, take_trace_cancellation_guard,
+        FireCallProfile, FireNetworkLayer, FireRequestProfile, TracedRequest,
     },
     notifications::{merge_notification_event_data, FireNotificationRuntime},
     presence::{merge_topic_presence_event_data, FireTopicPresenceRuntime},
@@ -581,11 +581,22 @@ async fn read_message_bus_error_response_for_diagnostics(
     trace_id: u64,
     response: Response<ResponseBody>,
 ) -> Result<bool, FireCoreError> {
+    let mut response = response;
+    let _trace_guard = take_trace_cancellation_guard(&mut response).unwrap_or_else(|| {
+        diagnostics.cancellation_guard(
+            trace_id,
+            "Request cancelled",
+            "Future dropped while reading the message bus error response body",
+        )
+    });
     let status = response.status().as_u16();
-    let body = response.into_body().text().await.map_err(|source| {
-        diagnostics.record_call_failed(trace_id, &source);
-        FireCoreError::Network { source }
-    })?;
+    let body = match response.into_body().text().await {
+        Ok(body) => body,
+        Err(source) => {
+            diagnostics.record_call_failed(trace_id, &source);
+            return Err(FireCoreError::Network { source });
+        }
+    };
     diagnostics.record_http_status_error(trace_id, status, &body);
     Err(classify_http_status_error(
         MESSAGE_BUS_OPERATION,
@@ -599,16 +610,27 @@ async fn read_message_bus_success_response(
     trace_id: u64,
     response: Response<ResponseBody>,
 ) -> Result<bool, FireCoreError> {
+    let mut response = response;
+    let _trace_guard = take_trace_cancellation_guard(&mut response).unwrap_or_else(|| {
+        context.diagnostics.cancellation_guard(
+            trace_id,
+            "Request cancelled",
+            "Future dropped while processing the message bus response body",
+        )
+    });
     let content_type = header_value(response.headers(), "content-type");
     let mut body = response.into_body();
     let mut response_text = String::new();
     let mut chunk_buffer = String::new();
 
     while let Some(frame) = body.frame().await {
-        let frame = frame.map_err(|source| {
-            context.diagnostics.record_call_failed(trace_id, &source);
-            FireCoreError::Network { source }
-        })?;
+        let frame = match frame {
+            Ok(frame) => frame,
+            Err(source) => {
+                context.diagnostics.record_call_failed(trace_id, &source);
+                return Err(FireCoreError::Network { source });
+            }
+        };
         let Ok(bytes) = frame.into_data() else {
             continue;
         };
@@ -656,6 +678,14 @@ async fn read_notification_alert_success_response(
     channel: &str,
     initial_last_message_id: i64,
 ) -> Result<NotificationAlertPollResult, FireCoreError> {
+    let mut response = response;
+    let _trace_guard = take_trace_cancellation_guard(&mut response).unwrap_or_else(|| {
+        diagnostics.cancellation_guard(
+            trace_id,
+            "Request cancelled",
+            "Future dropped while processing the notification alert response body",
+        )
+    });
     let content_type = header_value(response.headers(), "content-type");
     let mut body = response.into_body();
     let mut response_text = String::new();
@@ -668,10 +698,13 @@ async fn read_notification_alert_success_response(
     };
 
     while let Some(frame) = body.frame().await {
-        let frame = frame.map_err(|source| {
-            diagnostics.record_call_failed(trace_id, &source);
-            FireCoreError::Network { source }
-        })?;
+        let frame = match frame {
+            Ok(frame) => frame,
+            Err(source) => {
+                diagnostics.record_call_failed(trace_id, &source);
+                return Err(FireCoreError::Network { source });
+            }
+        };
         let Ok(bytes) = frame.into_data() else {
             continue;
         };

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -19,7 +19,10 @@ use super::{
 };
 use crate::{
     cookies::FireSessionCookieJar,
-    diagnostics::{FireDiagnosticsStore, FireNetworkTraceEventListenerFactory},
+    diagnostics::{
+        FireDiagnosticsStore, FireNetworkTraceCancellationGuard,
+        FireNetworkTraceEventListenerFactory,
+    },
     error::FireCoreError,
     sync_utils::read_rwlock,
 };
@@ -59,6 +62,7 @@ pub(crate) enum FireCallProfile {
 #[derive(Clone)]
 pub(crate) struct FireNetworkLayer {
     client: Client,
+    diagnostics: Arc<FireDiagnosticsStore>,
 }
 
 #[derive(Clone)]
@@ -162,13 +166,18 @@ impl FireNetworkLayer {
             .pool_max_idle_per_host(CLIENT_POOL_MAX_IDLE_PER_HOST)
             .http2_keep_alive_interval(MESSAGE_BUS_HTTP2_KEEP_ALIVE_INTERVAL)
             .http2_keep_alive_while_idle(true)
-            .event_listener_factory(FireNetworkTraceEventListenerFactory::new(diagnostics));
+            .event_listener_factory(FireNetworkTraceEventListenerFactory::new(Arc::clone(
+                &diagnostics,
+            )));
         #[cfg(debug_assertions)]
         let builder = builder.use_system_proxy(true);
         let client = builder
             .build()
             .map_err(|source| FireCoreError::ClientBuild { source })?;
-        Ok(Self { client })
+        Ok(Self {
+            client,
+            diagnostics,
+        })
     }
 
     pub(crate) fn client(&self) -> Client {
@@ -180,33 +189,53 @@ impl FireNetworkLayer {
         traced: TracedRequest,
         profile: FireCallProfile,
     ) -> Result<(u64, Response<ResponseBody>), FireCoreError> {
+        let trace_id = traced.trace_id;
         debug!(
-            trace_id = traced.trace_id,
+            trace_id,
             method = %traced.request.method(),
             uri = %traced.request.uri(),
             profile = ?profile,
             "executing HTTP request"
         );
-        let response = apply_call_profile(self.client.new_call(traced.request), profile)
+        let trace_guard = self.diagnostics.cancellation_guard(
+            trace_id,
+            "Request cancelled",
+            "Future dropped before the trace reached a terminal state",
+        );
+        let mut response = match apply_call_profile(self.client.new_call(traced.request), profile)
             .execute()
             .await
-            .map_err(|source| {
+        {
+            Ok(response) => response,
+            Err(source) => {
+                self.diagnostics
+                    .record_call_failed_if_in_progress(trace_id, &source);
                 warn!(
-                    trace_id = traced.trace_id,
+                    trace_id,
                     error = %source,
                     profile = ?profile,
                     "HTTP request failed"
                 );
-                FireCoreError::Network { source }
-            })?;
+                return Err(FireCoreError::Network { source });
+            }
+        };
+        response.extensions_mut().insert(trace_guard);
         debug!(
-            trace_id = traced.trace_id,
+            trace_id,
             status = response.status().as_u16(),
             profile = ?profile,
             "HTTP response received"
         );
-        Ok((traced.trace_id, response))
+        Ok((trace_id, response))
     }
+}
+
+pub(crate) fn take_trace_cancellation_guard(
+    response: &mut Response<ResponseBody>,
+) -> Option<FireNetworkTraceCancellationGuard> {
+    response
+        .extensions_mut()
+        .remove::<FireNetworkTraceCancellationGuard>()
 }
 
 fn apply_call_profile(call: Call, profile: FireCallProfile) -> Call {
@@ -414,11 +443,22 @@ impl FireCore {
         trace_id: u64,
         response: Response<ResponseBody>,
     ) -> Result<String, FireCoreError> {
+        let mut response = response;
+        let _trace_guard = take_trace_cancellation_guard(&mut response).unwrap_or_else(|| {
+            self.diagnostics.cancellation_guard(
+                trace_id,
+                "Request cancelled",
+                "Future dropped while reading the response body",
+            )
+        });
         let content_type = header_value(response.headers(), "content-type");
-        let text = response.into_body().text().await.map_err(|source| {
-            self.diagnostics.record_call_failed(trace_id, &source);
-            FireCoreError::Network { source }
-        })?;
+        let text = match response.into_body().text().await {
+            Ok(text) => text,
+            Err(source) => {
+                self.diagnostics.record_call_failed(trace_id, &source);
+                return Err(FireCoreError::Network { source });
+            }
+        };
         self.diagnostics
             .record_response_body_text(trace_id, &text, content_type.as_deref());
         Ok(text)
@@ -528,7 +568,15 @@ pub(crate) async fn expect_success(
         return Ok(response);
     }
 
+    let mut response = response;
     let status = response.status().as_u16();
+    let _trace_guard = take_trace_cancellation_guard(&mut response).unwrap_or_else(|| {
+        core.diagnostics.cancellation_guard(
+            trace_id,
+            "Request cancelled",
+            "Future dropped while reading the error response body",
+        )
+    });
     let body = response
         .into_body()
         .text()

--- a/rust/crates/fire-core/src/diagnostics.rs
+++ b/rust/crates/fire-core/src/diagnostics.rs
@@ -36,6 +36,7 @@ pub enum NetworkTraceOutcome {
     InProgress,
     Succeeded,
     Failed,
+    Cancelled,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -144,7 +145,10 @@ impl NetworkTraceRecord {
     }
 
     fn mark_succeeded(&mut self) {
-        if self.outcome != NetworkTraceOutcome::Failed {
+        if !matches!(
+            self.outcome,
+            NetworkTraceOutcome::Failed | NetworkTraceOutcome::Cancelled
+        ) {
             self.outcome = NetworkTraceOutcome::Succeeded;
             self.error_message = None;
         }
@@ -215,6 +219,40 @@ struct FireDiagnosticsState {
 pub(crate) struct FireDiagnosticsStore {
     next_trace_id: AtomicU64,
     inner: Mutex<FireDiagnosticsState>,
+}
+
+pub(crate) struct FireNetworkTraceCancellationGuard {
+    inner: Arc<FireNetworkTraceCancellationGuardInner>,
+}
+
+struct FireNetworkTraceCancellationGuardInner {
+    diagnostics: Arc<FireDiagnosticsStore>,
+    trace_id: u64,
+    summary: String,
+    details: String,
+    armed: std::sync::atomic::AtomicBool,
+}
+
+impl Drop for FireNetworkTraceCancellationGuard {
+    fn drop(&mut self) {
+        if !self.inner.armed.swap(false, Ordering::AcqRel) {
+            return;
+        }
+
+        self.inner.diagnostics.record_cancelled_if_in_progress(
+            self.inner.trace_id,
+            &self.inner.summary,
+            Some(&self.inner.details),
+        );
+    }
+}
+
+impl Clone for FireNetworkTraceCancellationGuard {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
 }
 
 impl Default for FireDiagnosticsStore {
@@ -293,6 +331,23 @@ impl FireDiagnosticsStore {
             .map(NetworkTraceRecord::to_detail)
     }
 
+    pub(crate) fn cancellation_guard(
+        self: &Arc<Self>,
+        trace_id: u64,
+        summary: impl Into<String>,
+        details: impl Into<String>,
+    ) -> FireNetworkTraceCancellationGuard {
+        FireNetworkTraceCancellationGuard {
+            inner: Arc::new(FireNetworkTraceCancellationGuardInner {
+                diagnostics: Arc::clone(self),
+                trace_id,
+                summary: summary.into(),
+                details: details.into(),
+                armed: std::sync::atomic::AtomicBool::new(true),
+            }),
+        }
+    }
+
     pub(crate) fn record_call_start(&self, trace_id: u64, ctx: &CallContext) {
         self.with_trace(trace_id, |trace| {
             trace.call_id = Some(ctx.call_id().as_u64());
@@ -324,14 +379,23 @@ impl FireDiagnosticsStore {
         self.with_trace(trace_id, |trace| {
             trace.push_event(
                 "call_end",
-                format!("Call completed with HTTP {}", response.status().as_u16()),
-                None,
+                format!("Transport returned HTTP {}", response.status().as_u16()),
+                Some("response body may still be in progress".to_string()),
             );
         });
     }
 
     pub(crate) fn record_call_failed(&self, trace_id: u64, error: &WireError) {
         self.record_failure(
+            trace_id,
+            "call_failed",
+            "Call failed".to_string(),
+            error.to_string(),
+        );
+    }
+
+    pub(crate) fn record_call_failed_if_in_progress(&self, trace_id: u64, error: &WireError) {
+        self.record_failure_if_in_progress(
             trace_id,
             "call_failed",
             "Call failed".to_string(),
@@ -407,6 +471,9 @@ impl FireDiagnosticsStore {
 
     pub(crate) fn record_http_status_error(&self, trace_id: u64, status: u16, body: &str) {
         self.with_trace(trace_id, |trace| {
+            if trace.outcome == NetworkTraceOutcome::Cancelled {
+                return;
+            }
             trace.outcome = NetworkTraceOutcome::Failed;
             trace.status_code = Some(status);
             trace.error_message = Some(format!("HTTP {status}"));
@@ -674,8 +741,50 @@ impl FireDiagnosticsStore {
         }
     }
 
+    fn record_failure_if_in_progress(
+        &self,
+        trace_id: u64,
+        phase: &str,
+        summary: String,
+        details: String,
+    ) {
+        self.with_trace(trace_id, |trace| {
+            if trace.outcome != NetworkTraceOutcome::InProgress {
+                return;
+            }
+            trace.outcome = NetworkTraceOutcome::Failed;
+            trace.error_message = Some(details.clone());
+            trace.finished_at_unix_ms = Some(now_unix_ms());
+            trace.push_event(phase, summary, Some(details));
+        });
+    }
+
+    pub(crate) fn record_cancelled_if_in_progress(
+        &self,
+        trace_id: u64,
+        summary: &str,
+        details: Option<&str>,
+    ) {
+        self.with_trace(trace_id, |trace| {
+            if trace.outcome != NetworkTraceOutcome::InProgress {
+                return;
+            }
+            trace.outcome = NetworkTraceOutcome::Cancelled;
+            trace.error_message = None;
+            trace.finished_at_unix_ms = Some(now_unix_ms());
+            trace.push_event(
+                "cancelled",
+                summary.to_string(),
+                details.map(ToOwned::to_owned),
+            );
+        });
+    }
+
     fn record_failure(&self, trace_id: u64, phase: &str, summary: String, details: String) {
         self.with_trace(trace_id, |trace| {
+            if trace.outcome == NetworkTraceOutcome::Cancelled {
+                return;
+            }
             trace.outcome = NetworkTraceOutcome::Failed;
             trace.error_message = Some(details.clone());
             trace.finished_at_unix_ms = Some(now_unix_ms());
@@ -1178,6 +1287,8 @@ fn now_unix_ms() -> u64 {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::{FireDiagnosticsStore, NetworkTraceOutcome, Request, RequestBody};
 
     #[test]
@@ -1243,5 +1354,81 @@ mod tests {
         assert_eq!(detail.response_body_bytes, Some(97));
         assert!(detail.finished_at_unix_ms.is_some());
         assert_eq!(detail.response_body, None);
+    }
+
+    #[test]
+    fn cancellation_guard_marks_in_progress_trace_as_cancelled() {
+        let store = Arc::new(FireDiagnosticsStore::new());
+        let mut request = Request::builder()
+            .method("GET")
+            .uri("https://linux.do/message-bus/1/poll")
+            .body(RequestBody::empty())
+            .expect("request");
+        let trace_id = store.prepare_request_trace("message bus poll", &mut request);
+
+        {
+            let _guard = store.cancellation_guard(
+                trace_id,
+                "Request cancelled",
+                "Future dropped before the trace reached a terminal state",
+            );
+        }
+
+        let detail = store.detail(trace_id).expect("detail");
+        assert_eq!(detail.outcome, NetworkTraceOutcome::Cancelled);
+        assert!(detail.finished_at_unix_ms.is_some());
+        assert_eq!(detail.error_message, None);
+        assert_eq!(detail.events.last().expect("event").phase, "cancelled");
+    }
+
+    #[test]
+    fn cancellation_guard_does_not_override_succeeded_trace() {
+        let store = Arc::new(FireDiagnosticsStore::new());
+        let mut request = Request::builder()
+            .method("GET")
+            .uri("https://linux.do/latest.json")
+            .body(RequestBody::empty())
+            .expect("request");
+        let trace_id = store.prepare_request_trace("fetch", &mut request);
+
+        {
+            let _guard = store.cancellation_guard(
+                trace_id,
+                "Request cancelled",
+                "Future dropped before the trace reached a terminal state",
+            );
+            store.record_response_body_text(trace_id, "{\"ok\":true}", Some("application/json"));
+        }
+
+        let detail = store.detail(trace_id).expect("detail");
+        assert_eq!(detail.outcome, NetworkTraceOutcome::Succeeded);
+    }
+
+    #[test]
+    fn failure_events_do_not_override_cancelled_trace() {
+        let store = Arc::new(FireDiagnosticsStore::new());
+        let mut request = Request::builder()
+            .method("GET")
+            .uri("https://linux.do/latest.json")
+            .body(RequestBody::empty())
+            .expect("request");
+        let trace_id = store.prepare_request_trace("fetch", &mut request);
+
+        {
+            let _guard = store.cancellation_guard(
+                trace_id,
+                "Request cancelled",
+                "Future dropped before the trace reached a terminal state",
+            );
+        }
+        store.record_parse_error(
+            trace_id,
+            "Failed to parse response".to_string(),
+            "unexpected payload".to_string(),
+        );
+
+        let detail = store.detail(trace_id).expect("detail");
+        assert_eq!(detail.outcome, NetworkTraceOutcome::Cancelled);
+        assert_eq!(detail.events.last().expect("event").phase, "cancelled");
     }
 }

--- a/rust/crates/fire-core/tests/messagebus.rs
+++ b/rust/crates/fire-core/tests/messagebus.rs
@@ -3,7 +3,7 @@ mod common;
 use std::time::Duration;
 
 use common::{raw_json_response, TestServer, TestServerStep};
-use fire_core::{FireCore, FireCoreConfig};
+use fire_core::{FireCore, FireCoreConfig, NetworkTraceOutcome};
 use fire_models::{
     BootstrapArtifacts, CookieSnapshot, MessageBusClientMode, MessageBusEventKind,
     MessageBusSubscription, MessageBusSubscriptionScope,
@@ -255,6 +255,22 @@ async fn active_message_bus_coalesces_subscription_changes_into_single_restart()
 
     tokio::time::sleep(Duration::from_millis(400)).await;
     core.stop_message_bus(true);
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let traces = core.list_network_traces(10);
+    assert!(
+        traces
+            .iter()
+            .filter(|trace| trace.operation == "message bus poll")
+            .all(|trace| trace.outcome != NetworkTraceOutcome::InProgress),
+        "expected restarted/stopped poll traces to reach a terminal state: {traces:?}"
+    );
+    assert!(
+        traces
+            .iter()
+            .any(|trace| trace.outcome == NetworkTraceOutcome::Cancelled),
+        "expected at least one cancelled message bus trace after restart: {traces:?}"
+    );
 
     let requests = server.shutdown_with_requests().await;
     assert_eq!(

--- a/rust/crates/fire-uniffi/src/lib.rs
+++ b/rust/crates/fire-uniffi/src/lib.rs
@@ -1715,7 +1715,6 @@ pub struct TopicDetailState {
     pub tags: Vec<TopicTagState>,
     pub views: u32,
     pub like_count: u32,
-    pub interaction_count: u32,
     pub created_at: Option<String>,
     pub last_read_post_number: Option<u32>,
     pub bookmarks: Vec<u64>,
@@ -1736,7 +1735,6 @@ pub struct TopicDetailState {
 
 impl From<TopicDetail> for TopicDetailState {
     fn from(value: TopicDetail) -> Self {
-        let interaction_count = value.interaction_count();
         Self {
             id: value.id,
             title: value.title,
@@ -1746,7 +1744,6 @@ impl From<TopicDetail> for TopicDetailState {
             tags: value.tags.into_iter().map(Into::into).collect(),
             views: value.views,
             like_count: value.like_count,
-            interaction_count,
             created_at: value.created_at,
             last_read_post_number: value.last_read_post_number,
             bookmarks: value.bookmarks,
@@ -1833,6 +1830,7 @@ pub enum NetworkTraceOutcomeState {
     InProgress,
     Succeeded,
     Failed,
+    Cancelled,
 }
 
 impl From<NetworkTraceOutcome> for NetworkTraceOutcomeState {
@@ -1841,6 +1839,7 @@ impl From<NetworkTraceOutcome> for NetworkTraceOutcomeState {
             NetworkTraceOutcome::InProgress => Self::InProgress,
             NetworkTraceOutcome::Succeeded => Self::Succeeded,
             NetworkTraceOutcome::Failed => Self::Failed,
+            NetworkTraceOutcome::Cancelled => Self::Cancelled,
         }
     }
 }
@@ -3112,27 +3111,6 @@ mod tests {
             FireUniFfiError::Storage { details }
                 if details.contains("/tmp/session.json") && details.contains("denied")
         ));
-    }
-
-    #[test]
-    fn topic_detail_state_carries_interaction_count() {
-        let state = TopicDetailState::from(TopicDetail {
-            like_count: 8,
-            post_stream: TopicPostStream {
-                posts: vec![TopicPost {
-                    reactions: vec![TopicReaction {
-                        id: "clap".into(),
-                        count: 2,
-                        ..TopicReaction::default()
-                    }],
-                    ..TopicPost::default()
-                }],
-                ..TopicPostStream::default()
-            },
-            ..TopicDetail::default()
-        });
-
-        assert_eq!(state.interaction_count, 10);
     }
 
     #[test]

--- a/rust/crates/fire-uniffi/src/lib.rs
+++ b/rust/crates/fire-uniffi/src/lib.rs
@@ -1715,6 +1715,7 @@ pub struct TopicDetailState {
     pub tags: Vec<TopicTagState>,
     pub views: u32,
     pub like_count: u32,
+    pub interaction_count: u32,
     pub created_at: Option<String>,
     pub last_read_post_number: Option<u32>,
     pub bookmarks: Vec<u64>,
@@ -1735,6 +1736,7 @@ pub struct TopicDetailState {
 
 impl From<TopicDetail> for TopicDetailState {
     fn from(value: TopicDetail) -> Self {
+        let interaction_count = value.interaction_count();
         Self {
             id: value.id,
             title: value.title,
@@ -1744,6 +1746,7 @@ impl From<TopicDetail> for TopicDetailState {
             tags: value.tags.into_iter().map(Into::into).collect(),
             views: value.views,
             like_count: value.like_count,
+            interaction_count,
             created_at: value.created_at,
             last_read_post_number: value.last_read_post_number,
             bookmarks: value.bookmarks,
@@ -3111,6 +3114,27 @@ mod tests {
             FireUniFfiError::Storage { details }
                 if details.contains("/tmp/session.json") && details.contains("denied")
         ));
+    }
+
+    #[test]
+    fn topic_detail_state_carries_interaction_count() {
+        let state = TopicDetailState::from(TopicDetail {
+            like_count: 8,
+            post_stream: TopicPostStream {
+                posts: vec![TopicPost {
+                    reactions: vec![TopicReaction {
+                        id: "clap".into(),
+                        count: 2,
+                        ..TopicReaction::default()
+                    }],
+                    ..TopicPost::default()
+                }],
+                ..TopicPostStream::default()
+            },
+            ..TopicDetail::default()
+        });
+
+        assert_eq!(state.interaction_count, 10);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- finalize dropped network traces with a Rust-side cancellation guard and add a `Cancelled` outcome
- carry that guard through response and message bus body handling so restarted polls no longer get stuck in `InProgress`
- surface the cancelled state in UniFFI, iOS, and Android diagnostics UI and document the terminal-outcome contract

## Testing
- `cargo test -p fire-core --test messagebus -- --nocapture`
- `cargo check -p fire-uniffi`
- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -configuration Debug -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' CODE_SIGNING_ALLOWED=NO build`
- `./gradlew compileDebugKotlin` *(fails because Gradle 8.14 download hit `java.net.ConnectException: Connection refused`)*
