### PR TITLE
Upgrade iOS diagnostics workflows

### DIFF
--- a/docs/architecture/fire-native-workspace.md
+++ b/docs/architecture/fire-native-workspace.md
@@ -114,6 +114,7 @@ File ownership convention:
 - The current Rust-owned file layout inside that workspace is:
   - `logs/` for Mars Xlog output
   - `diagnostics/fire-readable.log` for a plaintext tracing mirror
+  - `diagnostics/support-bundles/` for locally exported redacted diagnostics bundles
   - `cache/xlog/` for Xlog cache and mmap spill files
   - `session.json` for the persisted session snapshot triggered by the host shell
 - `session.json` remains host-triggered persistence under that workspace root.

--- a/native/android-app/src/main/java/com/fire/app/RequestTraceDetailActivity.kt
+++ b/native/android-app/src/main/java/com/fire/app/RequestTraceDetailActivity.kt
@@ -74,6 +74,9 @@ class RequestTraceDetailActivity : AppCompatActivity() {
                     detail.responseBodyBytes?.let {
                         appendLine("Body Size: ${DiagnosticsPresentation.formatBytes(it)}")
                     }
+                    detail.responseBodyStoredBytes?.let {
+                        appendLine("Cached Preview: ${DiagnosticsPresentation.formatBytes(it)}")
+                    }
                     detail.summary.errorMessage?.let {
                         appendLine("Error: $it")
                     }
@@ -84,10 +87,14 @@ class RequestTraceDetailActivity : AppCompatActivity() {
                 responseHeadersText.text =
                     DiagnosticsPresentation.renderHeaders(detail.responseHeaders)
                 responseBodyText.text = detail.responseBody?.let { body ->
-                    if (detail.responseBodyTruncated) {
-                        "$body\n\n<response body truncated to first 64 KB>"
-                    } else {
-                        body
+                    buildString {
+                        append(body)
+                        when {
+                            detail.responseBodyStorageTruncated ->
+                                append("\n\n<stored preview truncated to the first 256 KB>")
+                            detail.responseBodyPageAvailable ->
+                                append("\n\n<additional cached body content available>")
+                        }
                     }
                 } ?: getString(R.string.diagnostics_trace_response_empty)
                 executionChainText.text = if (detail.events.isEmpty()) {

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -90,6 +90,7 @@ final class FireAppViewModel: ObservableObject {
     private static let topicPostPageSize = 30
     private static let topicPostPrefetchThreshold = 6
     private static let topicDetailLogTarget = "ios.topic-detail"
+    private static let diagnosticsLifecycleLogTarget = "ios.lifecycle"
     private static let topicListRefreshLoadingPollInterval: Duration = .milliseconds(250)
 
     // MARK: - Session
@@ -1036,6 +1037,21 @@ final class FireAppViewModel: ObservableObject {
         return try await sessionStore.readLogFile(relativePath: relativePath)
     }
 
+    func readLogFilePage(
+        relativePath: String,
+        cursor: UInt64? = nil,
+        maxBytes: UInt64? = nil,
+        direction: DiagnosticsPageDirectionState
+    ) async throws -> LogFilePageState {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.readLogFilePage(
+            relativePath: relativePath,
+            cursor: cursor,
+            maxBytes: maxBytes,
+            direction: direction
+        )
+    }
+
     func listNetworkTraces(limit: UInt64 = 200) async throws -> [NetworkTraceSummaryState] {
         let sessionStore = try await sessionStoreValue()
         return try await sessionStore.listNetworkTraces(limit: limit)
@@ -1047,6 +1063,52 @@ final class FireAppViewModel: ObservableObject {
             throw FireDiagnosticsAccessError.traceNotFound
         }
         return detail
+    }
+
+    func networkTraceBodyPage(
+        traceID: UInt64,
+        cursor: UInt64? = nil,
+        maxBytes: UInt64? = nil,
+        direction: DiagnosticsPageDirectionState
+    ) async throws -> NetworkTraceBodyPageState? {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.networkTraceBodyPage(
+            traceID: traceID,
+            cursor: cursor,
+            maxBytes: maxBytes,
+            direction: direction
+        )
+    }
+
+    func diagnosticSessionID() async throws -> String {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.diagnosticSessionID()
+    }
+
+    func exportSupportBundle(scenePhase: String?) async throws -> SupportBundleExportState {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.exportSupportBundle(
+            platform: "ios",
+            appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            buildNumber: Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String,
+            scenePhase: scenePhase
+        )
+    }
+
+    func flushDiagnosticsLogs(sync: Bool = true) async throws {
+        let sessionStore = try await sessionStoreValue()
+        try await sessionStore.flushLogs(sync: sync)
+    }
+
+    func handleDiagnosticsScenePhaseChange(_ phase: String, isAuthenticated: Bool) {
+        Task {
+            guard let sessionStore else { return }
+            let logger = sessionStore.makeLogger(target: Self.diagnosticsLifecycleLogTarget)
+            logger.info("scene phase changed to \(phase), authenticated=\(isAuthenticated)")
+            if phase == "background" || phase == "inactive" {
+                try? await sessionStore.flushLogs(sync: phase == "background")
+            }
+        }
     }
 
     func dismissError() {

--- a/native/ios-app/App/FireDiagnosticsView.swift
+++ b/native/ios-app/App/FireDiagnosticsView.swift
@@ -2,21 +2,152 @@ import Foundation
 import SwiftUI
 import UIKit
 
+struct FireDiagnosticsTextWindow: Equatable {
+    let text: String
+    let startOffset: UInt64
+    let endOffset: UInt64
+    let totalBytes: UInt64
+    let hasMoreOlder: Bool
+    let hasMoreNewer: Bool
+    let isHeadAligned: Bool
+    let isTailAligned: Bool
+
+    init(page: DiagnosticsTextPageState) {
+        self.text = page.text
+        self.startOffset = page.startOffset
+        self.endOffset = page.endOffset
+        self.totalBytes = page.totalBytes
+        self.hasMoreOlder = page.hasMoreOlder
+        self.hasMoreNewer = page.hasMoreNewer
+        self.isHeadAligned = page.isHeadAligned
+        self.isTailAligned = page.isTailAligned
+    }
+
+    init(
+        text: String,
+        startOffset: UInt64,
+        endOffset: UInt64,
+        totalBytes: UInt64,
+        hasMoreOlder: Bool,
+        hasMoreNewer: Bool,
+        isHeadAligned: Bool,
+        isTailAligned: Bool
+    ) {
+        self.text = text
+        self.startOffset = startOffset
+        self.endOffset = endOffset
+        self.totalBytes = totalBytes
+        self.hasMoreOlder = hasMoreOlder
+        self.hasMoreNewer = hasMoreNewer
+        self.isHeadAligned = isHeadAligned
+        self.isTailAligned = isTailAligned
+    }
+}
+
+struct FireDiagnosticsPagedTextDocument: Equatable {
+    let newestFirst: Bool
+    private(set) var windows: [FireDiagnosticsTextWindow]
+
+    init(newestFirst: Bool, windows: [FireDiagnosticsTextWindow]) {
+        self.newestFirst = newestFirst
+        self.windows = windows.sorted { $0.startOffset < $1.startOffset }
+    }
+
+    var totalBytes: UInt64 {
+        windows.last?.totalBytes ?? 0
+    }
+
+    var olderCursor: UInt64? {
+        guard let first = windows.first, first.hasMoreOlder else {
+            return nil
+        }
+        return first.startOffset
+    }
+
+    var newerCursor: UInt64? {
+        guard let last = windows.last, last.hasMoreNewer else {
+            return nil
+        }
+        return last.endOffset
+    }
+
+    var hasLoadedAdditionalPages: Bool {
+        windows.count > 1 || !(windows.first?.isHeadAligned ?? true)
+    }
+
+    var hasMultipleWindows: Bool {
+        windows.count > 1
+    }
+
+    var loadedBytes: UInt64 {
+        guard let first = windows.first, let last = windows.last else {
+            return 0
+        }
+        return last.endOffset >= first.startOffset
+            ? last.endOffset - first.startOffset
+            : 0
+    }
+
+    var renderedText: String {
+        let combined = windows
+            .sorted { $0.startOffset < $1.startOffset }
+            .map(\.text)
+            .joined()
+        guard newestFirst else {
+            return combined
+        }
+
+        var lines = combined.components(separatedBy: .newlines)
+        if lines.last == "" {
+            lines.removeLast()
+        }
+        return lines.reversed().joined(separator: "\n")
+    }
+
+    var renderedLines: [String] {
+        var lines = renderedText.components(separatedBy: .newlines)
+        if lines.last == "" {
+            lines.removeLast()
+        }
+        return lines.isEmpty ? [""] : lines
+    }
+
+    mutating func replace(with window: FireDiagnosticsTextWindow) {
+        windows = [window]
+    }
+
+    mutating func merge(with window: FireDiagnosticsTextWindow) {
+        guard !windows.contains(where: { $0.startOffset == window.startOffset && $0.endOffset == window.endOffset }) else {
+            return
+        }
+        windows.append(window)
+        windows.sort { $0.startOffset < $1.startOffset }
+    }
+}
+
 @MainActor
 final class FireDiagnosticsViewModel: ObservableObject {
     private static let traceAutoRefreshInterval: Duration = .seconds(1)
+    private static let logPageBytes: UInt64 = 128 * 1024
+    private static let traceBodyPageBytes: UInt64 = 32 * 1024
 
+    @Published private(set) var diagnosticSessionID: String?
     @Published private(set) var logFiles: [LogFileSummaryState] = []
-    @Published private(set) var logFileDetails: [String: LogFileDetailState] = [:]
+    @Published private(set) var logDocuments: [String: FireDiagnosticsPagedTextDocument] = [:]
     @Published private(set) var requestTraces: [NetworkTraceSummaryState] = []
     @Published private(set) var requestTraceDetails: [UInt64: NetworkTraceDetailState] = [:]
+    @Published private(set) var traceBodyDocuments: [UInt64: FireDiagnosticsPagedTextDocument] = [:]
+    @Published private(set) var latestSupportBundle: SupportBundleExportState?
+    @Published private(set) var isExportingSupportBundle = false
     @Published private(set) var isLoading = false
     @Published var errorMessage: String?
 
     private let appViewModel: FireAppViewModel
     private var traceAutoRefreshTask: Task<Void, Never>?
     private var isRefreshingTraces = false
+    private var loadingLogPagePaths: Set<String> = []
     private var loadingTraceDetailIDs: Set<UInt64> = []
+    private var loadingTraceBodyPageIDs: Set<UInt64> = []
 
     init(appViewModel: FireAppViewModel) {
         self.appViewModel = appViewModel
@@ -37,9 +168,11 @@ final class FireDiagnosticsViewModel: ObservableObject {
 
             do {
                 errorMessage = nil
+                async let diagnosticSessionID = appViewModel.diagnosticSessionID()
                 async let files = appViewModel.listLogFiles()
                 async let traces = appViewModel.listNetworkTraces(limit: 200)
                 let latestTraces = try await traces
+                self.diagnosticSessionID = try await diagnosticSessionID
                 logFiles = try await files
                 applyTraceSummaries(latestTraces)
                 await refreshCachedTraceDetails(using: latestTraces)
@@ -69,22 +202,79 @@ final class FireDiagnosticsViewModel: ObservableObject {
     }
 
     func loadLogFile(relativePath: String) {
-        guard logFileDetails[relativePath] == nil else {
+        if logDocuments[relativePath] != nil {
             return
         }
+        loadLogFile(relativePath: relativePath, force: false)
+    }
 
+    func loadLogFile(relativePath: String, force: Bool) {
+        guard !loadingLogPagePaths.contains(relativePath) else {
+            return
+        }
         Task {
+            if force {
+                logDocuments.removeValue(forKey: relativePath)
+            }
+            loadingLogPagePaths.insert(relativePath)
+            defer { loadingLogPagePaths.remove(relativePath) }
             do {
                 errorMessage = nil
-                logFileDetails[relativePath] = try await appViewModel.readLogFile(relativePath: relativePath)
+                let page = try await appViewModel.readLogFilePage(
+                    relativePath: relativePath,
+                    cursor: nil,
+                    maxBytes: Self.logPageBytes,
+                    direction: .older
+                )
+                logDocuments[relativePath] = FireDiagnosticsPagedTextDocument(
+                    newestFirst: true,
+                    windows: [FireDiagnosticsTextWindow(page: page.page)]
+                )
             } catch {
                 errorMessage = error.localizedDescription
             }
         }
     }
 
-    func logFile(relativePath: String) -> LogFileDetailState? {
-        logFileDetails[relativePath]
+    func resetLogFile(relativePath: String) {
+        loadLogFile(relativePath: relativePath, force: true)
+    }
+
+    func loadOlderLogPage(relativePath: String) {
+        guard let cursor = logDocuments[relativePath]?.olderCursor else {
+            return
+        }
+        guard !loadingLogPagePaths.contains(relativePath) else {
+            return
+        }
+
+        Task {
+            loadingLogPagePaths.insert(relativePath)
+            defer { loadingLogPagePaths.remove(relativePath) }
+            do {
+                errorMessage = nil
+                let page = try await appViewModel.readLogFilePage(
+                    relativePath: relativePath,
+                    cursor: cursor,
+                    maxBytes: Self.logPageBytes,
+                    direction: .older
+                )
+                var document = logDocuments[relativePath]
+                    ?? FireDiagnosticsPagedTextDocument(newestFirst: true, windows: [])
+                document.merge(with: FireDiagnosticsTextWindow(page: page.page))
+                logDocuments[relativePath] = document
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func isLoadingLogPage(relativePath: String) -> Bool {
+        loadingLogPagePaths.contains(relativePath)
+    }
+
+    func logDocument(relativePath: String) -> FireDiagnosticsPagedTextDocument? {
+        logDocuments[relativePath]
     }
 
     func loadTraceDetail(traceID: UInt64, force: Bool = false) {
@@ -100,7 +290,12 @@ final class FireDiagnosticsViewModel: ObservableObject {
             defer { loadingTraceDetailIDs.remove(traceID) }
             do {
                 errorMessage = nil
-                requestTraceDetails[traceID] = try await appViewModel.networkTraceDetail(traceID: traceID)
+                let detail = try await appViewModel.networkTraceDetail(traceID: traceID)
+                requestTraceDetails[traceID] = detail
+                seedTraceBodyDocumentIfNeeded(
+                    from: detail,
+                    replaceInlinePreview: force && !(traceBodyDocuments[traceID]?.hasLoadedAdditionalPages ?? false)
+                )
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -109,6 +304,149 @@ final class FireDiagnosticsViewModel: ObservableObject {
 
     func requestTraceDetail(traceID: UInt64) -> NetworkTraceDetailState? {
         requestTraceDetails[traceID]
+    }
+
+    func traceBodyDocument(traceID: UInt64) -> FireDiagnosticsPagedTextDocument? {
+        traceBodyDocuments[traceID]
+    }
+
+    func isLoadingTraceBodyPage(traceID: UInt64) -> Bool {
+        loadingTraceBodyPageIDs.contains(traceID)
+    }
+
+    func loadNewerTraceBodyPage(traceID: UInt64) {
+        guard let cursor = traceBodyDocuments[traceID]?.newerCursor else {
+            return
+        }
+        loadTraceBodyPage(
+            traceID: traceID,
+            cursor: cursor,
+            direction: .newer,
+            replaceExisting: false
+        )
+    }
+
+    func loadOlderTraceBodyPage(traceID: UInt64) {
+        guard let cursor = traceBodyDocuments[traceID]?.olderCursor else {
+            return
+        }
+        loadTraceBodyPage(
+            traceID: traceID,
+            cursor: cursor,
+            direction: .older,
+            replaceExisting: false
+        )
+    }
+
+    func showTraceBodyTail(traceID: UInt64) {
+        loadTraceBodyPage(
+            traceID: traceID,
+            cursor: nil,
+            direction: .older,
+            replaceExisting: true
+        )
+    }
+
+    func resetTraceBodyPreview(traceID: UInt64) {
+        guard let detail = requestTraceDetails[traceID] else {
+            loadTraceDetail(traceID: traceID, force: true)
+            return
+        }
+        seedTraceBodyDocumentIfNeeded(from: detail, replaceInlinePreview: true)
+    }
+
+    func exportSupportBundle(scenePhase: String) {
+        guard !isExportingSupportBundle else {
+            return
+        }
+
+        Task {
+            isExportingSupportBundle = true
+            defer { isExportingSupportBundle = false }
+            do {
+                errorMessage = nil
+                latestSupportBundle = try await appViewModel.exportSupportBundle(scenePhase: scenePhase)
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func supportBundleURL() -> URL? {
+        latestSupportBundle.map { URL(fileURLWithPath: $0.absolutePath) }
+    }
+
+    private func loadTraceBodyPage(
+        traceID: UInt64,
+        cursor: UInt64?,
+        direction: DiagnosticsPageDirectionState,
+        replaceExisting: Bool
+    ) {
+        guard !loadingTraceBodyPageIDs.contains(traceID) else {
+            return
+        }
+
+        Task {
+            loadingTraceBodyPageIDs.insert(traceID)
+            defer { loadingTraceBodyPageIDs.remove(traceID) }
+            do {
+                errorMessage = nil
+                guard let page = try await appViewModel.networkTraceBodyPage(
+                    traceID: traceID,
+                    cursor: cursor,
+                    maxBytes: Self.traceBodyPageBytes,
+                    direction: direction
+                ) else {
+                    return
+                }
+
+                let window = FireDiagnosticsTextWindow(page: page.page)
+                var document = traceBodyDocuments[traceID]
+                    ?? FireDiagnosticsPagedTextDocument(newestFirst: false, windows: [])
+                if replaceExisting {
+                    document.replace(with: window)
+                } else {
+                    document.merge(with: window)
+                }
+                traceBodyDocuments[traceID] = document
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    private func seedTraceBodyDocumentIfNeeded(
+        from detail: NetworkTraceDetailState,
+        replaceInlinePreview: Bool
+    ) {
+        guard let responseBody = detail.responseBody, !responseBody.isEmpty else {
+            if replaceInlinePreview {
+                traceBodyDocuments.removeValue(forKey: detail.summary.id)
+            }
+            return
+        }
+
+        if traceBodyDocuments[detail.summary.id] != nil, !replaceInlinePreview {
+            return
+        }
+
+        let inlineBytes = UInt64(responseBody.lengthOfBytes(using: .utf8))
+        let totalBytes = detail.responseBodyStoredBytes ?? inlineBytes
+        traceBodyDocuments[detail.summary.id] = FireDiagnosticsPagedTextDocument(
+            newestFirst: false,
+            windows: [
+                FireDiagnosticsTextWindow(
+                    text: responseBody,
+                    startOffset: 0,
+                    endOffset: inlineBytes,
+                    totalBytes: totalBytes,
+                    hasMoreOlder: false,
+                    hasMoreNewer: detail.responseBodyPageAvailable,
+                    isHeadAligned: true,
+                    isTailAligned: !detail.responseBodyPageAvailable
+                )
+            ]
+        )
     }
 
     // MARK: - Computed Stats
@@ -199,6 +537,7 @@ final class FireDiagnosticsViewModel: ObservableObject {
 // MARK: - Dashboard (Entry Point)
 
 struct FireDiagnosticsView: View {
+    @Environment(\.scenePhase) private var scenePhase
     @StateObject private var diagnosticsViewModel: FireDiagnosticsViewModel
 
     init(viewModel: FireAppViewModel) {
@@ -229,6 +568,8 @@ struct FireDiagnosticsView: View {
                 } label: {
                     logCard
                 }
+
+                supportBundleCard
             }
             .listRowSeparator(.hidden)
             .listRowInsets(EdgeInsets(top: 6, leading: 16, bottom: 6, trailing: 16))
@@ -237,6 +578,9 @@ struct FireDiagnosticsView: View {
         .navigationTitle("诊断工具")
         .onAppear {
             diagnosticsViewModel.startTraceAutoRefresh()
+        }
+        .onDisappear {
+            diagnosticsViewModel.stopTraceAutoRefresh()
         }
         .task {
             diagnosticsViewModel.refresh()
@@ -324,6 +668,76 @@ struct FireDiagnosticsView: View {
         )
     }
 
+    private var supportBundleCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("诊断包", systemImage: "square.and.arrow.up")
+                .font(.headline)
+
+            Text("导出最近日志窗口、网络请求摘要和已脱敏会话快照，便于本地留档或分享排障。")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            if let diagnosticSessionID = diagnosticsViewModel.diagnosticSessionID {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Session ID")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+
+                    Text(diagnosticSessionID)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+
+            HStack(spacing: 10) {
+                Button {
+                    diagnosticsViewModel.exportSupportBundle(
+                        scenePhase: scenePhaseLabel(scenePhase)
+                    )
+                } label: {
+                    Label(
+                        diagnosticsViewModel.isExportingSupportBundle ? "导出中…" : "导出诊断包",
+                        systemImage: "tray.and.arrow.down"
+                    )
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(diagnosticsViewModel.isExportingSupportBundle)
+
+                if let bundleURL = diagnosticsViewModel.supportBundleURL() {
+                    ShareLink(item: bundleURL) {
+                        Label("分享", systemImage: "square.and.arrow.up")
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                if diagnosticsViewModel.isExportingSupportBundle {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            if let export = diagnosticsViewModel.latestSupportBundle {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(export.fileName) · \(FireDiagnosticsPresentation.byteSize(export.sizeBytes))")
+                        .font(.caption.monospaced())
+                    Text(FireDiagnosticsPresentation.timestamp(export.createdAtUnixMs))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(export.relativePath)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(.secondarySystemGroupedBackground))
+        )
+    }
+
     private func miniStat(value: String, label: String, color: Color) -> some View {
         VStack(spacing: 2) {
             Text(value)
@@ -334,6 +748,19 @@ struct FireDiagnosticsView: View {
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private func scenePhaseLabel(_ phase: ScenePhase) -> String {
+        switch phase {
+        case .active:
+            return "active"
+        case .inactive:
+            return "inactive"
+        case .background:
+            return "background"
+        @unknown default:
+            return "unknown"
+        }
     }
 }
 
@@ -472,6 +899,10 @@ private struct FireRequestTraceDetailView: View {
         case timeline = "Timeline"
     }
 
+    private var bodyDocument: FireDiagnosticsPagedTextDocument? {
+        viewModel.traceBodyDocument(traceID: traceID)
+    }
+
     var body: some View {
         Group {
             if let detail = viewModel.requestTraceDetail(traceID: traceID) {
@@ -505,7 +936,12 @@ private struct FireRequestTraceDetailView: View {
                 .toolbar {
                     ToolbarItem(placement: .navigationBarTrailing) {
                         Button {
-                            copyToClipboard(fullHTTPText(detail: detail))
+                            copyToClipboard(
+                                fullHTTPText(
+                                    detail: detail,
+                                    bodyText: bodyDocument?.renderedText ?? detail.responseBody
+                                )
+                            )
                         } label: {
                             Label("复制全部", systemImage: "doc.on.doc")
                         }
@@ -549,7 +985,10 @@ private struct FireRequestTraceDetailView: View {
 
     // MARK: - Full Request Copy
 
-    private func fullHTTPText(detail: NetworkTraceDetailState) -> String {
+    private func fullHTTPText(
+        detail: NetworkTraceDetailState,
+        bodyText: String?
+    ) -> String {
         var lines: [String] = []
 
         lines.append("\(detail.summary.method) \(detail.summary.url) HTTP/1.1")
@@ -572,9 +1011,9 @@ private struct FireRequestTraceDetailView: View {
             }
         }
 
-        if let body = detail.responseBody, !body.isEmpty {
+        if let bodyText, !bodyText.isEmpty {
             lines.append("")
-            lines.append(body)
+            lines.append(bodyText)
         }
 
         return lines.joined(separator: "\n")
@@ -648,6 +1087,10 @@ private struct FireRequestTraceDetailView: View {
                 kvRow("Body Size", FireDiagnosticsPresentation.byteSize(responseBodyBytes))
             }
 
+            if let storedBytes = detail.responseBodyStoredBytes {
+                kvRow("Preview Cache", FireDiagnosticsPresentation.byteSize(storedBytes))
+            }
+
             if let contentType = detail.summary.responseContentType {
                 kvRow("Content-Type", contentType)
             }
@@ -714,26 +1157,77 @@ private struct FireRequestTraceDetailView: View {
             sectionHeader(
                 "Body",
                 copyAction: {
-                    guard let body = detail.responseBody, !body.isEmpty else { return }
+                    guard let body = bodyDocument?.renderedText ?? detail.responseBody, !body.isEmpty else { return }
                     copyToClipboard(body)
                 }
             )
 
-            if let responseBody = detail.responseBody, !responseBody.isEmpty {
-                if detail.responseBodyTruncated {
-                    Label("已截断至 256 KB", systemImage: "scissors")
-                        .font(.caption)
-                        .foregroundStyle(.orange)
-                        .padding(.bottom, 4)
-                }
+            if let document = bodyDocument {
+                VStack(alignment: .leading, spacing: 8) {
+                    if detail.responseBodyStorageTruncated {
+                        Label("响应 body 仅保留前 256 KB 缓存预览，无法回看原始尾部。", systemImage: "scissors")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    } else if detail.responseBodyPageAvailable {
+                        Label("当前仅内联首屏预览，可继续按需加载。", systemImage: "text.append")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
 
-                Text(responseBody)
-                    .font(.system(.caption, design: .monospaced))
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(12)
-                    .background(Color(.tertiarySystemGroupedBackground))
-                    .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                    HStack(spacing: 8) {
+                        if let storedBytes = detail.responseBodyStoredBytes {
+                            Text("已加载 \(FireDiagnosticsPresentation.byteSize(document.loadedBytes)) / \(FireDiagnosticsPresentation.byteSize(storedBytes))")
+                                .font(.caption2.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                        }
+
+                        Spacer()
+
+                        if bodyDocument?.hasLoadedAdditionalPages == true {
+                            Button("回到首屏") {
+                                viewModel.resetTraceBodyPreview(traceID: traceID)
+                            }
+                            .font(.caption)
+                            .buttonStyle(.borderless)
+                        }
+                    }
+
+                    HStack(spacing: 8) {
+                        if document.newerCursor != nil {
+                            Button("加载更多") {
+                                viewModel.loadNewerTraceBodyPage(traceID: traceID)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        }
+
+                        if detail.responseBodyPageAvailable || detail.responseBodyStorageTruncated {
+                            Button(detail.responseBodyStorageTruncated ? "查看缓存尾部" : "查看尾部") {
+                                viewModel.showTraceBodyTail(traceID: traceID)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        }
+
+                        if document.olderCursor != nil {
+                            Button("向前加载") {
+                                viewModel.loadOlderTraceBodyPage(traceID: traceID)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
+                        }
+
+                        if viewModel.isLoadingTraceBodyPage(traceID: traceID) {
+                            ProgressView()
+                                .controlSize(.small)
+                        }
+                    }
+
+                    FireDiagnosticsTextView(text: document.renderedText)
+                        .frame(minHeight: 220, maxHeight: 360)
+                        .background(Color(.tertiarySystemGroupedBackground))
+                        .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+                }
             } else {
                 emptyNote("未捕获到响应 body")
             }
@@ -976,30 +1470,42 @@ private struct FireDiagnosticsLogView: View {
     @ObservedObject var viewModel: FireDiagnosticsViewModel
     let relativePath: String
 
+    private var fileSummary: LogFileSummaryState? {
+        viewModel.logFiles.first { $0.relativePath == relativePath }
+    }
+
     var body: some View {
         Group {
-            if let logFile = viewModel.logFile(relativePath: relativePath) {
+            if let document = viewModel.logDocument(relativePath: relativePath) {
                 VStack(alignment: .leading, spacing: 12) {
                     HStack {
                         VStack(alignment: .leading, spacing: 4) {
-                            Text(logFile.fileName)
+                            Text(fileSummary?.fileName ?? relativePath)
                                 .font(.headline)
 
-                            Text(FireDiagnosticsPresentation.byteSize(logFile.sizeBytes))
+                            if let fileSummary {
+                                Text(FireDiagnosticsPresentation.byteSize(fileSummary.sizeBytes))
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                            }
+
+                            Text("最新在上，滚动到底部自动加载更早内容")
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                         }
 
                         Spacer()
 
-                        if logFile.isTruncated {
-                            Label("已截断", systemImage: "scissors")
-                                .font(.caption)
-                                .foregroundStyle(.orange)
+                        if document.hasMultipleWindows {
+                            Button("回到最新") {
+                                viewModel.resetLogFile(relativePath: relativePath)
+                            }
+                            .buttonStyle(.bordered)
+                            .controlSize(.small)
                         }
                     }
 
-                    if logFile.contents.isEmpty {
+                    if document.renderedLines == [""] {
                         Text("暂无日志内容。")
                             .font(.system(.caption, design: .monospaced))
                             .foregroundStyle(.secondary)
@@ -1008,7 +1514,32 @@ private struct FireDiagnosticsLogView: View {
                             .background(Color(.tertiarySystemGroupedBackground))
                             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
                     } else {
-                        FireDiagnosticsLogTextView(text: logFile.contents)
+                        Text("已加载 \(FireDiagnosticsPresentation.byteSize(document.loadedBytes)) / \(FireDiagnosticsPresentation.byteSize(document.totalBytes))")
+                            .font(.caption2.monospacedDigit())
+                            .foregroundStyle(.secondary)
+
+                        ScrollView {
+                            LazyVStack(alignment: .leading, spacing: 6) {
+                                ForEach(Array(document.renderedLines.enumerated()), id: \.offset) { _, line in
+                                    Text(line.isEmpty ? " " : line)
+                                        .font(.system(.caption, design: .monospaced))
+                                        .frame(maxWidth: .infinity, alignment: .leading)
+                                }
+
+                                if viewModel.isLoadingLogPage(relativePath: relativePath) {
+                                    ProgressView()
+                                        .padding(.vertical, 8)
+                                } else if document.olderCursor != nil {
+                                    Color.clear
+                                        .frame(height: 1)
+                                        .onAppear {
+                                            viewModel.loadOlderLogPage(relativePath: relativePath)
+                                        }
+                                }
+                            }
+                            .padding(12)
+                            .textSelection(.enabled)
+                        }
                             .frame(maxWidth: .infinity, maxHeight: .infinity)
                             .background(Color(.tertiarySystemGroupedBackground))
                             .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
@@ -1028,7 +1559,7 @@ private struct FireDiagnosticsLogView: View {
     }
 }
 
-private struct FireDiagnosticsLogTextView: UIViewRepresentable {
+private struct FireDiagnosticsTextView: UIViewRepresentable {
     let text: String
 
     func makeUIView(context: Context) -> UITextView {

--- a/native/ios-app/App/FireTabRoot.swift
+++ b/native/ios-app/App/FireTabRoot.swift
@@ -63,6 +63,10 @@ struct FireTabRoot: View {
             }
         }
         .onChange(of: scenePhase) { _, phase in
+            viewModel.handleDiagnosticsScenePhaseChange(
+                scenePhaseLabel(phase),
+                isAuthenticated: isAuthenticated
+            )
             switch phase {
             case .active:
                 if isAuthenticated {
@@ -105,6 +109,19 @@ struct FireTabRoot: View {
                 "postNumber": deepLink.postNumber as Any
             ]
         )
+    }
+
+    private func scenePhaseLabel(_ phase: ScenePhase) -> String {
+        switch phase {
+        case .active:
+            return "active"
+        case .inactive:
+            return "inactive"
+        case .background:
+            return "background"
+        @unknown default:
+            return "unknown"
+        }
     }
 }
 

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -68,7 +68,10 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
 - `App/FireDiagnosticsView.swift`
   - renders a native diagnostics screen on top of the shared Rust diagnostics APIs
   - lists workspace log files plus reverse-chronological network request traces
-  - opens dedicated detail pages for log content and per-request execution chains
+  - opens tail-first log pages, preview-first network body viewers, and per-request execution chains without pushing full diagnostic text across the UniFFI boundary by default
+  - exports local support bundles containing redacted session state, recent log windows, and recent trace summaries for share-sheet based escalation
+- `App/FireTabRoot.swift`
+  - forwards scene-phase transitions into shared diagnostics lifecycle logging and flushes logs before `inactive` / `background` so exported diagnostics stay durable
 - `App/FireTopicPresentation.swift`
   - normalizes topic/post timestamps for native presentation
   - extracts inline cooked-image attachments plus enabled reaction options from bootstrap/topic HTML so the native detail view can render media and interaction affordances without a WebView
@@ -106,6 +109,7 @@ Workspace note:
 - The iOS host now passes `Application Support/Fire` into Rust as the workspace root.
 - Rust now initializes shared logging under `Application Support/Fire/logs` and keeps xlog cache files under `Application Support/Fire/cache/xlog`.
 - Rust also mirrors readable tracing output into `Application Support/Fire/diagnostics/fire-readable.log`.
+- Rust now writes locally shareable support bundles into `Application Support/Fire/diagnostics/support-bundles/`.
 - Swift host-side logs can now write back into that same Rust-owned logging pipeline, so native lifecycle/debug messages land in the shared xlog and readable-log artifacts instead of a separate `OSLog` stream.
 - Rust can resolve relative paths inside that workspace for shared file ownership such as logs, caches, or exports.
 - The current persisted session file remains `Application Support/Fire/session.json`, but iOS now writes it as a redacted cache.
@@ -134,7 +138,7 @@ Current UX note:
 - Topic posts now render normalized native text plus inline image attachments in the detail screen, while more complex cooked modules still fall back to the lightweight native presentation instead of a full HTML/WebView renderer.
 - The app now keeps the in-app notification list synchronized from Rust-owned notification runtime state when MessageBus notification events arrive, instead of only updating the unread badge count.
 - iOS now schedules background refresh work for `/notification-alert/{userId}` and presents host-owned local notifications from a dedicated one-shot Rust MessageBus poll path.
-- The app now exposes a diagnostics screen for readable logs and Rust-owned request trace inspection.
+- The app now exposes a diagnostics screen for tail-first log inspection, preview-first request-trace body paging, and local support-bundle export.
 - The profile screen now consumes Rust-derived session display labels, so authenticated recovery states are described consistently across hosts instead of being inferred separately in Swift.
 
 Build prerequisites:

--- a/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
+++ b/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
@@ -68,7 +68,7 @@ public actor FireSessionStore {
     private let workspacePath: String
     private let sessionFilePath: String
     private let authCookieStore: any FireAuthCookieSecureStore
-    // Keep blocking log flush/list/read work off elevated Swift concurrency executors.
+    // Keep blocking diagnostics IO off elevated Swift concurrency executors.
     private let diagnosticsQueue = DispatchQueue(
         label: "com.fire.session-store.diagnostics",
         qos: .utility
@@ -247,12 +247,100 @@ public actor FireSessionStore {
         }
     }
 
+    public func readLogFilePage(
+        relativePath: String,
+        cursor: UInt64? = nil,
+        maxBytes: UInt64? = nil,
+        direction: DiagnosticsPageDirectionState
+    ) async throws -> LogFilePageState {
+        let core = self.core
+        let diagnosticsQueue = self.diagnosticsQueue
+        return try await withCheckedThrowingContinuation { continuation in
+            diagnosticsQueue.async {
+                continuation.resume(
+                    with: Result {
+                        try core.readLogFilePage(
+                            relativePath: relativePath,
+                            cursor: cursor,
+                            maxBytes: maxBytes,
+                            direction: direction
+                        )
+                    }
+                )
+            }
+        }
+    }
+
     public func listNetworkTraces(limit: UInt64 = 200) throws -> [NetworkTraceSummaryState] {
         try core.listNetworkTraces(limit: limit)
     }
 
     public func networkTraceDetail(traceID: UInt64) throws -> NetworkTraceDetailState? {
         try core.networkTraceDetail(traceId: traceID)
+    }
+
+    public func networkTraceBodyPage(
+        traceID: UInt64,
+        cursor: UInt64? = nil,
+        maxBytes: UInt64? = nil,
+        direction: DiagnosticsPageDirectionState
+    ) async throws -> NetworkTraceBodyPageState? {
+        let core = self.core
+        let diagnosticsQueue = self.diagnosticsQueue
+        return try await withCheckedThrowingContinuation { continuation in
+            diagnosticsQueue.async {
+                continuation.resume(
+                    with: Result {
+                        try core.networkTraceBodyPage(
+                            traceId: traceID,
+                            cursor: cursor,
+                            maxBytes: maxBytes,
+                            direction: direction
+                        )
+                    }
+                )
+            }
+        }
+    }
+
+    public func diagnosticSessionID() throws -> String {
+        try core.diagnosticSessionId()
+    }
+
+    public func exportSupportBundle(
+        platform: String,
+        appVersion: String?,
+        buildNumber: String?,
+        scenePhase: String?
+    ) async throws -> SupportBundleExportState {
+        let core = self.core
+        let diagnosticsQueue = self.diagnosticsQueue
+        return try await withCheckedThrowingContinuation { continuation in
+            diagnosticsQueue.async {
+                continuation.resume(
+                    with: Result {
+                        try core.exportSupportBundle(
+                            hostContext: SupportBundleHostContextState(
+                                platform: platform,
+                                appVersion: appVersion,
+                                buildNumber: buildNumber,
+                                scenePhase: scenePhase
+                            )
+                        )
+                    }
+                )
+            }
+        }
+    }
+
+    public func flushLogs(sync: Bool = true) async throws {
+        let core = self.core
+        let diagnosticsQueue = self.diagnosticsQueue
+        try await withCheckedThrowingContinuation { continuation in
+            diagnosticsQueue.async {
+                continuation.resume(with: Result { try core.flushLogs(sync: sync) })
+            }
+        }
     }
 
     public func exportSessionJSON() throws -> String {

--- a/rust/crates/fire-core/src/core/mod.rs
+++ b/rust/crates/fire-core/src/core/mod.rs
@@ -26,8 +26,10 @@ use crate::{
     config::FireCoreConfig,
     cookies::FireSessionCookieJar,
     diagnostics::{
-        list_log_files, read_log_file, FireDiagnosticsStore, FireLogFileDetail, FireLogFileSummary,
-        NetworkTraceDetail, NetworkTraceSummary,
+        export_support_bundle, list_log_files, read_log_file, read_log_file_page,
+        DiagnosticsPageDirection, FireDiagnosticsStore, FireLogFileDetail, FireLogFilePage,
+        FireLogFileSummary, FireSupportBundleExport, FireSupportBundleHostContext,
+        NetworkTraceBodyPage, NetworkTraceDetail, NetworkTraceSummary,
     },
     error::FireCoreError,
     logging::{log_host_message, logger_runtime_for_workspace, FireHostLogLevel},
@@ -59,10 +61,12 @@ impl FireCore {
     pub fn new(config: FireCoreConfig) -> Result<Self, FireCoreError> {
         let base_url = Url::parse(&config.base_url)?;
         let workspace_path = normalize_workspace_path(config.workspace_path);
+        let diagnostics = Arc::new(FireDiagnosticsStore::new());
         if let Some(workspace_path) = workspace_path.as_deref() {
             let logger = logger_runtime_for_workspace(workspace_path)?;
             info!(
                 workspace_path = %workspace_path.display(),
+                diagnostic_session_id = %diagnostics.diagnostic_session_id(),
                 log_dir = %logger.log_dir.display(),
                 cache_dir = %logger.cache_dir.display(),
                 "initialized fire workspace logging"
@@ -78,7 +82,6 @@ impl FireCore {
         };
         let session = Arc::new(RwLock::new(session));
         let cookie_jar = Arc::new(FireSessionCookieJar::new(base_url.clone(), session.clone()));
-        let diagnostics = Arc::new(FireDiagnosticsStore::new());
         let network = network::FireNetworkLayer::new(
             &base_url,
             Arc::clone(&session),
@@ -126,6 +129,10 @@ impl FireCore {
         }
     }
 
+    pub fn diagnostic_session_id(&self) -> String {
+        self.diagnostics.diagnostic_session_id().to_string()
+    }
+
     pub fn log_host(
         &self,
         level: FireHostLogLevel,
@@ -135,7 +142,12 @@ impl FireCore {
         if let Some(workspace_path) = self.workspace_path() {
             let _ = logger_runtime_for_workspace(workspace_path);
         }
-        log_host_message(level, target.as_ref(), message.as_ref());
+        log_host_message(
+            level,
+            target.as_ref(),
+            message.as_ref(),
+            Some(self.diagnostics.diagnostic_session_id()),
+        );
     }
 
     pub fn snapshot(&self) -> SessionSnapshot {
@@ -165,12 +177,54 @@ impl FireCore {
         read_log_file(workspace_path, relative_path)
     }
 
+    pub fn read_log_file_page(
+        &self,
+        relative_path: impl AsRef<Path>,
+        cursor: Option<u64>,
+        max_bytes: usize,
+        direction: DiagnosticsPageDirection,
+    ) -> Result<FireLogFilePage, FireCoreError> {
+        self.flush_logs(true);
+        let workspace_path = self
+            .workspace_path()
+            .ok_or(FireCoreError::MissingWorkspacePath)?;
+        read_log_file_page(workspace_path, relative_path, cursor, max_bytes, direction)
+    }
+
     pub fn list_network_traces(&self, limit: usize) -> Vec<NetworkTraceSummary> {
         self.diagnostics.summaries(limit)
     }
 
     pub fn network_trace_detail(&self, trace_id: u64) -> Option<NetworkTraceDetail> {
         self.diagnostics.detail(trace_id)
+    }
+
+    pub fn network_trace_body_page(
+        &self,
+        trace_id: u64,
+        cursor: Option<u64>,
+        max_bytes: usize,
+        direction: DiagnosticsPageDirection,
+    ) -> Option<NetworkTraceBodyPage> {
+        self.diagnostics
+            .network_trace_body_page(trace_id, cursor, max_bytes, direction)
+    }
+
+    pub fn export_support_bundle(
+        &self,
+        host_context: FireSupportBundleHostContext,
+    ) -> Result<FireSupportBundleExport, FireCoreError> {
+        self.flush_logs(true);
+        let workspace_path = self
+            .workspace_path()
+            .ok_or(FireCoreError::MissingWorkspacePath)?;
+        let session_json = self.export_redacted_session_json()?;
+        export_support_bundle(
+            workspace_path,
+            &self.diagnostics,
+            &session_json,
+            &host_context,
+        )
     }
 
     pub(crate) fn update_session<F>(&self, mutate: F) -> SessionSnapshot

--- a/rust/crates/fire-core/src/diagnostics.rs
+++ b/rust/crates/fire-core/src/diagnostics.rs
@@ -2186,7 +2186,10 @@ mod tests {
         );
 
         let listed_logs = super::list_log_files(&workspace_dir).expect("list logs");
-        assert_eq!(listed_logs[0].relative_path, "diagnostics/fire-readable.log");
+        assert_eq!(
+            listed_logs[0].relative_path,
+            "diagnostics/fire-readable.log"
+        );
         assert!(listed_logs.iter().all(|file| {
             !file
                 .relative_path

--- a/rust/crates/fire-core/src/diagnostics.rs
+++ b/rust/crates/fire-core/src/diagnostics.rs
@@ -23,12 +23,23 @@ use openwire::{
     CallContext, ConnectionId, EventListener, EventListenerFactory, RequestBody, ResponseBody,
     WireError,
 };
+use serde_json::{json, Value};
 
-use crate::{error::FireCoreError, workspace::validate_workspace_relative_path};
+use crate::{
+    error::FireCoreError, session_store::write_atomic, workspace::validate_workspace_relative_path,
+};
 
 const MAX_NETWORK_TRACES: usize = 200;
 const MAX_RESPONSE_BODY_BYTES: usize = 256 * 1024;
+const MAX_RESPONSE_BODY_INLINE_BYTES: usize = 16 * 1024;
 const MAX_LOG_CONTENT_BYTES: usize = 512 * 1024;
+const DEFAULT_LOG_PAGE_BYTES: usize = 128 * 1024;
+const DEFAULT_TRACE_BODY_PAGE_BYTES: usize = 32 * 1024;
+const SUPPORT_BUNDLE_LOG_FILE_LIMIT: usize = 4;
+const SUPPORT_BUNDLE_TRACE_LIMIT: usize = 20;
+const SUPPORT_BUNDLE_LOG_PAGE_BYTES: usize = 96 * 1024;
+const SUPPORT_BUNDLE_TRACE_BODY_BYTES: usize = 32 * 1024;
+const SUPPORT_BUNDLE_DIR_NAME: &str = "support-bundles";
 const REDACTED_HEADER_VALUE: &str = "<redacted>";
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -37,6 +48,25 @@ pub enum NetworkTraceOutcome {
     Succeeded,
     Failed,
     Cancelled,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DiagnosticsPageDirection {
+    Older,
+    Newer,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiagnosticsTextPage {
+    pub text: String,
+    pub start_offset: u64,
+    pub end_offset: u64,
+    pub total_bytes: u64,
+    pub next_cursor: Option<u64>,
+    pub has_more_older: bool,
+    pub has_more_newer: bool,
+    pub is_head_aligned: bool,
+    pub is_tail_aligned: bool,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -89,6 +119,9 @@ pub struct NetworkTraceDetail {
     pub response_content_type: Option<String>,
     pub response_body: Option<String>,
     pub response_body_truncated: bool,
+    pub response_body_storage_truncated: bool,
+    pub response_body_stored_bytes: Option<u64>,
+    pub response_body_page_available: bool,
     pub response_body_bytes: Option<u64>,
     pub events: Vec<NetworkTraceEvent>,
 }
@@ -109,6 +142,42 @@ pub struct FireLogFileDetail {
     pub modified_at_unix_ms: u64,
     pub contents: String,
     pub is_truncated: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FireLogFilePage {
+    pub relative_path: String,
+    pub file_name: String,
+    pub size_bytes: u64,
+    pub modified_at_unix_ms: u64,
+    pub page: DiagnosticsTextPage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NetworkTraceBodyPage {
+    pub trace_id: u64,
+    pub response_content_type: Option<String>,
+    pub response_body_storage_truncated: bool,
+    pub response_body_stored_bytes: Option<u64>,
+    pub page: DiagnosticsTextPage,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FireSupportBundleHostContext {
+    pub platform: String,
+    pub app_version: Option<String>,
+    pub build_number: Option<String>,
+    pub scene_phase: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FireSupportBundleExport {
+    pub file_name: String,
+    pub relative_path: String,
+    pub absolute_path: String,
+    pub size_bytes: u64,
+    pub created_at_unix_ms: u64,
+    pub diagnostic_session_id: String,
 }
 
 #[derive(Debug, Clone)]
@@ -133,7 +202,7 @@ struct NetworkTraceRecord {
     response_headers: Vec<NetworkTraceHeader>,
     response_content_type: Option<String>,
     response_body: Option<String>,
-    response_body_truncated: bool,
+    response_body_storage_truncated: bool,
     response_body_bytes: Option<u64>,
     events: Vec<NetworkTraceEvent>,
 }
@@ -182,11 +251,25 @@ impl NetworkTraceRecord {
             status_code: self.status_code,
             error_message: self.error_message.clone(),
             response_content_type: self.response_content_type.clone(),
-            response_body_truncated: self.response_body_truncated,
+            response_body_truncated: self.response_body_storage_truncated,
         }
     }
 
     fn to_detail(&self) -> NetworkTraceDetail {
+        let response_body_page = self.response_body.as_deref().map(|body| {
+            paginate_text(
+                body,
+                None,
+                MAX_RESPONSE_BODY_INLINE_BYTES,
+                DiagnosticsPageDirection::Newer,
+            )
+        });
+        let response_body_page_available = response_body_page
+            .as_ref()
+            .is_some_and(|page| page.has_more_newer);
+        let response_body_truncated =
+            self.response_body_storage_truncated || response_body_page_available;
+
         NetworkTraceDetail {
             id: self.id,
             call_id: self.call_id,
@@ -202,8 +285,11 @@ impl NetworkTraceRecord {
             request_headers: self.request_headers.clone(),
             response_headers: self.response_headers.clone(),
             response_content_type: self.response_content_type.clone(),
-            response_body: self.response_body.clone(),
-            response_body_truncated: self.response_body_truncated,
+            response_body: response_body_page.as_ref().map(|page| page.text.clone()),
+            response_body_truncated,
+            response_body_storage_truncated: self.response_body_storage_truncated,
+            response_body_stored_bytes: self.response_body.as_ref().map(|body| body.len() as u64),
+            response_body_page_available,
             response_body_bytes: self.response_body_bytes,
             events: self.events.clone(),
         }
@@ -217,6 +303,7 @@ struct FireDiagnosticsState {
 }
 
 pub(crate) struct FireDiagnosticsStore {
+    diagnostic_session_id: String,
     next_trace_id: AtomicU64,
     inner: Mutex<FireDiagnosticsState>,
 }
@@ -264,9 +351,14 @@ impl Default for FireDiagnosticsStore {
 impl FireDiagnosticsStore {
     pub(crate) fn new() -> Self {
         Self {
+            diagnostic_session_id: new_diagnostic_session_id(),
             next_trace_id: AtomicU64::new(1),
             inner: Mutex::new(FireDiagnosticsState::default()),
         }
+    }
+
+    pub(crate) fn diagnostic_session_id(&self) -> &str {
+        &self.diagnostic_session_id
     }
 
     pub(crate) fn prepare_request_trace(
@@ -290,7 +382,7 @@ impl FireDiagnosticsStore {
             response_headers: Vec::new(),
             response_content_type: None,
             response_body: None,
-            response_body_truncated: false,
+            response_body_storage_truncated: false,
             response_body_bytes: None,
             events: Vec::new(),
         };
@@ -329,6 +421,31 @@ impl FireDiagnosticsStore {
             .traces
             .get(&trace_id)
             .map(NetworkTraceRecord::to_detail)
+    }
+
+    pub(crate) fn network_trace_body_page(
+        &self,
+        trace_id: u64,
+        cursor: Option<u64>,
+        max_bytes: usize,
+        direction: DiagnosticsPageDirection,
+    ) -> Option<NetworkTraceBodyPage> {
+        let state = self.inner.lock().expect("diagnostics store poisoned");
+        let trace = state.traces.get(&trace_id)?;
+        let body = trace.response_body.as_deref()?;
+        let page = paginate_text(
+            body,
+            cursor,
+            normalized_page_bytes(max_bytes, DEFAULT_TRACE_BODY_PAGE_BYTES),
+            direction,
+        );
+        Some(NetworkTraceBodyPage {
+            trace_id,
+            response_content_type: trace.response_content_type.clone(),
+            response_body_storage_truncated: trace.response_body_storage_truncated,
+            response_body_stored_bytes: Some(body.len() as u64),
+            page,
+        })
     }
 
     pub(crate) fn cancellation_guard(
@@ -450,9 +567,9 @@ impl FireDiagnosticsStore {
         response_content_type: Option<&str>,
     ) {
         self.with_trace(trace_id, |trace| {
-            let (stored, truncated) = truncate_text(body, MAX_RESPONSE_BODY_BYTES);
+            let (stored, truncated) = truncate_text_prefix(body, MAX_RESPONSE_BODY_BYTES);
             trace.response_body = Some(stored);
-            trace.response_body_truncated = truncated;
+            trace.response_body_storage_truncated = truncated;
             if let Some(content_type) = response_content_type {
                 trace.response_content_type = Some(content_type.to_string());
             }
@@ -478,9 +595,9 @@ impl FireDiagnosticsStore {
             trace.status_code = Some(status);
             trace.error_message = Some(format!("HTTP {status}"));
             trace.finished_at_unix_ms = Some(now_unix_ms());
-            let (stored, truncated) = truncate_text(body, MAX_RESPONSE_BODY_BYTES);
+            let (stored, truncated) = truncate_text_prefix(body, MAX_RESPONSE_BODY_BYTES);
             trace.response_body = Some(stored);
-            trace.response_body_truncated = truncated;
+            trace.response_body_storage_truncated = truncated;
             trace.push_event(
                 "http_error",
                 format!("Request failed with HTTP {status}"),
@@ -1093,6 +1210,144 @@ pub(crate) fn read_log_file(
     })
 }
 
+pub(crate) fn read_log_file_page(
+    workspace_path: &Path,
+    relative_path: impl AsRef<Path>,
+    cursor: Option<u64>,
+    max_bytes: usize,
+    direction: DiagnosticsPageDirection,
+) -> Result<FireLogFilePage, FireCoreError> {
+    let relative_path = relative_path.as_ref();
+    validate_workspace_relative_path(relative_path)?;
+
+    let resolved_path = workspace_path.join(relative_path);
+    let metadata = fs::metadata(&resolved_path).map_err(|source| FireCoreError::WorkspaceIo {
+        path: resolved_path.clone(),
+        source,
+    })?;
+    let bytes = fs::read(&resolved_path).map_err(|source| FireCoreError::WorkspaceIo {
+        path: resolved_path.clone(),
+        source,
+    })?;
+    let decoded = decode_log_file_contents(&resolved_path, &bytes);
+    let page = paginate_log_text(
+        &decoded,
+        cursor,
+        normalized_page_bytes(max_bytes, DEFAULT_LOG_PAGE_BYTES),
+        direction,
+    );
+
+    Ok(FireLogFilePage {
+        relative_path: relative_path.to_string_lossy().to_string(),
+        file_name: resolved_path
+            .file_name()
+            .and_then(|value| value.to_str())
+            .unwrap_or_default()
+            .to_string(),
+        size_bytes: metadata.len(),
+        modified_at_unix_ms: metadata
+            .modified()
+            .ok()
+            .and_then(|value| value.duration_since(UNIX_EPOCH).ok())
+            .map(|value| value.as_millis().min(u64::MAX as u128) as u64)
+            .unwrap_or_default(),
+        page,
+    })
+}
+
+pub(crate) fn export_support_bundle(
+    workspace_path: &Path,
+    diagnostics: &FireDiagnosticsStore,
+    redacted_session_json: &str,
+    host_context: &FireSupportBundleHostContext,
+) -> Result<FireSupportBundleExport, FireCoreError> {
+    let generated_at_unix_ms = now_unix_ms();
+    let file_name = format!("fire-support-{generated_at_unix_ms}.json");
+    let relative_path = Path::new("diagnostics")
+        .join("support-bundles")
+        .join(&file_name);
+    let absolute_path = workspace_path.join(&relative_path);
+    let parent = absolute_path
+        .parent()
+        .expect("support bundle path should have a parent");
+    fs::create_dir_all(parent).map_err(|source| FireCoreError::DiagnosticsIo {
+        path: parent.to_path_buf(),
+        source,
+    })?;
+
+    let session: Value = serde_json::from_str(redacted_session_json)
+        .map_err(FireCoreError::DiagnosticsDeserialize)?;
+    let log_files = list_log_files(workspace_path)?;
+    let log_pages = log_files
+        .iter()
+        .take(SUPPORT_BUNDLE_LOG_FILE_LIMIT)
+        .map(|file| {
+            read_log_file_page(
+                workspace_path,
+                &file.relative_path,
+                None,
+                SUPPORT_BUNDLE_LOG_PAGE_BYTES,
+                DiagnosticsPageDirection::Older,
+            )
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+    let trace_summaries = diagnostics.summaries(SUPPORT_BUNDLE_TRACE_LIMIT);
+    let trace_payloads = trace_summaries
+        .iter()
+        .map(|summary| {
+            let detail = diagnostics.detail(summary.id).ok_or_else(|| {
+                FireCoreError::DiagnosticsTraceNotFound {
+                    trace_id: summary.id.to_string(),
+                }
+            })?;
+            let body_page = diagnostics.network_trace_body_page(
+                summary.id,
+                None,
+                SUPPORT_BUNDLE_TRACE_BODY_BYTES,
+                DiagnosticsPageDirection::Newer,
+            );
+            Ok(support_bundle_trace_json(&detail, body_page.as_ref()))
+        })
+        .collect::<Result<Vec<_>, FireCoreError>>()?;
+
+    let payload = json!({
+        "version": 1,
+        "generated_at_unix_ms": generated_at_unix_ms,
+        "diagnostic_session_id": diagnostics.diagnostic_session_id(),
+        "host": {
+            "platform": host_context.platform,
+            "app_version": host_context.app_version,
+            "build_number": host_context.build_number,
+            "scene_phase": host_context.scene_phase,
+        },
+        "session": session,
+        "logs": log_pages.iter().map(support_bundle_log_json).collect::<Vec<_>>(),
+        "network_traces": trace_payloads,
+    });
+
+    let contents =
+        serde_json::to_vec_pretty(&payload).map_err(FireCoreError::DiagnosticsSerialize)?;
+    write_atomic(&absolute_path, &contents).map_err(|source| FireCoreError::DiagnosticsIo {
+        path: absolute_path.clone(),
+        source,
+    })?;
+    let size_bytes = fs::metadata(&absolute_path)
+        .map_err(|source| FireCoreError::DiagnosticsIo {
+            path: absolute_path.clone(),
+            source,
+        })?
+        .len();
+
+    Ok(FireSupportBundleExport {
+        file_name,
+        relative_path: relative_path.to_string_lossy().to_string(),
+        absolute_path: absolute_path.display().to_string(),
+        size_bytes,
+        created_at_unix_ms: generated_at_unix_ms,
+        diagnostic_session_id: diagnostics.diagnostic_session_id().to_string(),
+    })
+}
+
 fn visit_log_files(
     workspace_path: &Path,
     dir: &Path,
@@ -1108,7 +1363,14 @@ fn visit_log_files(
         })?;
         let path = entry.path();
         if path.is_dir() {
+            if is_support_bundle_path(workspace_path, &path) {
+                continue;
+            }
             visit_log_files(workspace_path, &path, out)?;
+            continue;
+        }
+
+        if is_support_bundle_path(workspace_path, &path) {
             continue;
         }
 
@@ -1262,6 +1524,256 @@ fn decode_block_payload(header: &LogHeader, payload: &[u8]) -> Result<Vec<u8>, S
     }
 }
 
+fn paginate_log_text(
+    text: &str,
+    cursor: Option<u64>,
+    max_bytes: usize,
+    direction: DiagnosticsPageDirection,
+) -> DiagnosticsTextPage {
+    if text.is_empty() {
+        return paginate_text(text, cursor, max_bytes, direction);
+    }
+
+    let total_bytes = text.len();
+    let max_bytes = max_bytes.max(1);
+
+    let (start, end, next_cursor) = match direction {
+        DiagnosticsPageDirection::Older => {
+            let end = previous_char_boundary(text, cursor.unwrap_or(total_bytes as u64) as usize);
+            let raw_start = end.saturating_sub(max_bytes);
+            let start = if raw_start == 0 {
+                0
+            } else {
+                line_start_at_or_before(text, raw_start)
+            };
+            let next_cursor = (start > 0).then_some(start as u64);
+            (start, end, next_cursor)
+        }
+        DiagnosticsPageDirection::Newer => {
+            let start = next_char_boundary(text, cursor.unwrap_or(0) as usize);
+            let raw_end = start.saturating_add(max_bytes).min(total_bytes);
+            let end = if raw_end >= total_bytes {
+                total_bytes
+            } else {
+                line_end_at_or_after(text, raw_end)
+            };
+            let next_cursor = (end < total_bytes).then_some(end as u64);
+            (start, end, next_cursor)
+        }
+    };
+
+    DiagnosticsTextPage {
+        text: text[start..end].to_string(),
+        start_offset: start as u64,
+        end_offset: end as u64,
+        total_bytes: total_bytes as u64,
+        next_cursor,
+        has_more_older: start > 0,
+        has_more_newer: end < total_bytes,
+        is_head_aligned: start == 0,
+        is_tail_aligned: end == total_bytes,
+    }
+}
+
+fn paginate_text(
+    text: &str,
+    cursor: Option<u64>,
+    max_bytes: usize,
+    direction: DiagnosticsPageDirection,
+) -> DiagnosticsTextPage {
+    let total_bytes = text.len();
+    let max_bytes = max_bytes.max(1);
+
+    if text.is_empty() {
+        return DiagnosticsTextPage {
+            text: String::new(),
+            start_offset: 0,
+            end_offset: 0,
+            total_bytes: 0,
+            next_cursor: None,
+            has_more_older: false,
+            has_more_newer: false,
+            is_head_aligned: true,
+            is_tail_aligned: true,
+        };
+    }
+
+    let (start, end, next_cursor) = match direction {
+        DiagnosticsPageDirection::Older => {
+            let end = previous_char_boundary(text, cursor.unwrap_or(total_bytes as u64) as usize);
+            let mut start = next_char_boundary(text, end.saturating_sub(max_bytes));
+            if start == end && end > 0 {
+                start = previous_char_boundary(text, end.saturating_sub(1));
+            }
+            let next_cursor = (start > 0).then_some(start as u64);
+            (start, end, next_cursor)
+        }
+        DiagnosticsPageDirection::Newer => {
+            let start = next_char_boundary(text, cursor.unwrap_or(0) as usize);
+            let mut end = previous_char_boundary(text, start.saturating_add(max_bytes));
+            if end == start && start < total_bytes {
+                end = next_char_boundary(text, start.saturating_add(1));
+            }
+            let next_cursor = (end < total_bytes).then_some(end as u64);
+            (start, end, next_cursor)
+        }
+    };
+
+    DiagnosticsTextPage {
+        text: text[start..end].to_string(),
+        start_offset: start as u64,
+        end_offset: end as u64,
+        total_bytes: total_bytes as u64,
+        next_cursor,
+        has_more_older: start > 0,
+        has_more_newer: end < total_bytes,
+        is_head_aligned: start == 0,
+        is_tail_aligned: end == total_bytes,
+    }
+}
+
+fn line_start_at_or_before(text: &str, offset: usize) -> usize {
+    let offset = previous_char_boundary(text, offset);
+    match text[..offset].rfind('\n') {
+        Some(index) => index + 1,
+        None => 0,
+    }
+}
+
+fn line_end_at_or_after(text: &str, offset: usize) -> usize {
+    let offset = next_char_boundary(text, offset);
+    match text[offset..].find('\n') {
+        Some(index) => offset + index + 1,
+        None => text.len(),
+    }
+}
+
+fn previous_char_boundary(text: &str, offset: usize) -> usize {
+    let mut offset = offset.min(text.len());
+    while offset > 0 && !text.is_char_boundary(offset) {
+        offset -= 1;
+    }
+    offset
+}
+
+fn next_char_boundary(text: &str, offset: usize) -> usize {
+    let mut offset = offset.min(text.len());
+    while offset < text.len() && !text.is_char_boundary(offset) {
+        offset += 1;
+    }
+    offset
+}
+
+fn normalized_page_bytes(requested: usize, fallback: usize) -> usize {
+    match requested {
+        0 => fallback,
+        value => value,
+    }
+}
+
+fn is_support_bundle_path(workspace_path: &Path, path: &Path) -> bool {
+    let support_bundle_root = Path::new("diagnostics").join(SUPPORT_BUNDLE_DIR_NAME);
+    path.strip_prefix(workspace_path)
+        .ok()
+        .is_some_and(|relative_path| relative_path.starts_with(&support_bundle_root))
+}
+
+fn support_bundle_log_json(page: &FireLogFilePage) -> Value {
+    json!({
+        "relative_path": page.relative_path,
+        "file_name": page.file_name,
+        "size_bytes": page.size_bytes,
+        "modified_at_unix_ms": page.modified_at_unix_ms,
+        "window": diagnostics_text_page_json(&page.page),
+    })
+}
+
+fn support_bundle_trace_json(
+    detail: &NetworkTraceDetail,
+    body_page: Option<&NetworkTraceBodyPage>,
+) -> Value {
+    json!({
+        "summary": {
+            "id": detail.id,
+            "call_id": detail.call_id,
+            "operation": detail.operation,
+            "method": detail.method,
+            "url": detail.url,
+            "started_at_unix_ms": detail.started_at_unix_ms,
+            "finished_at_unix_ms": detail.finished_at_unix_ms,
+            "duration_ms": detail.duration_ms,
+            "outcome": support_bundle_trace_outcome(detail.outcome),
+            "status_code": detail.status_code,
+            "error_message": detail.error_message,
+            "response_content_type": detail.response_content_type,
+            "response_body_truncated": detail.response_body_truncated,
+            "response_body_storage_truncated": detail.response_body_storage_truncated,
+            "response_body_stored_bytes": detail.response_body_stored_bytes,
+            "response_body_page_available": detail.response_body_page_available,
+            "response_body_bytes": detail.response_body_bytes,
+        },
+        "request_headers": detail
+            .request_headers
+            .iter()
+            .map(support_bundle_header_json)
+            .collect::<Vec<_>>(),
+        "response_headers": detail
+            .response_headers
+            .iter()
+            .map(support_bundle_header_json)
+            .collect::<Vec<_>>(),
+        "events": detail.events.iter().map(support_bundle_event_json).collect::<Vec<_>>(),
+        "body_page": body_page.map(|page| {
+            json!({
+                "response_content_type": page.response_content_type,
+                "response_body_storage_truncated": page.response_body_storage_truncated,
+                "response_body_stored_bytes": page.response_body_stored_bytes,
+                "window": diagnostics_text_page_json(&page.page),
+            })
+        }),
+    })
+}
+
+fn diagnostics_text_page_json(page: &DiagnosticsTextPage) -> Value {
+    json!({
+        "text": page.text,
+        "start_offset": page.start_offset,
+        "end_offset": page.end_offset,
+        "total_bytes": page.total_bytes,
+        "next_cursor": page.next_cursor,
+        "has_more_older": page.has_more_older,
+        "has_more_newer": page.has_more_newer,
+        "is_head_aligned": page.is_head_aligned,
+        "is_tail_aligned": page.is_tail_aligned,
+    })
+}
+
+fn support_bundle_header_json(header: &NetworkTraceHeader) -> Value {
+    json!({
+        "name": header.name,
+        "value": header.value,
+    })
+}
+
+fn support_bundle_event_json(event: &NetworkTraceEvent) -> Value {
+    json!({
+        "sequence": event.sequence,
+        "timestamp_unix_ms": event.timestamp_unix_ms,
+        "phase": event.phase,
+        "summary": event.summary,
+        "details": event.details,
+    })
+}
+
+fn support_bundle_trace_outcome(outcome: NetworkTraceOutcome) -> &'static str {
+    match outcome {
+        NetworkTraceOutcome::InProgress => "in_progress",
+        NetworkTraceOutcome::Succeeded => "succeeded",
+        NetworkTraceOutcome::Failed => "failed",
+        NetworkTraceOutcome::Cancelled => "cancelled",
+    }
+}
+
 fn truncate_text(text: &str, max_bytes: usize) -> (String, bool) {
     if text.len() <= max_bytes {
         return (text.to_string(), false);
@@ -1277,6 +1789,19 @@ fn truncate_text(text: &str, max_bytes: usize) -> (String, bool) {
     (out, true)
 }
 
+fn truncate_text_prefix(text: &str, max_bytes: usize) -> (String, bool) {
+    if text.len() <= max_bytes {
+        return (text.to_string(), false);
+    }
+
+    let mut end = max_bytes;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+
+    (text[..end].to_string(), true)
+}
+
 fn now_unix_ms() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -1285,11 +1810,23 @@ fn now_unix_ms() -> u64 {
         })
 }
 
+fn new_diagnostic_session_id() -> String {
+    static NEXT_DIAGNOSTIC_SESSION: AtomicU64 = AtomicU64::new(1);
+    let counter = NEXT_DIAGNOSTIC_SESSION.fetch_add(1, Ordering::Relaxed);
+    format!("diag-{}-{counter}", now_unix_ms())
+}
+
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
+    use std::{env, fs, sync::Arc};
 
-    use super::{FireDiagnosticsStore, NetworkTraceOutcome, Request, RequestBody};
+    use serde_json::Value;
+
+    use super::{
+        export_support_bundle, read_log_file_page, DiagnosticsPageDirection, FireDiagnosticsStore,
+        FireSupportBundleHostContext, NetworkTraceOutcome, Request, RequestBody, Response,
+        ResponseBody,
+    };
 
     #[test]
     fn summaries_are_returned_in_reverse_creation_order() {
@@ -1331,10 +1868,26 @@ mod tests {
 
         let detail = store.detail(trace_id).expect("detail");
         assert!(detail.response_body_truncated);
-        assert!(detail
-            .response_body
-            .expect("body")
-            .ends_with("<... truncated ...>"));
+        assert!(detail.response_body_storage_truncated);
+        assert!(detail.response_body_page_available);
+        assert_eq!(
+            detail.response_body.expect("body").len(),
+            super::MAX_RESPONSE_BODY_INLINE_BYTES
+        );
+        assert_eq!(
+            detail.response_body_stored_bytes,
+            Some(super::MAX_RESPONSE_BODY_BYTES as u64)
+        );
+
+        let tail_page = store
+            .network_trace_body_page(trace_id, None, 512, DiagnosticsPageDirection::Older)
+            .expect("tail page");
+        assert!(tail_page.page.is_tail_aligned);
+        assert_eq!(
+            tail_page.response_body_stored_bytes,
+            Some(super::MAX_RESPONSE_BODY_BYTES as u64)
+        );
+        assert!(!tail_page.page.text.contains("<... truncated ...>"));
     }
 
     #[test]
@@ -1430,5 +1983,206 @@ mod tests {
         let detail = store.detail(trace_id).expect("detail");
         assert_eq!(detail.outcome, NetworkTraceOutcome::Cancelled);
         assert_eq!(detail.events.last().expect("event").phase, "cancelled");
+    }
+
+    #[test]
+    fn network_trace_detail_only_inlines_first_body_preview_page() {
+        let store = FireDiagnosticsStore::new();
+        let mut request = Request::builder()
+            .method("GET")
+            .uri("https://linux.do/latest.json")
+            .body(RequestBody::empty())
+            .expect("request");
+        let trace_id = store.prepare_request_trace("fetch", &mut request);
+        let body = "abcd".repeat((super::MAX_RESPONSE_BODY_INLINE_BYTES / 4) + 256);
+
+        store.record_response_body_text(trace_id, &body, Some("application/json"));
+
+        let detail = store.detail(trace_id).expect("detail");
+        let inline_preview = detail.response_body.expect("inline preview");
+        assert_eq!(inline_preview.len(), super::MAX_RESPONSE_BODY_INLINE_BYTES);
+        assert!(detail.response_body_page_available);
+        assert_eq!(
+            detail.response_body_stored_bytes,
+            Some(body.len().min(super::MAX_RESPONSE_BODY_BYTES) as u64)
+        );
+        assert!(!detail.response_body_storage_truncated);
+
+        let next_page = store
+            .network_trace_body_page(
+                trace_id,
+                Some(inline_preview.len() as u64),
+                super::MAX_RESPONSE_BODY_INLINE_BYTES,
+                DiagnosticsPageDirection::Newer,
+            )
+            .expect("body page");
+        assert_eq!(next_page.page.start_offset, inline_preview.len() as u64);
+        assert_eq!(
+            next_page.page.text,
+            body[inline_preview.len()..next_page.page.end_offset as usize]
+        );
+    }
+
+    #[test]
+    fn log_file_pages_default_to_tail_and_can_load_older_windows() {
+        let workspace_dir = temp_workspace_dir("diagnostics-log-page-tail");
+        let log_path = workspace_dir.join("diagnostics").join("tail.log");
+        fs::create_dir_all(log_path.parent().expect("parent")).expect("log dir");
+        fs::write(&log_path, "line-01\nline-02\nline-03\nline-04\nline-05\n").expect("log file");
+
+        let latest_page = read_log_file_page(
+            &workspace_dir,
+            "diagnostics/tail.log",
+            None,
+            14,
+            DiagnosticsPageDirection::Older,
+        )
+        .expect("latest page");
+
+        assert!(latest_page.page.is_tail_aligned);
+        assert!(latest_page.page.has_more_older);
+        assert_eq!(latest_page.page.text, "line-04\nline-05\n");
+
+        let older_page = read_log_file_page(
+            &workspace_dir,
+            "diagnostics/tail.log",
+            Some(latest_page.page.start_offset),
+            14,
+            DiagnosticsPageDirection::Older,
+        )
+        .expect("older page");
+
+        assert_eq!(older_page.page.text, "line-02\nline-03\n");
+        assert!(older_page.page.has_more_older);
+        assert!(older_page.page.has_more_newer);
+    }
+
+    #[test]
+    fn log_file_pages_respect_utf8_boundaries() {
+        let workspace_dir = temp_workspace_dir("diagnostics-log-page-utf8");
+        let log_path = workspace_dir.join("diagnostics").join("utf8.log");
+        fs::create_dir_all(log_path.parent().expect("parent")).expect("log dir");
+        fs::write(&log_path, "🙂🙂🙂").expect("log file");
+
+        let latest_page = read_log_file_page(
+            &workspace_dir,
+            "diagnostics/utf8.log",
+            None,
+            5,
+            DiagnosticsPageDirection::Older,
+        )
+        .expect("latest page");
+
+        assert_eq!(latest_page.page.text, "🙂🙂🙂");
+        assert_eq!(latest_page.page.text.chars().count(), 3);
+        assert!(latest_page.page.is_tail_aligned);
+    }
+
+    #[test]
+    fn support_bundle_export_contains_recent_windows_and_skips_bundle_dir() {
+        let workspace_dir = temp_workspace_dir("diagnostics-support-bundle");
+        let diagnostics_dir = workspace_dir.join("diagnostics");
+        let logs_dir = workspace_dir.join("logs");
+        fs::create_dir_all(&diagnostics_dir).expect("diagnostics dir");
+        fs::create_dir_all(&logs_dir).expect("logs dir");
+        fs::create_dir_all(diagnostics_dir.join(super::SUPPORT_BUNDLE_DIR_NAME))
+            .expect("support bundle dir");
+
+        fs::write(
+            diagnostics_dir.join("fire-readable.log"),
+            "line-01\nline-02\nline-03\nline-04\n",
+        )
+        .expect("readable log");
+        fs::write(
+            diagnostics_dir
+                .join(super::SUPPORT_BUNDLE_DIR_NAME)
+                .join("old-export.json"),
+            "{}",
+        )
+        .expect("old support bundle");
+
+        let store = FireDiagnosticsStore::new();
+        let mut request = Request::builder()
+            .method("GET")
+            .uri("https://linux.do/latest.json")
+            .header("cookie", "session=secret")
+            .body(RequestBody::empty())
+            .expect("request");
+        let trace_id = store.prepare_request_trace("fetch latest", &mut request);
+        store.record_request_headers_snapshot(trace_id, &request, 1);
+
+        let response = Response::builder()
+            .status(200)
+            .header("content-type", "application/json")
+            .header("set-cookie", "session=secret")
+            .body(ResponseBody::empty())
+            .expect("response");
+        store.record_response_headers(trace_id, &response);
+        store.record_response_body_text(trace_id, "{\"ok\":true}", Some("application/json"));
+
+        let export = export_support_bundle(
+            &workspace_dir,
+            &store,
+            r#"{"cookies":{"forum_session":"<redacted>"}}"#,
+            &FireSupportBundleHostContext {
+                platform: "ios".to_string(),
+                app_version: Some("1.0".to_string()),
+                build_number: Some("100".to_string()),
+                scene_phase: Some("active".to_string()),
+            },
+        )
+        .expect("export support bundle");
+
+        assert!(export.absolute_path.ends_with(&export.relative_path));
+
+        let payload: Value =
+            serde_json::from_slice(&fs::read(&export.absolute_path).expect("support bundle file"))
+                .expect("support bundle json");
+
+        assert_eq!(payload["host"]["platform"], "ios");
+        assert_eq!(
+            payload["diagnostic_session_id"],
+            export.diagnostic_session_id
+        );
+        assert_eq!(
+            payload["logs"][0]["relative_path"],
+            Value::String("diagnostics/fire-readable.log".to_string())
+        );
+        let request_headers = payload["network_traces"][0]["request_headers"]
+            .as_array()
+            .expect("request headers");
+        let response_headers = payload["network_traces"][0]["response_headers"]
+            .as_array()
+            .expect("response headers");
+        assert_eq!(
+            request_headers
+                .iter()
+                .find(|header| header["name"] == "cookie")
+                .expect("cookie header")["value"],
+            super::REDACTED_HEADER_VALUE
+        );
+        assert_eq!(
+            response_headers
+                .iter()
+                .find(|header| header["name"] == "set-cookie")
+                .expect("set-cookie header")["value"],
+            super::REDACTED_HEADER_VALUE
+        );
+
+        let listed_logs = super::list_log_files(&workspace_dir).expect("list logs");
+        assert!(listed_logs.iter().all(|file| {
+            !file
+                .relative_path
+                .starts_with("diagnostics/support-bundles/")
+        }));
+    }
+
+    fn temp_workspace_dir(name: &str) -> std::path::PathBuf {
+        let mut path = env::temp_dir();
+        path.push(format!("fire-diagnostics-tests-{}", std::process::id()));
+        path.push(name);
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("temp workspace dir");
+        path
     }
 }

--- a/rust/crates/fire-core/src/diagnostics.rs
+++ b/rust/crates/fire-core/src/diagnostics.rs
@@ -1192,7 +1192,7 @@ pub(crate) fn read_log_file(
     let (contents, is_truncated) = truncate_text(&decoded, MAX_LOG_CONTENT_BYTES);
 
     Ok(FireLogFileDetail {
-        relative_path: relative_path.to_string_lossy().to_string(),
+        relative_path: workspace_relative_path_string(relative_path),
         file_name: resolved_path
             .file_name()
             .and_then(|value| value.to_str())
@@ -1238,7 +1238,7 @@ pub(crate) fn read_log_file_page(
     );
 
     Ok(FireLogFilePage {
-        relative_path: relative_path.to_string_lossy().to_string(),
+        relative_path: workspace_relative_path_string(relative_path),
         file_name: resolved_path
             .file_name()
             .and_then(|value| value.to_str())
@@ -1340,7 +1340,7 @@ pub(crate) fn export_support_bundle(
 
     Ok(FireSupportBundleExport {
         file_name,
-        relative_path: relative_path.to_string_lossy().to_string(),
+        relative_path: workspace_relative_path_string(&relative_path),
         absolute_path: absolute_path.display().to_string(),
         size_bytes,
         created_at_unix_ms: generated_at_unix_ms,
@@ -1381,8 +1381,8 @@ fn visit_log_files(
                 source,
             })?;
         let relative_path = path.strip_prefix(workspace_path).map_or_else(
-            |_| path.to_string_lossy().to_string(),
-            |value| value.to_string_lossy().to_string(),
+            |_| workspace_relative_path_string(&path),
+            workspace_relative_path_string,
         );
 
         out.push(FireLogFileSummary {
@@ -1678,6 +1678,16 @@ fn is_support_bundle_path(workspace_path: &Path, path: &Path) -> bool {
         .is_some_and(|relative_path| relative_path.starts_with(&support_bundle_root))
 }
 
+fn workspace_relative_path_string(path: &Path) -> String {
+    path.iter()
+        .filter_map(|component| {
+            let component = component.to_string_lossy();
+            (!component.is_empty() && component != ".").then(|| component.into_owned())
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 fn support_bundle_log_json(page: &FireLogFilePage) -> Value {
     json!({
         "relative_path": page.relative_path,
@@ -1818,7 +1828,7 @@ fn new_diagnostic_session_id() -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::{env, fs, sync::Arc};
+    use std::{env, fs, path::Path, sync::Arc};
 
     use serde_json::Value;
 
@@ -2133,7 +2143,13 @@ mod tests {
         )
         .expect("export support bundle");
 
-        assert!(export.absolute_path.ends_with(&export.relative_path));
+        assert_eq!(
+            Path::new(&export.absolute_path),
+            workspace_dir.join(Path::new(&export.relative_path))
+        );
+        assert!(export
+            .relative_path
+            .starts_with("diagnostics/support-bundles/"));
 
         let payload: Value =
             serde_json::from_slice(&fs::read(&export.absolute_path).expect("support bundle file"))
@@ -2170,6 +2186,7 @@ mod tests {
         );
 
         let listed_logs = super::list_log_files(&workspace_dir).expect("list logs");
+        assert_eq!(listed_logs[0].relative_path, "diagnostics/fire-readable.log");
         assert!(listed_logs.iter().all(|file| {
             !file
                 .relative_path

--- a/rust/crates/fire-core/src/lib.rs
+++ b/rust/crates/fire-core/src/lib.rs
@@ -18,8 +18,10 @@ mod workspace;
 pub use config::FireCoreConfig;
 pub use core::FireCore;
 pub use diagnostics::{
-    FireLogFileDetail, FireLogFileSummary, NetworkTraceDetail, NetworkTraceEvent,
-    NetworkTraceHeader, NetworkTraceOutcome, NetworkTraceSummary,
+    DiagnosticsPageDirection, DiagnosticsTextPage, FireLogFileDetail, FireLogFilePage,
+    FireLogFileSummary, FireSupportBundleExport, FireSupportBundleHostContext,
+    NetworkTraceBodyPage, NetworkTraceDetail, NetworkTraceEvent, NetworkTraceHeader,
+    NetworkTraceOutcome, NetworkTraceSummary,
 };
 pub use error::FireCoreError;
 pub use logging::{FireHostLogLevel, FireLogger, FireLoggerConfig};

--- a/rust/crates/fire-core/src/logging.rs
+++ b/rust/crates/fire-core/src/logging.rs
@@ -19,6 +19,8 @@ const FIRE_LOG_CACHE_DIR_NAME: &str = "xlog";
 const FIRE_DIAGNOSTICS_DIR_NAME: &str = "diagnostics";
 const FIRE_READABLE_LOG_FILE_NAME: &str = "fire-readable.log";
 const FIRE_HOST_LOG_TARGET: &str = "fire.host";
+const FIRE_LOG_MAX_FILE_SIZE_BYTES: i64 = 8 * 1024 * 1024;
+const FIRE_LOG_MAX_ALIVE_SECONDS: i64 = 7 * 24 * 60 * 60;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FireHostLogLevel {
@@ -104,6 +106,8 @@ impl FireLoggerRuntime {
             name_prefix: FIRE_LOGGER_NAME_PREFIX.to_string(),
             level,
         })?;
+        logger.inner.set_max_file_size(FIRE_LOG_MAX_FILE_SIZE_BYTES);
+        logger.inner.set_max_alive_time(FIRE_LOG_MAX_ALIVE_SECONDS);
         logger.set_console_log_open(cfg!(debug_assertions));
         init_tracing(
             logger.inner.clone(),
@@ -173,25 +177,55 @@ fn level_filter_for(level: LogLevel) -> LevelFilter {
     }
 }
 
-pub fn log_host_message(level: FireHostLogLevel, target: &str, message: &str) {
+pub fn log_host_message(
+    level: FireHostLogLevel,
+    target: &str,
+    message: &str,
+    diagnostic_session_id: Option<&str>,
+) {
     let host_target = if target.trim().is_empty() {
         FIRE_LOGGER_NAME_PREFIX
     } else {
         target
     };
+    let diagnostic_session_id = diagnostic_session_id.unwrap_or("unknown");
 
     match level {
         FireHostLogLevel::Debug => {
-            tracing::debug!(target: FIRE_HOST_LOG_TARGET, host_target = host_target, "{}", message);
+            tracing::debug!(
+                target: FIRE_HOST_LOG_TARGET,
+                host_target = host_target,
+                diagnostic_session_id = diagnostic_session_id,
+                "{}",
+                message
+            );
         }
         FireHostLogLevel::Info => {
-            tracing::info!(target: FIRE_HOST_LOG_TARGET, host_target = host_target, "{}", message);
+            tracing::info!(
+                target: FIRE_HOST_LOG_TARGET,
+                host_target = host_target,
+                diagnostic_session_id = diagnostic_session_id,
+                "{}",
+                message
+            );
         }
         FireHostLogLevel::Warn => {
-            tracing::warn!(target: FIRE_HOST_LOG_TARGET, host_target = host_target, "{}", message);
+            tracing::warn!(
+                target: FIRE_HOST_LOG_TARGET,
+                host_target = host_target,
+                diagnostic_session_id = diagnostic_session_id,
+                "{}",
+                message
+            );
         }
         FireHostLogLevel::Error => {
-            tracing::error!(target: FIRE_HOST_LOG_TARGET, host_target = host_target, "{}", message);
+            tracing::error!(
+                target: FIRE_HOST_LOG_TARGET,
+                host_target = host_target,
+                diagnostic_session_id = diagnostic_session_id,
+                "{}",
+                message
+            );
         }
     }
 }

--- a/rust/crates/fire-uniffi/src/lib.rs
+++ b/rust/crates/fire-uniffi/src/lib.rs
@@ -12,9 +12,11 @@ use std::{
 use fire_core::{
     monogram_for_username as shared_monogram_for_username,
     plain_text_from_html as shared_plain_text_from_html,
-    preview_text_from_html as shared_preview_text_from_html, FireCore, FireCoreConfig,
-    FireCoreError, FireHostLogLevel, FireLogFileDetail, FireLogFileSummary, NetworkTraceDetail,
-    NetworkTraceEvent, NetworkTraceHeader, NetworkTraceOutcome, NetworkTraceSummary,
+    preview_text_from_html as shared_preview_text_from_html, DiagnosticsPageDirection,
+    DiagnosticsTextPage, FireCore, FireCoreConfig, FireCoreError, FireHostLogLevel,
+    FireLogFileDetail, FireLogFilePage, FireLogFileSummary, FireSupportBundleExport,
+    FireSupportBundleHostContext, NetworkTraceBodyPage, NetworkTraceDetail, NetworkTraceEvent,
+    NetworkTraceHeader, NetworkTraceOutcome, NetworkTraceSummary,
 };
 use fire_models::{
     Badge, BootstrapArtifacts, CookieSnapshot, GroupedSearchResult, LoginPhase, LoginSyncInput,
@@ -1810,6 +1812,71 @@ impl From<FireLogFileDetail> for LogFileDetailState {
 }
 
 #[derive(uniffi::Enum, Debug, Clone, Copy)]
+pub enum DiagnosticsPageDirectionState {
+    Older,
+    Newer,
+}
+
+impl From<DiagnosticsPageDirectionState> for DiagnosticsPageDirection {
+    fn from(value: DiagnosticsPageDirectionState) -> Self {
+        match value {
+            DiagnosticsPageDirectionState::Older => Self::Older,
+            DiagnosticsPageDirectionState::Newer => Self::Newer,
+        }
+    }
+}
+
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct DiagnosticsTextPageState {
+    pub text: String,
+    pub start_offset: u64,
+    pub end_offset: u64,
+    pub total_bytes: u64,
+    pub next_cursor: Option<u64>,
+    pub has_more_older: bool,
+    pub has_more_newer: bool,
+    pub is_head_aligned: bool,
+    pub is_tail_aligned: bool,
+}
+
+impl From<DiagnosticsTextPage> for DiagnosticsTextPageState {
+    fn from(value: DiagnosticsTextPage) -> Self {
+        Self {
+            text: value.text,
+            start_offset: value.start_offset,
+            end_offset: value.end_offset,
+            total_bytes: value.total_bytes,
+            next_cursor: value.next_cursor,
+            has_more_older: value.has_more_older,
+            has_more_newer: value.has_more_newer,
+            is_head_aligned: value.is_head_aligned,
+            is_tail_aligned: value.is_tail_aligned,
+        }
+    }
+}
+
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct LogFilePageState {
+    pub relative_path: String,
+    pub file_name: String,
+    pub size_bytes: u64,
+    pub modified_at_unix_ms: u64,
+    pub page: DiagnosticsTextPageState,
+}
+
+impl From<FireLogFilePage> for LogFilePageState {
+    fn from(value: FireLogFilePage) -> Self {
+        Self {
+            relative_path: value.relative_path,
+            file_name: value.file_name,
+            size_bytes: value.size_bytes,
+            modified_at_unix_ms: value.modified_at_unix_ms,
+            page: value.page.into(),
+        }
+    }
+}
+
+#[derive(uniffi::Enum, Debug, Clone, Copy)]
 pub enum HostLogLevelState {
     Debug,
     Info,
@@ -1927,6 +1994,9 @@ pub struct NetworkTraceDetailState {
     pub response_headers: Vec<NetworkTraceHeaderState>,
     pub response_body: Option<String>,
     pub response_body_truncated: bool,
+    pub response_body_storage_truncated: bool,
+    pub response_body_stored_bytes: Option<u64>,
+    pub response_body_page_available: bool,
     pub response_body_bytes: Option<u64>,
     pub events: Vec<NetworkTraceEventState>,
 }
@@ -1953,8 +2023,74 @@ impl From<NetworkTraceDetail> for NetworkTraceDetailState {
             response_headers: value.response_headers.into_iter().map(Into::into).collect(),
             response_body: value.response_body,
             response_body_truncated: value.response_body_truncated,
+            response_body_storage_truncated: value.response_body_storage_truncated,
+            response_body_stored_bytes: value.response_body_stored_bytes,
+            response_body_page_available: value.response_body_page_available,
             response_body_bytes: value.response_body_bytes,
             events: value.events.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct NetworkTraceBodyPageState {
+    pub trace_id: u64,
+    pub response_content_type: Option<String>,
+    pub response_body_storage_truncated: bool,
+    pub response_body_stored_bytes: Option<u64>,
+    pub page: DiagnosticsTextPageState,
+}
+
+impl From<NetworkTraceBodyPage> for NetworkTraceBodyPageState {
+    fn from(value: NetworkTraceBodyPage) -> Self {
+        Self {
+            trace_id: value.trace_id,
+            response_content_type: value.response_content_type,
+            response_body_storage_truncated: value.response_body_storage_truncated,
+            response_body_stored_bytes: value.response_body_stored_bytes,
+            page: value.page.into(),
+        }
+    }
+}
+
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct SupportBundleHostContextState {
+    pub platform: String,
+    pub app_version: Option<String>,
+    pub build_number: Option<String>,
+    pub scene_phase: Option<String>,
+}
+
+impl From<SupportBundleHostContextState> for FireSupportBundleHostContext {
+    fn from(value: SupportBundleHostContextState) -> Self {
+        Self {
+            platform: value.platform,
+            app_version: value.app_version,
+            build_number: value.build_number,
+            scene_phase: value.scene_phase,
+        }
+    }
+}
+
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct SupportBundleExportState {
+    pub file_name: String,
+    pub relative_path: String,
+    pub absolute_path: String,
+    pub size_bytes: u64,
+    pub created_at_unix_ms: u64,
+    pub diagnostic_session_id: String,
+}
+
+impl From<FireSupportBundleExport> for SupportBundleExportState {
+    fn from(value: FireSupportBundleExport) -> Self {
+        Self {
+            file_name: value.file_name,
+            relative_path: value.relative_path,
+            absolute_path: value.absolute_path,
+            size_bytes: value.size_bytes,
+            created_at_unix_ms: value.created_at_unix_ms,
+            diagnostic_session_id: value.diagnostic_session_id,
         }
     }
 }
@@ -2402,6 +2538,23 @@ impl FireCoreHandle {
         })
     }
 
+    pub fn diagnostic_session_id(&self) -> Result<String, FireUniFfiError> {
+        self.run_infallible("diagnostic_session_id", |inner| {
+            inner.diagnostic_session_id()
+        })
+    }
+
+    pub fn export_support_bundle(
+        &self,
+        host_context: SupportBundleHostContextState,
+    ) -> Result<SupportBundleExportState, FireUniFfiError> {
+        self.run_fallible("export_support_bundle", move |inner| {
+            inner
+                .export_support_bundle(host_context.into())
+                .map(Into::into)
+        })
+    }
+
     pub fn flush_logs(&self, sync: bool) -> Result<(), FireUniFfiError> {
         self.run_infallible("flush_logs", move |inner| inner.flush_logs(sync))
     }
@@ -2434,6 +2587,27 @@ impl FireCoreHandle {
         })
     }
 
+    pub fn read_log_file_page(
+        &self,
+        relative_path: String,
+        cursor: Option<u64>,
+        max_bytes: Option<u64>,
+        direction: DiagnosticsPageDirectionState,
+    ) -> Result<LogFilePageState, FireUniFfiError> {
+        self.run_fallible("read_log_file_page", move |inner| {
+            inner
+                .read_log_file_page(
+                    relative_path,
+                    cursor,
+                    max_bytes
+                        .and_then(|value| usize::try_from(value).ok())
+                        .unwrap_or_default(),
+                    direction.into(),
+                )
+                .map(Into::into)
+        })
+    }
+
     pub fn list_network_traces(
         &self,
         limit: u64,
@@ -2454,6 +2628,27 @@ impl FireCoreHandle {
     ) -> Result<Option<NetworkTraceDetailState>, FireUniFfiError> {
         self.run_infallible("network_trace_detail", move |inner| {
             inner.network_trace_detail(trace_id).map(Into::into)
+        })
+    }
+
+    pub fn network_trace_body_page(
+        &self,
+        trace_id: u64,
+        cursor: Option<u64>,
+        max_bytes: Option<u64>,
+        direction: DiagnosticsPageDirectionState,
+    ) -> Result<Option<NetworkTraceBodyPageState>, FireUniFfiError> {
+        self.run_infallible("network_trace_body_page", move |inner| {
+            inner
+                .network_trace_body_page(
+                    trace_id,
+                    cursor,
+                    max_bytes
+                        .and_then(|value| usize::try_from(value).ok())
+                        .unwrap_or_default(),
+                    direction.into(),
+                )
+                .map(Into::into)
         })
     }
 


### PR DESCRIPTION
## Summary
- add preview-first diagnostics APIs in Rust/UniFFI, including paged log reads, paged trace body reads, support bundle export, and diagnostic session metadata
- rebuild the iOS diagnostics surface around tail-first log viewing, preview-first response body viewing, support bundle export/share, and scene lifecycle log flushing
- keep Android compatible with the reshaped trace detail semantics and sync docs for the new support bundle workspace layout

## Testing
- cargo test -p fire-core diagnostics --lib
- cargo check -p fire-uniffi
- cargo test -p fire-uniffi --lib --no-run
- xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'generic/platform=iOS Simulator' build