### PR TITLE
Refactor iOS profile page layout

### DIFF
--- a/docs/architecture/profile-page-redesign.md
+++ b/docs/architecture/profile-page-redesign.md
@@ -4,6 +4,16 @@
 
 This redesign replaces the current `FireProfileView` diagnostic-oriented layout with a product-grade user profile. The existing session-info section and diagnostic actions move into a "developer tools" sub-page, preserving all current debug capabilities while removing them from the primary UX surface.
 
+## Current Implementation Snapshot
+
+The shipped iOS implementation now differs from the earliest proposal in a few important ways:
+
+- The main profile tab is a grouped `List`-based overview page, not a single long `ScrollView` with a decorative gradient banner.
+- Bookmarks moved above the activity feed so they remain visible without scrolling through long activity history.
+- The profile tab shows only a short recent-activity preview. Full activity browsing moved into a dedicated `FireProfileActivityTimelineView` screen with segmented filtering.
+- Developer tools and logout live behind the top-right gear menu instead of occupying permanent space at the bottom of the main profile page.
+- Pull-to-refresh now reloads both profile/summary data and the user-action feed via `FireProfileViewModel.refreshAll()`.
+
 ## Feasibility Assessment
 
 The Discourse backend already exposes all required data through well-documented endpoints: `GET /u/{username}.json` (identity, bio, trust level, flair, follow stats), `GET /u/{username}/summary.json` (activity stats, top topics/replies, badges), and `GET /user_actions.json` (activity feed). The Fluxdo Flutter reference client (`references/fluxdo/lib/models/user.dart`, `references/fluxdo/lib/pages/user_profile_page.dart`) proves these endpoints are stable and sufficient for a rich profile experience. The existing `FireTheme` design system provides a complete color palette and constant set. The Rust shared core (`fire-models`) currently lacks profile/badge types but adding them is straightforward serde work with no blockers.
@@ -12,7 +22,8 @@ Crate layering is clear: new API orchestration goes in `fire-core/src/core/users
 
 ## Current Surface Inventory
 
-- **`native/ios-app/App/FireProfileView.swift`** -- The sole "我的" tab view. Contains: error banner, user header (avatar+name+status dot), local topic-list stats (loaded topics, unread posts, solved), session info section (7 readiness indicators), actions section (diagnostics link, refresh bootstrap, restore session, logout/login).
+- **`native/ios-app/App/FireProfileView.swift`** -- The main "我的" overview page. Contains: error banner, profile identity header, social stats, bookmark shortcut, summary metric grid, badge preview, recent activity preview, and navigation into the full activity timeline.
+- **`native/ios-app/App/FireProfileActivityTimelineView.swift`** -- Dedicated full activity screen. Hosts segmented filters (全部/话题/回复/被赞), pagination, error banner handling, and navigation into topic detail.
 - **`native/ios-app/App/FireAppViewModel.swift`** -- Shared ViewModel. Exposes `session: SessionState`, `topicRows`, `errorMessage`, session lifecycle methods. `sessionStore: FireSessionStore?` and `sessionStoreValue()` are **private** (lines 152, 1956). No user-profile-specific API calls exist.
 - **`native/ios-app/Sources/FireAppSession/FireSessionStore.swift`** -- The `actor` wrapping `FireCoreHandle` that is the iOS-side Rust entry point (line 65). All Rust API calls from the app go through this actor. New profile API methods will be added here.
 - **`native/ios-app/App/SessionState+Helpers.swift`** -- Convenience extensions: `profileStatusTitle`, `profileDisplayName`, cookie mirroring.
@@ -37,35 +48,35 @@ Crate layering is clear: new API orchestration goes in `fire-core/src/core/users
    - Rejected alternative B: Making `sessionStore` public or injecting a shared `FireSessionStore` at `FireTabRoot` level. This would break the current ownership model where `FireAppViewModel` is the single session mediator.
    - Why: Adding narrow wrapper methods to `FireAppViewModel` (e.g. `fetchUserProfile`, `fetchUserSummary`, `fetchUserActions`) keeps the existing architecture intact while enabling the new ViewModel. The methods are thin: they resolve the session store, call the Rust method, and return the result.
 
-2. **Scrollable header with collapsible banner rather than `List` with `insetGrouped`.**
-   - Chosen: `ScrollView` with a custom header region (avatar, background, stats) followed by section cards in a `LazyVStack`.
-   - Rejected: Keeping `.listStyle(.insetGrouped)` with section rows.
-   - Why: A product profile page needs visual hierarchy: a hero header with the user's avatar, trust-level pill, bio snippet, and stats row, followed by content sections. `List` with grouped sections creates a settings-app aesthetic that doesn't convey identity or community engagement.
+2. **Grouped overview page rather than a decorative banner layout.**
+   - Chosen: A grouped `List` with a clean identity block, shortcut row, metric grid, badge preview, and recent-activity preview.
+   - Rejected: A long `ScrollView` with a decorative banner or hero treatment above the avatar.
+   - Why: The GitHub Mobile-inspired direction values clarity over ornament. The grouped overview keeps the page flatter, denser, and easier to scan on both small and large phones.
 
 3. **Trust level as a prominent visual element.**
    - Chosen: A colored pill/badge next to the username showing the trust level with a Discourse-aligned label (e.g. "领导者" for TL4, "老手" for TL3, "成员" for TL2, "基本" for TL1, "新人" for TL0).
    - Rejected: Hiding trust level in a detail sub-page.
    - Why: Trust level is the primary progression indicator on LinuxDo and a key motivator for community engagement. Making it visible on the profile reinforces the gamification loop.
 
-4. **Session/debug info moves to a "Developer Tools" sub-page rather than being removed entirely.**
-   - Chosen: A "Developer Tools" entry at the bottom of profile, leading to a page that contains the current session section + diagnostics.
-   - Rejected: Removing session info entirely, or keeping it inline.
-   - Why: The debug info is valuable for development and support, but pollutes the user-facing profile. Moving it preserves capability while cleaning the UX.
+4. **Session/debug info moves behind the gear menu instead of living in the main scroll body.**
+   - Chosen: The top-right gear menu surfaces "Developer Tools" and logout actions while the main profile body remains user-facing.
+   - Rejected: Removing session info entirely, or keeping it as a persistent bottom section in the main profile page.
+   - Why: The debug info is valuable for development and support, but it should not compete with bookmarks, badges, or activity on the primary page.
 
 5. **Phased data loading: bootstrap-local first, then network fetch.**
    - Chosen: On initial render, show what we already know from `SessionState` (username, user ID) in the header immediately, then fetch `/u/{username}.json` and `/u/{username}/summary.json` concurrently for full profile data. No offline cache is introduced in this phase; if the network fetch fails, the page shows the bootstrap-derived header with an error banner and a retry action.
    - Rejected: Blocking the whole page on network fetch.
    - Why: The profile tab is a frequent navigation target. Showing the cached identity immediately with a shimmer placeholder for stats/badges provides a responsive feel.
 
-6. **Badges displayed as a horizontal scrollable chip row, not a grid.**
-   - Chosen: A horizontally scrolling row of badge chips (icon + name) below stats. Tapping a badge chip is a no-op in v1 (future: badge detail page). "View All" link is a no-op in v1 (future: full badge list page).
-   - Rejected: A full grid on the profile page.
-   - Why: Most users earn 5-15 badges; a horizontal scroll is compact and invites exploration without dominating the page.
+6. **Badges displayed as a wrapped preview section, not a horizontal strip.**
+   - Chosen: A wrapped `FlowLayout` preview showing the first several badges plus a compact overflow count.
+   - Rejected: A long horizontal strip that competes with the activity preview for vertical space.
+   - Why: The overview page should stay scannable. Wrapping a bounded badge preview keeps recognition high without forcing horizontal exploration.
 
-7. **Activity sections via segmented tabs within the profile page.**
-   - Chosen: A tabbed content area (All Activity / Topics / Replies / Liked) within the profile scroll view, matching Fluxdo's 6-tab approach but scoped to 4 tabs for v1.
-   - Rejected: Separate navigation destinations for each activity type.
-   - Why: Users expect to browse their activity inline without deep navigation. Tabs keep context while organizing dense content.
+7. **Activity separated into preview + dedicated timeline screen.**
+   - Chosen: The main profile page shows only a short recent-activity preview, while `FireProfileActivityTimelineView` owns full filtering and pagination.
+   - Rejected: Embedding the entire segmented activity timeline directly in the main profile page.
+   - Why: Long activity lists were burying bookmarks and account actions. Splitting the experience restores first-screen clarity while still preserving full activity browsing.
 
 8. **API response envelope parsing with dedicated raw types, not direct serde into shared models.**
    - Chosen: Each endpoint gets a raw/envelope parser in `fire-core/src/user_payloads.rs` that unwraps the response structure (e.g. `data["user"]` for `/u/{username}.json`, `data["user_summary"]` + top-level sideloads for `/summary.json`) before converting to `fire-models` types.
@@ -83,33 +94,27 @@ Crate layering is clear: new API orchestration goes in `fire-core/src/core/users
 +--------------------------------------------------+
 |  Nav Bar: "我的"                          [gear]  |
 +--------------------------------------------------+
+|  [Avatar]  Display Name   [TL3]                  |
+|            @username                              |
+|            short bio                              |
 |                                                    |
-|  [===== Gradient / Profile Background =====]       |
+|  粉丝 / 关注 / 获赞                                |
+|  加入时间 / 最近活跃 / 阅读时长 / 活跃分            |
 |                                                    |
-|       +--------+                                   |
-|       | Avatar |   Display Name                    |
-|       | 72x72  |   @username  [TL3 老手]           |
-|       +--------+                                   |
+|  [我的书签]                                        |
 |                                                    |
-|  "A short bio snippet goes here..."                |
+|  --- 概览 ---                                      |
+|  [话题] [帖子]                                    |
+|  [书签] [访问天数]                                 |
 |                                                    |
-|  +----------+----------+----------+----------+     |
-|  | 关注      | 粉丝     | 获赞     | 访问天数  |     |
-|  | 128       | 256      | 1.2K    | 365      |     |
-|  +----------+----------+----------+----------+     |
+|  --- 勋章 ---                                      |
+|  [Badge1] [Badge2] [Badge3] [还有 N 枚]            |
 |                                                    |
-|  --- 勋章 ---                      查看全部 >      |
-|  [Badge1] [Badge2] [Badge3] [Badge4] ...  ->       |
-|                                                    |
-|  [全部] [话题] [回复] [被赞]                         |
-|  +-------------------------------------------------+
-|  | Activity content based on selected tab          |
-|  +-------------------------------------------------+
-|                                                    |
-|  --- 设置与工具 ---                                 |
-|  [我的书签]              (v1: placeholder, no-op)   |
-|  [开发者工具]                                       |
-|  [退出登录]                                         |
+|  --- 最近动态 ---                                  |
+|  [Activity 1]                                      |
+|  [Activity 2]                                      |
+|  [Activity 3]                                      |
+|  [查看全部动态] -> dedicated timeline              |
 +--------------------------------------------------+
 ```
 
@@ -645,17 +650,15 @@ These methods are intentionally thin: they don't modify any `@Published` state o
 ### Phase 6: Redesign FireProfileView
 
 **File: `native/ios-app/App/FireProfileView.swift`** (rewrite)
-- Replace entire body with a `NavigationStack` containing a `ScrollView`.
-- **Profile Header**: gradient or themed background region at top. `FireAvatarView` at 72pt size using `profile.avatarTemplate`. `FireAvatarView` already handles `{size}` resolution and relative URLs (confirmed at `native/ios-app/App/FireComponents.swift:619`); no avatar component changes needed. Display name, `@username`, trust level pill using `FireProfileTrustLevelPill`.
-- **Bio snippet**: if `profile.bioCooked` exists, render a 2-line truncated plain text version with a "more" disclosure.
-- **Stats Row**: 4-column horizontal stat display: 关注 (total_following), 粉丝 (total_followers), 获赞 (likes_received from summary stats), 访问天数 (days_visited from summary stats). Use `FireTheme.accent` for values, `FireTheme.subtleInk` for labels.
-- **Badges Row**: horizontal `ScrollView(.horizontal)` of badge chips from `summary.badges`. Each chip: badge icon/image + name. Gold/Silver/Bronze tint based on `badge_type_id`. "查看全部 >" trailing button (no-op in v1).
-- **Activity Tabs**: `Picker` with `.segmented` style for 全部/话题/回复/被赞. Content below switches based on selection.
-- **Activity Tab Content**: `LazyVStack` of `UserActionState` items with infinite scroll (trigger `loadActions(reset: false)` near bottom).
-- **Settings Section**: at bottom of scroll, a grouped section with "我的书签" (disabled with "coming soon" label), "开发者工具" (NavigationLink to `FireDeveloperToolsView`), "退出登录" button.
-- **Error handling**: `FireErrorBanner` at top of scroll if error exists, plus retry button.
-- **Loading states**: shimmer/placeholder views while `isLoadingProfile` is true.
-- Toolbar `.navigationBarTrailing`: gear icon (no-op in v1).
+- Replace the body with a `NavigationStack` containing a grouped `List`.
+- **Profile Header**: plain identity block with avatar, display name, `@username`, trust-level pill, bio, social stats, and compact metadata pills for joined date / last active / reading time / gamification score.
+- **Primary shortcut**: surface "我的书签" directly beneath the header so it is reachable without scrolling through activity history.
+- **Overview Section**: a 2x2 metric grid using `FireMetricTile` for 话题 / 帖子 / 书签 / 访问天数.
+- **Badges Preview**: wrapped `FlowLayout` preview of badges with an overflow-count pill.
+- **Recent Activity Preview**: only the first few action rows render on the main page. A trailing `NavigationLink` opens `FireProfileActivityTimelineView` for the complete activity history.
+- **Toolbar menu**: the top-right gear now opens developer tools and logout actions.
+- **Error handling**: `FireErrorBanner` remains at the top when profile or action requests fail.
+- **Refresh behavior**: pull-to-refresh calls `refreshAll()` so summary and activity stay in sync.
 
 **File: `native/ios-app/App/FireProfileTrustLevelPill.swift`** (new file)
 - A small SwiftUI component: rounded capsule with trust level label and color.
@@ -672,8 +675,12 @@ These methods are intentionally thin: they don't modify any `@Published` state o
 - Sized to content with `FireTheme.smallCornerRadius` rounding.
 
 **File: `native/ios-app/App/FireProfileActivityRow.swift`** (new file)
-- Renders a single `UserActionState`: action icon, title, excerpt snippet, relative time, category color dot.
-- Tappable to navigate to topic detail.
+- Renders a single `UserActionState`: action icon, event label, title, excerpt snippet, and relative time.
+- Used both in the overview-page preview and the dedicated full timeline screen.
+
+**File: `native/ios-app/App/FireProfileActivityTimelineView.swift`** (new file)
+- Hosts the full segmented activity experience.
+- Owns the segmented filter UI, infinite scroll pagination, and navigation into topic detail.
 
 ### Phase 7: Extract Developer Tools View
 
@@ -739,12 +746,13 @@ These methods are intentionally thin: they don't modify any `@Published` state o
 - `rust/crates/fire-uniffi/src/lib.rs` -- Add `UserProfileState`, `UserSummaryState`, `UserSummaryStatsState`, `ProfileSummaryTopicState`, `ProfileSummaryReplyState`, `ProfileSummaryTopCategoryState`, `ProfileSummaryUserReferenceState`, `BadgeState`, `UserActionState` records, `From` impls, and `FireCoreHandle` methods
 - `native/ios-app/Sources/FireAppSession/FireSessionStore.swift` -- Add `fetchUserProfile`, `fetchUserSummary`, `fetchUserActions` public methods
 - `native/ios-app/App/FireAppViewModel.swift` -- Add three thin public wrapper methods for profile API calls (no changes to existing published state or lifecycle)
-- `native/ios-app/App/FireProfileView.swift` -- Full rewrite: scrollable profile with header, stats, badges, activity tabs, settings section
+- `native/ios-app/App/FireProfileView.swift` -- Full rewrite: grouped overview page with header, bookmark shortcut, metric grid, badge preview, and recent activity preview
 - `native/ios-app/App/FireProfileViewModel.swift` -- New file: dedicated profile ViewModel with profile/summary/actions state management, holds `FireAppViewModel` reference
 - `native/ios-app/App/FireProfileTrustLevelPill.swift` -- New file: trust level capsule badge component
 - `native/ios-app/App/FireProfileStatsRow.swift` -- New file: 4-column stats display component
 - `native/ios-app/App/FireProfileBadgeChip.swift` -- New file: single badge chip component with tier tinting
 - `native/ios-app/App/FireProfileActivityRow.swift` -- New file: user action list row component
+- `native/ios-app/App/FireProfileActivityTimelineView.swift` -- New file: dedicated full activity timeline screen
 - `native/ios-app/App/FireDeveloperToolsView.swift` -- New file: extracted session info and diagnostic actions from old profile view
 - `native/ios-app/App/FireTabRoot.swift` -- Instantiate `FireProfileViewModel`, pass to `FireProfileView`, trigger load on appear
 - `rust/crates/fire-core/src/session_store.rs` -- Unchanged (persistence helper only; API orchestration goes in `core/users.rs`)

--- a/native/ios-app/App/FireProfileActivityRow.swift
+++ b/native/ios-app/App/FireProfileActivityRow.swift
@@ -2,13 +2,12 @@ import SwiftUI
 
 struct FireProfileActivityRow: View {
     let action: UserActionState
-    let onTap: () -> Void
+    var showsChevron = false
 
     private var actionIcon: String {
         switch action.actionType {
-        case 1: return "heart.fill"
-        case 2: return "heart.fill"
-        case 4: return "text.bubble"
+        case 1, 2: return "heart.fill"
+        case 4: return "text.bubble.fill"
         case 5: return "arrowshape.turn.up.left.fill"
         default: return "doc.text"
         }
@@ -23,44 +22,88 @@ struct FireProfileActivityRow: View {
         }
     }
 
+    private var actionLabel: String {
+        switch action.actionType {
+        case 1, 2:
+            if let username = action.actingUsername, !username.isEmpty {
+                return "@\(username) 赞了你的内容"
+            }
+            return "收到了新的赞"
+        case 4:
+            return "发布了新话题"
+        case 5:
+            return "发表了新回复"
+        default:
+            return "最近动态"
+        }
+    }
+
+    private var timestampText: String? {
+        guard let createdAt = action.createdAt else {
+            return nil
+        }
+        return relativeTimeString(createdAt)
+    }
+
+    private var excerptText: String? {
+        guard let excerpt = action.excerpt, !excerpt.isEmpty else {
+            return nil
+        }
+        return plainTextFromHtml(rawHtml: excerpt)
+    }
+
     var body: some View {
-        Button(action: onTap) {
-            HStack(alignment: .top, spacing: 12) {
-                Image(systemName: actionIcon)
-                    .font(.subheadline)
-                    .foregroundStyle(actionIconColor)
-                    .frame(width: 24, height: 24)
-
-                VStack(alignment: .leading, spacing: 4) {
-                    if let title = action.title, !title.isEmpty {
-                        Text(title)
-                            .font(.subheadline.weight(.medium))
-                            .foregroundStyle(FireTheme.ink)
-                            .lineLimit(2)
-                            .multilineTextAlignment(.leading)
-                    }
-
-                    if let excerpt = action.excerpt, !excerpt.isEmpty {
-                        Text(plainTextFromHtml(rawHtml: excerpt))
-                            .font(.caption)
-                            .foregroundStyle(FireTheme.subtleInk)
-                            .lineLimit(2)
-                            .multilineTextAlignment(.leading)
-                    }
-
-                    if let createdAt = action.createdAt {
-                        Text(relativeTimeString(createdAt))
-                            .font(.caption2)
-                            .foregroundStyle(FireTheme.tertiaryInk)
-                    }
+        HStack(alignment: .top, spacing: 12) {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(actionIconColor.opacity(0.14))
+                .frame(width: 32, height: 32)
+                .overlay {
+                    Image(systemName: actionIcon)
+                        .font(.footnote.weight(.semibold))
+                        .foregroundStyle(actionIconColor)
                 }
 
-                Spacer(minLength: 0)
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(spacing: 8) {
+                    Text(actionLabel)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(actionIconColor)
+
+                    if let timestampText {
+                        Text(timestampText)
+                            .font(.caption)
+                            .foregroundStyle(FireTheme.tertiaryInk)
+                    }
+
+                    Spacer(minLength: 0)
+                }
+
+                if let title = action.title, !title.isEmpty {
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(FireTheme.ink)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                }
+
+                if let excerptText, !excerptText.isEmpty {
+                    Text(excerptText)
+                        .font(.footnote)
+                        .foregroundStyle(FireTheme.subtleInk)
+                        .lineLimit(3)
+                        .multilineTextAlignment(.leading)
+                }
             }
-            .padding(.vertical, 4)
-            .contentShape(Rectangle())
+
+            if showsChevron {
+                Image(systemName: "chevron.right")
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(FireTheme.tertiaryInk)
+                    .padding(.top, 2)
+            }
         }
-        .buttonStyle(.plain)
+        .padding(.vertical, 12)
+        .contentShape(Rectangle())
     }
 
     private func relativeTimeString(_ isoDate: String) -> String {

--- a/native/ios-app/App/FireProfileActivityTimelineView.swift
+++ b/native/ios-app/App/FireProfileActivityTimelineView.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+import UIKit
+
+struct FireProfileActivityTimelineView: View {
+    @ObservedObject var viewModel: FireAppViewModel
+    @ObservedObject var profileViewModel: FireProfileViewModel
+
+    var body: some View {
+        List {
+            if let errorMessage = profileViewModel.errorMessage ?? viewModel.errorMessage {
+                Section {
+                    FireErrorBanner(
+                        message: errorMessage,
+                        copied: false,
+                        onCopy: {
+                            UIPasteboard.general.string = errorMessage
+                        },
+                        onDismiss: {
+                            profileViewModel.errorMessage = nil
+                            viewModel.dismissError()
+                        }
+                    )
+                }
+            }
+
+            Section {
+                Picker(
+                    "动态筛选",
+                    selection: Binding(
+                        get: { profileViewModel.selectedTab },
+                        set: { profileViewModel.selectTab($0) }
+                    )
+                ) {
+                    ForEach(FireProfileViewModel.ProfileTab.allCases, id: \.self) { tab in
+                        Text(tab.title).tag(tab)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .padding(.vertical, 4)
+            }
+
+            Section {
+                if profileViewModel.actions.isEmpty, profileViewModel.isLoadingActions {
+                    HStack {
+                        Spacer()
+                        ProgressView()
+                            .padding(.vertical, 20)
+                        Spacer()
+                    }
+                } else if profileViewModel.actions.isEmpty {
+                    Text("暂无动态")
+                        .font(.subheadline)
+                        .foregroundStyle(FireTheme.tertiaryInk)
+                        .frame(maxWidth: .infinity, alignment: .center)
+                        .padding(.vertical, 24)
+                } else {
+                    ForEach(Array(profileViewModel.actions.enumerated()), id: \.offset) { index, action in
+                        activityRow(action)
+                            .onAppear {
+                                if index >= max(profileViewModel.actions.count - 3, 0) {
+                                    profileViewModel.loadActions(reset: false)
+                                }
+                            }
+                    }
+
+                    if profileViewModel.isLoadingActions {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                                .controlSize(.small)
+                                .padding(.vertical, 8)
+                            Spacer()
+                        }
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(FireTheme.canvasTop)
+        .navigationTitle("全部动态")
+        .navigationBarTitleDisplayMode(.inline)
+        .refreshable {
+            await profileViewModel.refreshAll()
+        }
+        .task {
+            if profileViewModel.actions.isEmpty && !profileViewModel.isLoadingActions {
+                profileViewModel.loadActions(reset: true)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func activityRow(_ action: UserActionState) -> some View {
+        if let row = topicRow(for: action) {
+            NavigationLink {
+                FireTopicDetailView(
+                    viewModel: viewModel,
+                    row: row,
+                    scrollToPostNumber: action.postNumber
+                )
+            } label: {
+                FireProfileActivityRow(action: action, showsChevron: true)
+            }
+            .buttonStyle(.plain)
+        } else {
+            FireProfileActivityRow(action: action)
+        }
+    }
+
+    private func topicRow(for action: UserActionState) -> FireTopicRowPresentation? {
+        guard let topicId = action.topicId else {
+            return nil
+        }
+
+        let resolvedSlug = {
+            let trimmed = action.slug?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return trimmed.isEmpty ? "topic-\(topicId)" : trimmed
+        }()
+
+        return .stub(
+            topicId: topicId,
+            title: action.title?.ifEmpty("话题 #\(topicId)") ?? "话题 #\(topicId)",
+            slug: resolvedSlug,
+            categoryId: action.categoryId
+        )
+    }
+}

--- a/native/ios-app/App/FireProfileStatsRow.swift
+++ b/native/ios-app/App/FireProfileStatsRow.swift
@@ -8,19 +8,20 @@ struct FireProfileStatsRow: View {
             ForEach(Array(items.enumerated()), id: \.offset) { index, item in
                 if index > 0 {
                     Divider()
-                        .frame(height: 30)
+                        .frame(height: 22)
                 }
                 VStack(spacing: 4) {
                     Text(item.value)
-                        .font(.title3.monospacedDigit().weight(.semibold))
+                        .font(.headline.monospacedDigit().weight(.semibold))
                         .foregroundStyle(FireTheme.ink)
+                        .contentTransition(.numericText())
                     Text(item.label)
-                        .font(.caption2)
+                        .font(.caption)
                         .foregroundStyle(FireTheme.subtleInk)
                 }
                 .frame(maxWidth: .infinity)
             }
         }
-        .padding(.vertical, 8)
+        .padding(.vertical, 6)
     }
 }

--- a/native/ios-app/App/FireProfileTrustLevelPill.swift
+++ b/native/ios-app/App/FireProfileTrustLevelPill.swift
@@ -28,9 +28,9 @@ struct FireProfileTrustLevelPill: View {
     var body: some View {
         Text(label)
             .font(.caption2.weight(.semibold))
-            .foregroundStyle(.white)
+            .foregroundStyle(color)
             .padding(.horizontal, 8)
-            .padding(.vertical, 3)
-            .background(color, in: Capsule())
+            .padding(.vertical, 4)
+            .background(color.opacity(0.14), in: Capsule())
     }
 }

--- a/native/ios-app/App/FireProfileView.swift
+++ b/native/ios-app/App/FireProfileView.swift
@@ -7,6 +7,10 @@ struct FireProfileView: View {
     @State private var copiedErrorMessage = false
     @State private var showLogoutConfirmation = false
     @State private var showComingSoonToast = false
+    @State private var showDeveloperTools = false
+
+    private static let badgePreviewLimit = 8
+    private static let recentActivityPreviewLimit = 3
 
     private var isLoggedIn: Bool {
         viewModel.session.readiness.canReadAuthenticatedApi
@@ -16,31 +20,183 @@ struct FireProfileView: View {
         viewModel.session.hasLoginSession || isLoggedIn
     }
 
+    private var displayUsername: String {
+        profileViewModel.currentUsername ?? viewModel.session.profileDisplayName
+    }
+
+    private var displayName: String {
+        let trimmedName = profileViewModel.profile?.name?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmedName.isEmpty ? displayUsername : trimmedName
+    }
+
+    private var bookmarkCount: UInt32 {
+        profileViewModel.summary?.stats.bookmarkCount ?? 0
+    }
+
+    private var bookmarkSubtitle: String {
+        if bookmarkCount > 0 {
+            return "已保存 \(formatNumber(bookmarkCount)) 条内容，后续会提供统一管理。"
+        }
+        return "把想回看的内容收进来，后续会统一管理。"
+    }
+
+    private var socialStats: [(value: String, label: String)] {
+        [
+            (formatNumber(profileViewModel.profile?.totalFollowers ?? 0), "粉丝"),
+            (formatNumber(profileViewModel.profile?.totalFollowing ?? 0), "关注"),
+            (formatNumber(profileViewModel.summary?.stats.likesReceived ?? 0), "获赞"),
+        ]
+    }
+
+    private var overviewMetrics: [(label: String, value: String)] {
+        let stats = profileViewModel.summary?.stats
+        return [
+            ("话题", formatNumber(stats?.topicCount ?? 0)),
+            ("帖子", formatNumber(stats?.postCount ?? 0)),
+            ("书签", formatNumber(stats?.bookmarkCount ?? 0)),
+            ("访问天数", formatNumber(stats?.daysVisited ?? 0)),
+        ]
+    }
+
+    private var recentActions: [UserActionState] {
+        Array(profileViewModel.actions.prefix(Self.recentActivityPreviewLimit))
+    }
+
+    private var recentActivityTitle: String {
+        profileViewModel.selectedTab == .all ? "最近动态" : "最近\(profileViewModel.selectedTab.title)"
+    }
+
+    private var pageBackground: Color {
+        Color(uiColor: .systemGroupedBackground)
+    }
+
     var body: some View {
         NavigationStack {
-            ScrollView {
-                VStack(spacing: 0) {
-                    if let errorMessage = profileViewModel.errorMessage ?? viewModel.errorMessage {
+            List {
+                if let errorMessage = profileViewModel.errorMessage ?? viewModel.errorMessage {
+                    Section {
                         errorBanner(message: errorMessage)
                     }
+                }
 
+                Section {
                     profileHeader
-                    statsRow
-                    badgesSection
-                    activitySection
-                    settingsSection
+                }
+                .listRowSeparator(.hidden)
+
+                Section {
+                    shortcutRow(
+                        icon: "bookmark.fill",
+                        tint: FireTheme.accent,
+                        title: "我的书签",
+                        subtitle: bookmarkSubtitle
+                    ) {
+                        showComingSoonToast = true
+                        Task { @MainActor in
+                            try? await Task.sleep(for: .seconds(1.5))
+                            showComingSoonToast = false
+                        }
+                    }
+                }
+
+                Section {
+                    overviewSection
+                } header: {
+                    Text("概览")
+                }
+
+                if let badges = profileViewModel.summary?.badges, !badges.isEmpty {
+                    Section {
+                        badgePreviewSection(badges)
+                    } header: {
+                        HStack {
+                            Text("勋章")
+                            Spacer()
+                            Text("\(badges.count) 枚")
+                                .font(.caption)
+                                .foregroundStyle(FireTheme.tertiaryInk)
+                        }
+                    }
+                }
+
+                Section {
+                    if recentActions.isEmpty, profileViewModel.isLoadingActions {
+                        HStack {
+                            Spacer()
+                            ProgressView()
+                                .padding(.vertical, 18)
+                            Spacer()
+                        }
+                    } else if recentActions.isEmpty {
+                        Text("还没有可展示的动态")
+                            .font(.subheadline)
+                            .foregroundStyle(FireTheme.tertiaryInk)
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.vertical, 18)
+                    } else {
+                        ForEach(Array(recentActions.enumerated()), id: \.offset) { _, action in
+                            activityRow(action)
+                        }
+                    }
+
+                    NavigationLink {
+                        FireProfileActivityTimelineView(
+                            viewModel: viewModel,
+                            profileViewModel: profileViewModel
+                        )
+                    } label: {
+                        HStack(spacing: 12) {
+                            Image(systemName: "clock.arrow.trianglehead.counterclockwise.rotate.90")
+                                .font(.subheadline.weight(.semibold))
+                                .foregroundStyle(FireTheme.accent)
+                                .frame(width: 24)
+
+                            Text("查看全部动态")
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(FireTheme.ink)
+                        }
+                        .padding(.vertical, 4)
+                    }
+                } header: {
+                    Text(recentActivityTitle)
                 }
             }
-            .refreshable {
-                await profileViewModel.refreshProfile()
-            }
-            .background(FireTheme.canvasTop)
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+            .background(pageBackground)
             .navigationTitle("我的")
+            .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Image(systemName: "gearshape")
-                        .foregroundStyle(FireTheme.subtleInk)
+                    Menu {
+                        Button {
+                            showDeveloperTools = true
+                        } label: {
+                            Label("开发者工具", systemImage: "wrench.and.screwdriver")
+                        }
+
+                        if canLogout {
+                            Button(role: .destructive) {
+                                showLogoutConfirmation = true
+                            } label: {
+                                Label(
+                                    viewModel.isLoggingOut ? "退出中…" : "退出登录",
+                                    systemImage: "rectangle.portrait.and.arrow.right"
+                                )
+                            }
+                            .disabled(viewModel.isLoggingOut)
+                        }
+                    } label: {
+                        Image(systemName: "gearshape")
+                            .foregroundStyle(FireTheme.subtleInk)
+                    }
                 }
+            }
+            .navigationDestination(isPresented: $showDeveloperTools) {
+                FireDeveloperToolsView(viewModel: viewModel)
+            }
+            .refreshable {
+                await profileViewModel.refreshAll()
             }
             .task(id: profileViewModel.currentUsername) {
                 profileViewModel.syncWithCurrentSession()
@@ -50,264 +206,201 @@ struct FireProfileView: View {
                     comingSoonToast
                 }
             }
+            .alert("确认退出", isPresented: $showLogoutConfirmation) {
+                Button("取消", role: .cancel) {}
+                Button("退出登录", role: .destructive) {
+                    viewModel.logout()
+                }
+            } message: {
+                Text("确定要退出当前账号吗？")
+            }
         }
     }
-
-    // MARK: - Profile Header
 
     private var profileHeader: some View {
-        VStack(spacing: 12) {
-            LinearGradient(
-                colors: [FireTheme.accent.opacity(0.3), FireTheme.canvasTop],
-                startPoint: .top,
-                endPoint: .bottom
-            )
-            .frame(height: 60)
-            .overlay(alignment: .bottom) {
-                headerContent
-                    .offset(y: 36)
-            }
-
-            Spacer()
-                .frame(height: 40)
-        }
-    }
-
-    private var headerContent: some View {
-        VStack(spacing: 8) {
-            FireAvatarView(
-                avatarTemplate: profileViewModel.profile?.avatarTemplate,
-                username: profileViewModel.currentUsername ?? viewModel.session.profileDisplayName,
-                size: 72
-            )
-
-            VStack(spacing: 4) {
-                if let name = profileViewModel.profile?.name, !name.isEmpty {
-                    Text(name)
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(FireTheme.ink)
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 16) {
+                FireAvatarView(
+                    avatarTemplate: profileViewModel.profile?.avatarTemplate,
+                    username: displayUsername,
+                    size: 84
+                )
+                .overlay {
+                    Circle()
+                        .strokeBorder(Color.white.opacity(0.7), lineWidth: 1)
                 }
 
-                HStack(spacing: 6) {
-                    Text("@\(profileViewModel.currentUsername ?? viewModel.session.profileDisplayName)")
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(alignment: .center, spacing: 8) {
+                        Text(displayName)
+                            .font(.title3.weight(.bold))
+                            .foregroundStyle(FireTheme.ink)
+                            .lineLimit(2)
+
+                        if let profile = profileViewModel.profile {
+                            FireProfileTrustLevelPill(trustLevel: profile.trustLevel)
+                        }
+                    }
+
+                    Text("@\(displayUsername)")
                         .font(.subheadline)
                         .foregroundStyle(FireTheme.subtleInk)
 
-                    if let profile = profileViewModel.profile {
-                        FireProfileTrustLevelPill(trustLevel: profile.trustLevel)
+                    if let bioCooked = profileViewModel.profile?.bioCooked, !bioCooked.isEmpty {
+                        Text(plainTextFromHtml(rawHtml: bioCooked))
+                            .font(.footnote)
+                            .foregroundStyle(FireTheme.subtleInk)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 }
+            }
 
-                if let bioCooked = profileViewModel.profile?.bioCooked, !bioCooked.isEmpty {
-                    Text(plainTextFromHtml(rawHtml: bioCooked))
-                        .font(.caption)
-                        .foregroundStyle(FireTheme.subtleInk)
-                        .lineLimit(2)
-                        .multilineTextAlignment(.center)
-                        .padding(.horizontal, 32)
-                        .padding(.top, 2)
+            FireProfileStatsRow(items: socialStats)
+
+            if hasProfileMeta {
+                FlowLayout(
+                    spacing: 8,
+                    fallbackWidth: max(UIScreen.main.bounds.width - 72, 220)
+                ) {
+                    if let joinedDateText {
+                        profileMetaPill(symbol: "calendar", text: "加入于 \(joinedDateText)")
+                    }
+                    if let lastSeenText {
+                        profileMetaPill(symbol: "clock", text: lastSeenText)
+                    }
+                    if let readTimeText {
+                        profileMetaPill(symbol: "book.closed", text: readTimeText)
+                    }
+                    if let gamificationText {
+                        profileMetaPill(symbol: "bolt.fill", text: gamificationText, tint: FireTheme.accent)
+                    }
                 }
             }
         }
+        .padding(.vertical, 4)
     }
 
-    // MARK: - Stats Row
-
-    private var statsRow: some View {
-        let following = profileViewModel.profile?.totalFollowing ?? 0
-        let followers = profileViewModel.profile?.totalFollowers ?? 0
-        let likes = profileViewModel.summary?.stats.likesReceived ?? 0
-        let daysVisited = profileViewModel.summary?.stats.daysVisited ?? 0
-
-        return FireProfileStatsRow(items: [
-            (value: formatNumber(UInt32(following)), label: "关注"),
-            (value: formatNumber(UInt32(followers)), label: "粉丝"),
-            (value: formatNumber(likes), label: "获赞"),
-            (value: formatNumber(daysVisited), label: "访问天数"),
-        ])
-        .padding(.horizontal, 16)
-        .padding(.top, 8)
+    private var overviewSection: some View {
+        LazyVGrid(
+            columns: [
+                GridItem(.flexible(), spacing: 12),
+                GridItem(.flexible(), spacing: 12),
+            ],
+            spacing: 12
+        ) {
+            ForEach(Array(overviewMetrics.enumerated()), id: \.offset) { _, item in
+                FireMetricTile(label: item.label, value: item.value)
+            }
+        }
+        .padding(.vertical, 4)
     }
 
-    // MARK: - Badges Section
+    private func badgePreviewSection(_ badges: [BadgeState]) -> some View {
+        FlowLayout(
+            spacing: 8,
+            fallbackWidth: max(UIScreen.main.bounds.width - 72, 220)
+        ) {
+            ForEach(Array(badges.prefix(Self.badgePreviewLimit)), id: \.id) { badge in
+                FireProfileBadgeChip(badge: badge)
+            }
+
+            if badges.count > Self.badgePreviewLimit {
+                Text("还有 \(badges.count - Self.badgePreviewLimit) 枚")
+                    .font(.caption.weight(.medium))
+                    .foregroundStyle(FireTheme.subtleInk)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 7)
+                    .background(FireTheme.softSurface, in: Capsule())
+            }
+        }
+        .padding(.vertical, 4)
+    }
 
     @ViewBuilder
-    private var badgesSection: some View {
-        if let badges = profileViewModel.summary?.badges, !badges.isEmpty {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack {
-                    Text("勋章")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(FireTheme.ink)
-                    Spacer()
-                    Text("查看全部 >")
-                        .font(.caption)
-                        .foregroundStyle(FireTheme.subtleInk)
-                }
-                .padding(.horizontal, 16)
-
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 8) {
-                        ForEach(badges, id: \.id) { badge in
-                            FireProfileBadgeChip(badge: badge)
-                        }
-                    }
-                    .padding(.horizontal, 16)
-                }
+    private func activityRow(_ action: UserActionState) -> some View {
+        if let row = topicRow(for: action) {
+            NavigationLink {
+                FireTopicDetailView(
+                    viewModel: viewModel,
+                    row: row,
+                    scrollToPostNumber: action.postNumber
+                )
+            } label: {
+                FireProfileActivityRow(action: action, showsChevron: true)
             }
-            .padding(.top, 16)
+            .buttonStyle(.plain)
+        } else {
+            FireProfileActivityRow(action: action)
         }
     }
 
-    // MARK: - Activity Section
-
-    private var activitySection: some View {
-        VStack(spacing: 0) {
-            Picker("Activity", selection: Binding(
-                get: { profileViewModel.selectedTab },
-                set: { profileViewModel.selectTab($0) }
-            )) {
-                ForEach(FireProfileViewModel.ProfileTab.allCases, id: \.self) { tab in
-                    Text(tab.title).tag(tab)
-                }
-            }
-            .pickerStyle(.segmented)
-            .padding(.horizontal, 16)
-            .padding(.top, 20)
-            .padding(.bottom, 8)
-
-            LazyVStack(spacing: 0) {
-                ForEach(Array(profileViewModel.actions.enumerated()), id: \.offset) { index, action in
-                    FireProfileActivityRow(action: action) {
-                    }
-                    .padding(.horizontal, 16)
-
-                    if index < profileViewModel.actions.count - 1 {
-                        Divider()
-                            .padding(.leading, 52)
-                    }
-
-                    if index == profileViewModel.actions.count - 3 {
-                        Color.clear
-                            .frame(height: 1)
-                            .onAppear {
-                                profileViewModel.loadActions(reset: false)
-                            }
-                    }
-                }
-
-                if profileViewModel.isLoadingActions {
-                    ProgressView()
-                        .padding(.vertical, 16)
-                }
-
-                if profileViewModel.actions.isEmpty && !profileViewModel.isLoadingActions && !profileViewModel.isLoadingProfile {
-                    Text("暂无动态")
-                        .font(.subheadline)
-                        .foregroundStyle(FireTheme.tertiaryInk)
-                        .padding(.vertical, 32)
-                }
-            }
+    private func topicRow(for action: UserActionState) -> FireTopicRowPresentation? {
+        guard let topicId = action.topicId else {
+            return nil
         }
+
+        let resolvedSlug = {
+            let trimmed = action.slug?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return trimmed.isEmpty ? "topic-\(topicId)" : trimmed
+        }()
+
+        return .stub(
+            topicId: topicId,
+            title: action.title?.ifEmpty("话题 #\(topicId)") ?? "话题 #\(topicId)",
+            slug: resolvedSlug,
+            categoryId: action.categoryId
+        )
     }
 
-    // MARK: - Settings Section
-
-    private var settingsSection: some View {
-        VStack(spacing: 0) {
-            Divider()
-                .padding(.top, 16)
-
-            VStack(spacing: 0) {
-                settingsRow(icon: "bookmark", title: "我的书签", showChevron: true) {
-                    showComingSoonToast = true
-                    Task { @MainActor in
-                        try? await Task.sleep(for: .seconds(1.5))
-                        showComingSoonToast = false
-                    }
-                }
-
-                Divider()
-                    .padding(.leading, 44)
-
-                NavigationLink {
-                    FireDeveloperToolsView(viewModel: viewModel)
-                } label: {
-                    settingsRowContent(icon: "wrench.and.screwdriver", title: "开发者工具", showChevron: true)
-                }
-                .buttonStyle(.plain)
-
-                Divider()
-                    .padding(.leading, 44)
-
-                if canLogout {
-                    settingsRow(
-                        icon: "rectangle.portrait.and.arrow.right",
-                        title: viewModel.isLoggingOut ? "退出中…" : "退出登录",
-                        isDestructive: true,
-                        showChevron: false
-                    ) {
-                        showLogoutConfirmation = true
-                    }
-                    .disabled(viewModel.isLoggingOut)
-                    .alert("确认退出", isPresented: $showLogoutConfirmation) {
-                        Button("取消", role: .cancel) {}
-                        Button("退出登录", role: .destructive) {
-                            viewModel.logout()
-                        }
-                    } message: {
-                        Text("确定要退出当前账号吗？")
-                    }
-                }
-            }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
-        }
-        .padding(.bottom, 32)
-    }
-
-    private func settingsRow(
+    private func shortcutRow(
         icon: String,
+        tint: Color,
         title: String,
-        isDestructive: Bool = false,
-        showChevron: Bool,
+        subtitle: String,
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            settingsRowContent(icon: icon, title: title, isDestructive: isDestructive, showChevron: showChevron)
-        }
-        .buttonStyle(.plain)
-    }
+            HStack(spacing: 12) {
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(tint.opacity(0.12))
+                    .frame(width: 36, height: 36)
+                    .overlay {
+                        Image(systemName: icon)
+                            .font(.footnote.weight(.semibold))
+                            .foregroundStyle(tint)
+                    }
 
-    private func settingsRowContent(
-        icon: String,
-        title: String,
-        isDestructive: Bool = false,
-        showChevron: Bool
-    ) -> some View {
-        HStack(spacing: 12) {
-            Image(systemName: icon)
-                .font(.subheadline)
-                .foregroundStyle(isDestructive ? .red : FireTheme.subtleInk)
-                .frame(width: 24)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(FireTheme.ink)
 
-            Text(title)
-                .font(.subheadline)
-                .foregroundStyle(isDestructive ? .red : FireTheme.ink)
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(FireTheme.subtleInk)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
 
-            Spacer()
+                Spacer(minLength: 12)
 
-            if showChevron {
                 Image(systemName: "chevron.right")
                     .font(.caption2.weight(.semibold))
                     .foregroundStyle(FireTheme.tertiaryInk)
             }
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
         }
-        .padding(.vertical, 12)
-        .contentShape(Rectangle())
+        .buttonStyle(.plain)
     }
 
-    // MARK: - Error Banner
+    private func profileMetaPill(symbol: String, text: String, tint: Color = FireTheme.subtleInk) -> some View {
+        Label(text, systemImage: symbol)
+            .font(.caption)
+            .foregroundStyle(tint)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(FireTheme.softSurface, in: Capsule())
+    }
 
     private func errorBanner(message: String) -> some View {
         FireErrorBanner(
@@ -326,11 +419,8 @@ struct FireProfileView: View {
                 viewModel.dismissError()
             }
         )
-        .padding(.horizontal, 16)
-        .padding(.top, 8)
+        .padding(.vertical, 2)
     }
-
-    // MARK: - Coming Soon Toast
 
     private var comingSoonToast: some View {
         VStack {
@@ -347,14 +437,101 @@ struct FireProfileView: View {
         .animation(.easeInOut(duration: 0.3), value: showComingSoonToast)
     }
 
-    // MARK: - Helpers
+    private var hasProfileMeta: Bool {
+        joinedDateText != nil || lastSeenText != nil || readTimeText != nil || gamificationText != nil
+    }
+
+    private var joinedDateText: String? {
+        formattedDate(profileViewModel.profile?.createdAt)
+    }
+
+    private var lastSeenText: String? {
+        guard let lastSeen = profileViewModel.profile?.lastSeenAt else {
+            return nil
+        }
+
+        return "最近活跃 \(relativeTimeString(lastSeen))"
+    }
+
+    private var readTimeText: String? {
+        let seconds = profileViewModel.summary?.stats.timeReadSeconds ?? 0
+        guard seconds > 0 else {
+            return nil
+        }
+
+        return "已阅读 \(formatReadTime(seconds))"
+    }
+
+    private var gamificationText: String? {
+        guard let score = profileViewModel.profile?.gamificationScore, score > 0 else {
+            return nil
+        }
+
+        return "\(formatNumber(score)) 活跃分"
+    }
 
     private func formatNumber(_ value: UInt32) -> String {
         if value >= 10000 {
             return String(format: "%.1fw", Double(value) / 10000.0)
-        } else if value >= 1000 {
+        }
+        if value >= 1000 {
             return String(format: "%.1fK", Double(value) / 1000.0)
         }
         return "\(value)"
+    }
+
+    private func formatReadTime(_ seconds: UInt64) -> String {
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+
+        if hours > 0 {
+            return minutes > 0 ? "\(hours) 小时 \(minutes) 分钟" : "\(hours) 小时"
+        }
+        if minutes > 0 {
+            return "\(minutes) 分钟"
+        }
+        return "不到 1 分钟"
+    }
+
+    private func formattedDate(_ isoDate: String?) -> String? {
+        guard let isoDate else {
+            return nil
+        }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let date: Date?
+        if let parsed = formatter.date(from: isoDate) {
+            date = parsed
+        } else {
+            formatter.formatOptions = [.withInternetDateTime]
+            date = formatter.date(from: isoDate)
+        }
+
+        guard let date else {
+            return nil
+        }
+
+        return DateFormatter.localizedString(from: date, dateStyle: .medium, timeStyle: .none)
+    }
+
+    private func relativeTimeString(_ isoDate: String) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+
+        let date: Date?
+        if let parsed = formatter.date(from: isoDate) {
+            date = parsed
+        } else {
+            formatter.formatOptions = [.withInternetDateTime]
+            date = formatter.date(from: isoDate)
+        }
+
+        guard let date else {
+            return isoDate
+        }
+
+        return RelativeDateTimeFormatter().localizedString(for: date, relativeTo: Date())
     }
 }

--- a/native/ios-app/App/FireProfileViewModel.swift
+++ b/native/ios-app/App/FireProfileViewModel.swift
@@ -168,7 +168,7 @@ final class FireProfileViewModel: ObservableObject {
         loadActions(reset: true)
     }
 
-    func refreshProfile() async {
+    func refreshAll() async {
         guard let username = normalizedCurrentUsername(), loadedUsername == username else { return }
 
         do {
@@ -179,6 +179,7 @@ final class FireProfileViewModel: ObservableObject {
             self.profile = fetchedProfile
             self.summary = fetchedSummary
             self.errorMessage = nil
+            loadActions(reset: true)
         } catch is CancellationError {
         } catch {
             self.errorMessage = error.localizedDescription

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		428170833590DCF14AEEA64C /* FireTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFC5F5EA7CD05C23FBEB9A2 /* FireTheme.swift */; };
 		48C404692D8F5FA7471852BF /* FireSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08AB12E53EB29136A0946A /* FireSearchView.swift */; };
 		5A95F9C29909968BF4B17AD7 /* FireAuthCookieKeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313FFDD8D569FA6D9B1C0E0 /* FireAuthCookieKeychainStore.swift */; };
+		5FA66113E53795C8DC6D0563 /* FireProfileActivityTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35E67F65FB748821001726D /* FireProfileActivityTimelineView.swift */; };
 		6A8BA8AACC4ED45E311894CE /* FireTopicDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67647993BFF688FB02B71DBB /* FireTopicDetailView.swift */; };
 		6A93EC6F3D79F51A9CB66A58 /* FireAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300B5894E4B597FC94E645D3 /* FireAppDelegate.swift */; };
 		72EF4FD238A8072A48B7948E /* FireTopicRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1C4D30FB92D47F801B64D4 /* FireTopicRow.swift */; };
@@ -99,6 +100,7 @@
 		C810E3D0B2CF415495A3D5C4 /* FireFilteredTopicListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireFilteredTopicListView.swift; sourceTree = "<group>"; };
 		CC6840B06FC02F67318B0991 /* FireSessionSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSessionSecurityTests.swift; sourceTree = "<group>"; };
 		CEBEB262C9A5B9B7348537B8 /* FireNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNavigationState.swift; sourceTree = "<group>"; };
+		D35E67F65FB748821001726D /* FireProfileActivityTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileActivityTimelineView.swift; sourceTree = "<group>"; };
 		DD9004CEFFCDDBE2E50D71B0 /* FireOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireOnboardingView.swift; sourceTree = "<group>"; };
 		E2A86A280EED500EF3126038 /* FireNotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNotificationsView.swift; sourceTree = "<group>"; };
 		E69013450F80AEC210D5512D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
@@ -165,6 +167,7 @@
 				E2A86A280EED500EF3126038 /* FireNotificationsView.swift */,
 				DD9004CEFFCDDBE2E50D71B0 /* FireOnboardingView.swift */,
 				292A9A11D19C39A02BC00B38 /* FireProfileActivityRow.swift */,
+				D35E67F65FB748821001726D /* FireProfileActivityTimelineView.swift */,
 				BABD32407FB273553E9394B3 /* FireProfileBadgeChip.swift */,
 				6210541C2E8219CE500CFC04 /* FireProfileStatsRow.swift */,
 				F02D3C136EFF0589DC131FB9 /* FireProfileTrustLevelPill.swift */,
@@ -369,6 +372,7 @@
 				9D5F82625F6960B6A6ED10B9 /* FireNotificationsView.swift in Sources */,
 				792980AB2D2B5BF56221DF47 /* FireOnboardingView.swift in Sources */,
 				8D3E53867C1B21D940FB765A /* FireProfileActivityRow.swift in Sources */,
+				5FA66113E53795C8DC6D0563 /* FireProfileActivityTimelineView.swift in Sources */,
 				E56F67E343C97A5F77A3068E /* FireProfileBadgeChip.swift in Sources */,
 				8F10E1B26BE2D5FC5F2D6C1B /* FireProfileStatsRow.swift in Sources */,
 				B21E0A6B519EA414B836E4BE /* FireProfileTrustLevelPill.swift in Sources */,


### PR DESCRIPTION
## Summary
- flatten the iOS profile tab into a cleaner overview page and remove the old decorative banner treatment
- move bookmarks into the main visible area and split full activity browsing into a dedicated timeline screen
- keep developer tools behind the gear menu, refresh profile + actions together, and sync the profile redesign doc

## Testing
- xcodegen generate --spec native/ios-app/project.yml
- xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'generic/platform=iOS Simulator' build