### PR TITLE
Isolate iOS signing in local xcconfig overrides

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /rust/target/
 **/*.xcodeproj/xcuserdata/
 **/*.xcworkspace/xcuserdata/
+native/ios-app/Configs/Fire-Local-Debug.xcconfig
+native/ios-app/Configs/Fire-Local-Release.xcconfig

--- a/native/ios-app/Configs/Fire-Debug.xcconfig
+++ b/native/ios-app/Configs/Fire-Debug.xcconfig
@@ -1,0 +1,2 @@
+#include "Fire-Shared.xcconfig"
+#include? "Fire-Local-Debug.xcconfig"

--- a/native/ios-app/Configs/Fire-Local-Debug.example.xcconfig
+++ b/native/ios-app/Configs/Fire-Local-Debug.example.xcconfig
@@ -1,0 +1,3 @@
+// Copy to Fire-Local-Debug.xcconfig for ignored local device signing overrides.
+FIRE_DEVELOPMENT_TEAM = YOUR_DEVELOPMENT_TEAM_ID
+FIRE_PRODUCT_BUNDLE_IDENTIFIER = com.example.fire.dev

--- a/native/ios-app/Configs/Fire-Local-Release.example.xcconfig
+++ b/native/ios-app/Configs/Fire-Local-Release.example.xcconfig
@@ -1,0 +1,5 @@
+// Copy to Fire-Local-Release.xcconfig for ignored local archive/release signing overrides.
+FIRE_DEVELOPMENT_TEAM = YOUR_DEVELOPMENT_TEAM_ID
+// Optional: switch to Manual when you need explicit local archive signing.
+// FIRE_CODE_SIGN_STYLE = Manual
+// FIRE_PROVISIONING_PROFILE_SPECIFIER = Your Provisioning Profile Name

--- a/native/ios-app/Configs/Fire-Release.xcconfig
+++ b/native/ios-app/Configs/Fire-Release.xcconfig
@@ -1,0 +1,2 @@
+#include "Fire-Shared.xcconfig"
+#include? "Fire-Local-Release.xcconfig"

--- a/native/ios-app/Configs/Fire-Shared.xcconfig
+++ b/native/ios-app/Configs/Fire-Shared.xcconfig
@@ -1,0 +1,2 @@
+FIRE_CODE_SIGN_STYLE = Automatic
+FIRE_PRODUCT_BUNDLE_IDENTIFIER = com.fire.app.ios

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -67,6 +67,7 @@
 		08F96260D49AF4E41AB4739C /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		0C933069DE6C026030AAB6EF /* FireTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = FireTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		0D1C4D30FB92D47F801B64D4 /* FireTopicRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicRow.swift; sourceTree = "<group>"; };
+		0DB69FD096A581A18D9D16C5 /* Fire-Local-Release.example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Fire-Local-Release.example.xcconfig"; sourceTree = "<group>"; };
 		0F4A54860996435FDDF40EBE /* FireDiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDiagnosticsView.swift; sourceTree = "<group>"; };
 		27F174773C4A2B3D0A4D29DD /* FireComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireComponents.swift; sourceTree = "<group>"; };
 		292A9A11D19C39A02BC00B38 /* FireProfileActivityRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileActivityRow.swift; sourceTree = "<group>"; };
@@ -81,6 +82,7 @@
 		6210541C2E8219CE500CFC04 /* FireProfileStatsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileStatsRow.swift; sourceTree = "<group>"; };
 		6725F42C679E922AA3DD1FBF /* FireLoginWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireLoginWebView.swift; sourceTree = "<group>"; };
 		67647993BFF688FB02B71DBB /* FireTopicDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailView.swift; sourceTree = "<group>"; };
+		7337AE7EB0411AC9B53AD853 /* Fire-Local-Debug.example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Fire-Local-Debug.example.xcconfig"; sourceTree = "<group>"; };
 		859219285EC36B189AF68256 /* FireTopicListMessageBusRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicListMessageBusRefreshTests.swift; sourceTree = "<group>"; };
 		8675E5DED6CD306553C88CFE /* FireCategoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireCategoriesView.swift; sourceTree = "<group>"; };
 		8834ADE6E3ADB8A03391560C /* FireSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSessionStore.swift; sourceTree = "<group>"; };
@@ -88,9 +90,11 @@
 		8FFC5F5EA7CD05C23FBEB9A2 /* FireTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTheme.swift; sourceTree = "<group>"; };
 		9189433D7C9260885742A5BA /* FireTopicPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicPresentationTests.swift; sourceTree = "<group>"; };
 		92A16F4854521A901D87D1DD /* FireTagPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTagPickerSheet.swift; sourceTree = "<group>"; };
+		97B0FC401C941BC8F73B959A /* Fire-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Fire-Release.xcconfig"; sourceTree = "<group>"; };
 		996D95DE48DA65385BD587F7 /* FireApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireApp.swift; sourceTree = "<group>"; };
 		9AD6D7178B2622B10A5644E2 /* FireTopicTimingTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicTimingTracker.swift; sourceTree = "<group>"; };
 		9B970247E0258DD4D4F34101 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		A0AFFF5DCC989B801C9DF88E /* Fire-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Fire-Debug.xcconfig"; sourceTree = "<group>"; };
 		A14122231F5DBCCFFC5AD36C /* FireTopicPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicPresentation.swift; sourceTree = "<group>"; };
 		B5E5271F93B7DF18859B101F /* FireWebViewLoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWebViewLoginCoordinator.swift; sourceTree = "<group>"; };
 		BABD32407FB273553E9394B3 /* FireProfileBadgeChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileBadgeChip.swift; sourceTree = "<group>"; };
@@ -107,6 +111,7 @@
 		F02D3C136EFF0589DC131FB9 /* FireProfileTrustLevelPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileTrustLevelPill.swift; sourceTree = "<group>"; };
 		F5F3291447D7DA0AEF9AA413 /* SessionState+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionState+Helpers.swift"; sourceTree = "<group>"; };
 		F75C8AF749DA8EF7CB5E3A64 /* FireNotificationHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNotificationHistoryView.swift; sourceTree = "<group>"; };
+		FA8E7753E3E1BB8E3CD88E96 /* Fire-Shared.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Fire-Shared.xcconfig"; sourceTree = "<group>"; };
 		FD5A94769988E39B8BEA7B56 /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
@@ -199,6 +204,7 @@
 			isa = PBXGroup;
 			children = (
 				73EB36381D2DB9DA74378162 /* App */,
+				BD212BBA5E9DA62F41FF41F4 /* Configs */,
 				32338F9E71B0E67C5112C300 /* FireAppSession */,
 				B6732AD346DE25D47D208DE1 /* Generated */,
 				8FCD2C1B029D07F4C1B82746 /* Unit */,
@@ -213,6 +219,18 @@
 				588B3F8CFD76DF758BE3A242 /* fire_uniffi.swift */,
 			);
 			path = Generated;
+			sourceTree = "<group>";
+		};
+		BD212BBA5E9DA62F41FF41F4 /* Configs */ = {
+			isa = PBXGroup;
+			children = (
+				A0AFFF5DCC989B801C9DF88E /* Fire-Debug.xcconfig */,
+				7337AE7EB0411AC9B53AD853 /* Fire-Local-Debug.example.xcconfig */,
+				0DB69FD096A581A18D9D16C5 /* Fire-Local-Release.example.xcconfig */,
+				97B0FC401C941BC8F73B959A /* Fire-Release.xcconfig */,
+				FA8E7753E3E1BB8E3CD88E96 /* Fire-Shared.xcconfig */,
+			);
+			path = Configs;
 			sourceTree = "<group>";
 		};
 		D5EBFF4F5452417E0754E6D0 /* Frameworks */ = {
@@ -275,11 +293,9 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
-					3ACA300207EBD80A07FC30BD = {
-						ProvisioningStyle = Automatic;
-					};
 					87BF3D86E2CA36A3D645AA33 = {
-						ProvisioningStyle = Automatic;
+						DevelopmentTeam = "$(FIRE_DEVELOPMENT_TEAM)";
+						ProvisioningStyle = "$(FIRE_CODE_SIGN_STYLE)";
 					};
 				};
 			};
@@ -403,9 +419,12 @@
 /* Begin XCBuildConfiguration section */
 		011FC950603A8869D189F2BD /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = A0AFFF5DCC989B801C9DF88E /* Fire-Debug.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = "$(FIRE_CODE_SIGN_STYLE)";
+				DEVELOPMENT_TEAM = "$(FIRE_DEVELOPMENT_TEAM)";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = (
 					"com.fire.app.ios.notification-alert-refresh",
@@ -429,8 +448,9 @@
 					"$(inherited)",
 					"-lfire_uniffi",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.fire.app.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FIRE_PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = Fire;
+				PROVISIONING_PROFILE_SPECIFIER = "$(FIRE_PROVISIONING_PROFILE_SPECIFIER)";
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = (
 					"$(inherited)",
@@ -515,7 +535,6 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -578,7 +597,6 @@
 				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
-				CODE_SIGN_STYLE = Automatic;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
@@ -603,9 +621,12 @@
 		};
 		E900A14E059026239A5E3A91 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 97B0FC401C941BC8F73B959A /* Fire-Release.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
+				CODE_SIGN_STYLE = "$(FIRE_CODE_SIGN_STYLE)";
+				DEVELOPMENT_TEAM = "$(FIRE_DEVELOPMENT_TEAM)";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = (
 					"com.fire.app.ios.notification-alert-refresh",
@@ -629,8 +650,9 @@
 					"$(inherited)",
 					"-lfire_uniffi",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.fire.app.ios;
+				PRODUCT_BUNDLE_IDENTIFIER = "$(FIRE_PRODUCT_BUNDLE_IDENTIFIER)";
 				PRODUCT_NAME = Fire;
+				PROVISIONING_PROFILE_SPECIFIER = "$(FIRE_PROVISIONING_PROFILE_SPECIFIER)";
 				SDKROOT = iphoneos;
 				SWIFT_INCLUDE_PATHS = (
 					"$(inherited)",

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -100,9 +100,24 @@ Expected integration flow:
 Xcode project generation rules:
 
 - `native/ios-app/project.yml` is the source of truth for `Fire.xcodeproj`.
+- Signing now flows through `native/ios-app/Configs/Fire-*.xcconfig` so local developer-account overrides do not need to touch the generated project.
 - New Swift files placed under existing source roots such as `App/` or `Sources/FireAppSession/` do not require a `project.yml` edit, but they do require rerunning `xcodegen generate --spec native/ios-app/project.yml` and committing the regenerated `Fire.xcodeproj`.
 - Changes that introduce a new source/resource directory, framework dependency, build script, target, or Xcode build setting must update `project.yml` first, then regenerate `Fire.xcodeproj`.
 - CI regenerates `Fire.xcodeproj` from `project.yml` before building and now fails if the checked-in project differs from the generated result. This catches local project drift where source files exist on disk but the committed Xcode project was not regenerated.
+
+Local signing overrides:
+
+- Default signing values live in `native/ios-app/Configs/Fire-Shared.xcconfig`.
+- `Debug` loads `native/ios-app/Configs/Fire-Local-Debug.xcconfig` if it exists.
+- `Release` loads `native/ios-app/Configs/Fire-Local-Release.xcconfig` if it exists.
+- The two `Fire-Local-*.xcconfig` files are ignored by git; use the matching `.example.xcconfig` file as the template.
+- Recommended local-device setup:
+  1. Copy `native/ios-app/Configs/Fire-Local-Debug.example.xcconfig` to `native/ios-app/Configs/Fire-Local-Debug.xcconfig`.
+  2. Set `FIRE_DEVELOPMENT_TEAM` to your Apple Developer team ID.
+  3. If your personal/team signing requires a separate app id, set `FIRE_PRODUCT_BUNDLE_IDENTIFIER` to a local-only bundle identifier.
+  4. Run `xcodegen generate --spec native/ios-app/project.yml` after any `project.yml` or `Configs/` change.
+- If you need a local archive/export setup later, create `native/ios-app/Configs/Fire-Local-Release.xcconfig` from the example instead of editing Xcode Signing UI values in the generated project.
+- Avoid changing signing values directly inside Xcode's generated project settings for routine local work. Those edits dirty `Fire.xcodeproj/project.pbxproj` and will be overwritten the next time `xcodegen` runs.
 
 Workspace note:
 

--- a/native/ios-app/project.yml
+++ b/native/ios-app/project.yml
@@ -1,6 +1,8 @@
 name: Fire
 options:
   minimumXcodeGenVersion: 2.45.3
+fileGroups:
+  - Configs
 schemes:
   Fire:
     build:
@@ -17,12 +19,14 @@ schemes:
 settings:
   base:
     SWIFT_VERSION: "5.10"
-    CODE_SIGN_STYLE: Automatic
 targets:
   Fire:
     type: application
     platform: iOS
     deploymentTarget: "17.0"
+    configFiles:
+      Debug: Configs/Fire-Debug.xcconfig
+      Release: Configs/Fire-Release.xcconfig
     sources:
       - path: App
       - path: Sources/FireAppSession
@@ -36,7 +40,10 @@ targets:
       - sdk: libiconv.tbd
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.fire.app.ios
+        CODE_SIGN_STYLE: $(FIRE_CODE_SIGN_STYLE)
+        DEVELOPMENT_TEAM: $(FIRE_DEVELOPMENT_TEAM)
+        PRODUCT_BUNDLE_IDENTIFIER: $(FIRE_PRODUCT_BUNDLE_IDENTIFIER)
+        PROVISIONING_PROFILE_SPECIFIER: $(FIRE_PROVISIONING_PROFILE_SPECIFIER)
         PRODUCT_NAME: Fire
         TARGETED_DEVICE_FAMILY: "1,2"
         GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
## Summary
- move Fire iOS signing inputs to shared `xcconfig` files generated through XcodeGen
- add ignored local Debug/Release override entry points plus tracked example templates
- document the local signing workflow so developer-specific Team/bundle changes stop dirtying the generated project

## Verification
- `xcodegen generate --spec native/ios-app/project.yml`
- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -configuration Debug -destination 'generic/platform=iOS' -showBuildSettings`
- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -configuration Release -destination 'generic/platform=iOS' -showBuildSettings`

## Notes
- Full iOS build is currently blocked by an existing unrelated Rust compile error in `rust/crates/fire-core/src/core/network.rs` (`ClientBuilder::use_system_proxy` is missing from the current `openwire` version). This PR does not change that area.