### PR TITLE
feat(ios): add beta apm runtime foundation

### DIFF
--- a/.github/workflows/ios-release-artifacts.yml
+++ b/.github/workflows/ios-release-artifacts.yml
@@ -1,0 +1,61 @@
+name: iOS Release Artifacts
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: "true"
+  RUST_TOOLCHAIN: 1.88.0
+
+jobs:
+  archive:
+    name: Archive iOS Release Artifacts
+    runs-on: macos-15
+
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install Rust toolchain and iOS targets
+        shell: bash
+        run: |
+          rustup toolchain install "${RUST_TOOLCHAIN}" --profile minimal
+          rustup default "${RUST_TOOLCHAIN}"
+          rustup target add aarch64-apple-ios aarch64-apple-ios-sim x86_64-apple-ios
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: rust-${{ runner.os }}-${{ env.RUST_TOOLCHAIN }}
+          workspaces: |
+            . -> rust/target
+
+      - name: Install XcodeGen
+        shell: bash
+        env:
+          HOMEBREW_NO_AUTO_UPDATE: "1"
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+        run: |
+          if command -v xcodegen >/dev/null 2>&1; then
+            xcodegen --version
+          else
+            brew install xcodegen
+          fi
+
+      - name: Generate archive and dSYM artifacts
+        shell: bash
+        env:
+          CODE_SIGNING_ALLOWED: "NO"
+          FIRE_GIT_SHA: ${{ github.sha }}
+          OUT_ROOT: ${{ github.workspace }}/artifacts/ios-release
+        run: ./scripts/ios/archive_release.sh
+
+      - name: Upload archive artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-release-artifacts
+          path: artifacts/ios-release
+          if-no-files-found: error

--- a/docs/architecture/fire-native-workspace.md
+++ b/docs/architecture/fire-native-workspace.md
@@ -46,6 +46,7 @@ fire/
   - WebView login
   - Cloudflare challenge completion
   - cookie extraction from platform stores
+  - crash capture and host-owned APM collection
   - native UI, files, media, notifications, keychain/keystore
 - Rust-owned:
   - session state
@@ -126,6 +127,7 @@ File ownership convention:
   - `diagnostics/support-bundles/` for locally exported diagnostics bundles
   - `cache/xlog/` for Xlog cache and mmap spill files
   - `session.json` for the persisted session snapshot triggered by the host shell
+- iOS now also owns `ios-apm/` under the same workspace root for beta crash/APM files. That directory is explicitly host-owned and must not be treated as shared Rust diagnostics state.
 - Debug builds may also mirror shared logs into the platform console for local development, but release builds keep shared logging file-only through Xlog/readable-log artifacts.
 - `session.json` remains host-triggered persistence under that workspace root.
 - iOS currently treats `session.json` as a full-fidelity development cache and stores the same-site browser cookie batch in Keychain, including expiry metadata and refreshed auth-cookie state observed by Rust.

--- a/docs/architecture/ios-apm-beta-foundation.md
+++ b/docs/architecture/ios-apm-beta-foundation.md
@@ -1,0 +1,48 @@
+# iOS Beta APM Foundation
+
+This document describes the iOS-only crash and APM runtime added for the beta phase.
+
+## Scope
+
+- Crash capture uses `PLCrashReporter` from the native host.
+- System metrics and delayed diagnostics use `MetricKit`.
+- SwiftUI route correlation, launch spans, topic/detail/reply/notification spans, and main-thread stall tracking stay on the iOS side.
+- Shared Rust diagnostics, logs, request traces, and MessageBus networking remain Rust-owned.
+
+## Runtime layout
+
+- Workspace root remains `Application Support/Fire`.
+- New iOS-owned APM data lives under `Application Support/Fire/ios-apm/`.
+- Current subdirectories:
+  - `events/` daily NDJSON event files
+  - `crashes/` raw `.plcrash` payloads
+  - `metrickit/` raw MetricKit JSON payloads
+  - `exports/` shareable `.firesupportbundle` directories
+  - `tmp/` PLCrashReporter temporary files
+  - `runtime-state.json` last durable route / scene / breadcrumb snapshot
+
+## Correlation model
+
+- Each host launch generates a `launch_id`.
+- When `FireSessionStore` becomes available, the iOS APM runtime fetches Rust `diagnostic_session_id` and records a `session_link` event.
+- Crash harvest on the next cold start uses the previous `runtime-state.json` to recover the last known route, scene phase, active spans, and breadcrumbs.
+- Host-owned APM files are not written back into Rust diagnostics directories.
+
+## Export and release workflow
+
+- Standard diagnostics export still comes from Rust via `export_support_bundle`.
+- Full iOS APM export creates a `.firesupportbundle` package containing:
+  - Rust support bundle copy, when available
+  - iOS APM events
+  - raw crash payloads
+  - raw MetricKit payloads
+  - APM manifest with build metadata
+- Release artifact generation is handled by `scripts/ios/archive_release.sh`.
+- CI/manual archive artifact generation is handled by `.github/workflows/ios-release-artifacts.yml`.
+- The archive script injects `FIRE_GIT_SHA`, archives the app, copies `dSYMs/`, and emits `build-metadata.json`.
+
+## Privacy rules
+
+- Crash, MetricKit, route, span, breadcrumb, and resource sample metadata are retained for beta diagnostics.
+- `Cookie`, `Set-Cookie`, `Authorization`, `X-CSRF-Token`, and Keychain contents are never persisted into iOS APM artifacts.
+- The iOS runtime may reference Rust trace summaries indirectly through the shared diagnostics surface later, but it does not duplicate shared request bodies.

--- a/native/ios-app/App/FireAppDelegate.swift
+++ b/native/ios-app/App/FireAppDelegate.swift
@@ -7,6 +7,7 @@ final class FireAppDelegate: NSObject, UIApplicationDelegate, UNUserNotification
         _ application: UIApplication,
         didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
     ) -> Bool {
+        FireAPMManager.shared.start()
         UNUserNotificationCenter.current().delegate = self
         FireBackgroundNotificationAlertScheduler.registerBackgroundTask()
         return true

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -179,6 +179,7 @@ final class FireAppViewModel: ObservableObject {
     private var searchTask: Task<Void, Never>?
     private var latestSearchRequestID: UInt64 = 0
     private var filterChangeRefreshTask: Task<Void, Never>?
+    private var topLevelAPMRoute = "session.onboarding"
 
     init(
         initialSession: SessionState = .placeholder(),
@@ -219,16 +220,18 @@ final class FireAppViewModel: ObservableObject {
             }
 
             do {
-                let sessionStore = try await self.sessionStoreValue()
-                guard self.initialStateLoadGeneration == generation else { return }
-                self.errorMessage = nil
-                let restoredSession = try await sessionStore.restoreColdStartSession()
-                guard self.initialStateLoadGeneration == generation else { return }
-                await self.applySession(restoredSession)
-                guard self.initialStateLoadGeneration == generation else { return }
-                await self.refreshTopicsIfPossible(force: true)
-                guard self.initialStateLoadGeneration == generation else { return }
-                await self.loadRecentNotifications(force: false)
+                try await FireAPMManager.shared.withSpan(.appLaunchRestoreSession) {
+                    let sessionStore = try await self.sessionStoreValue()
+                    guard self.initialStateLoadGeneration == generation else { return }
+                    self.errorMessage = nil
+                    let restoredSession = try await sessionStore.restoreColdStartSession()
+                    guard self.initialStateLoadGeneration == generation else { return }
+                    await self.applySession(restoredSession)
+                    guard self.initialStateLoadGeneration == generation else { return }
+                    await self.refreshTopicsIfPossible(force: true)
+                    guard self.initialStateLoadGeneration == generation else { return }
+                    await self.loadRecentNotifications(force: false)
+                }
             } catch {
                 guard self.initialStateLoadGeneration == generation else { return }
                 if await self.handleRecoverableSessionErrorIfNeeded(error) {
@@ -287,11 +290,13 @@ final class FireAppViewModel: ObservableObject {
             defer { isSyncingLoginSession = false }
 
             do {
-                let loginCoordinator = try await loginCoordinatorValue()
-                errorMessage = nil
-                await applySession(try await loginCoordinator.completeLogin(from: webView))
-                isPresentingLogin = false
-                await refreshTopicsIfPossible(force: true)
+                try await FireAPMManager.shared.withSpan(.authLoginSync) {
+                    let loginCoordinator = try await loginCoordinatorValue()
+                    errorMessage = nil
+                    await applySession(try await loginCoordinator.completeLogin(from: webView))
+                    isPresentingLogin = false
+                    await refreshTopicsIfPossible(force: true)
+                }
             } catch {
                 if await handleRecoverableSessionErrorIfNeeded(error) {
                     return
@@ -304,10 +309,12 @@ final class FireAppViewModel: ObservableObject {
     func refreshBootstrap() {
         Task {
             do {
-                let sessionStore = try await sessionStoreValue()
-                errorMessage = nil
-                await applySession(try await sessionStore.refreshBootstrap())
-                await refreshTopicsIfPossible(force: false)
+                try await FireAPMManager.shared.withSpan(.bootstrapRefresh) {
+                    let sessionStore = try await sessionStoreValue()
+                    errorMessage = nil
+                    await applySession(try await sessionStore.refreshBootstrap())
+                    await refreshTopicsIfPossible(force: false)
+                }
             } catch {
                 if await handleRecoverableSessionErrorIfNeeded(error) {
                     return
@@ -445,16 +452,21 @@ final class FireAppViewModel: ObservableObject {
 
         do {
             errorMessage = nil
-            let detail = try await sessionStore.fetchTopicDetailInitial(
-                query: TopicDetailQueryState(
-                    topicId: topicId,
-                    postNumber: targetPostNumber,
-                    trackVisit: true,
-                    filter: nil,
-                    usernameFilters: nil,
-                    filterTopLevelReplies: false
+            let detail = try await FireAPMManager.shared.withSpan(
+                .topicDetailInitialLoad,
+                metadata: ["topic_id": String(topicId)]
+            ) {
+                try await sessionStore.fetchTopicDetailInitial(
+                    query: TopicDetailQueryState(
+                        topicId: topicId,
+                        postNumber: targetPostNumber,
+                        trackVisit: true,
+                        filter: nil,
+                        usernameFilters: nil,
+                        filterTopLevelReplies: false
+                    )
                 )
-            )
+            }
             applyTopicDetail(detail, topicId: topicId)
             topicDetailLogger()?.debug(
                 "loaded topic detail topic_id=\(topicId) loaded_posts=\(detail.postStream.posts.count) stream_posts=\(detail.postStream.stream.count)"
@@ -683,12 +695,20 @@ final class FireAppViewModel: ObservableObject {
 
         do {
             errorMessage = nil
-            let createdReply = try await performWriteWithCloudflareRetry {
-                try await sessionStore.createReply(
-                    topicID: topicId,
-                    raw: trimmed,
-                    replyToPostNumber: replyToPostNumber
-                )
+            let createdReply = try await FireAPMManager.shared.withSpan(
+                .topicReplySubmit,
+                metadata: [
+                    "topic_id": String(topicId),
+                    "reply_to_post_number": replyToPostNumber.map(String.init) ?? "root"
+                ]
+            ) {
+                try await performWriteWithCloudflareRetry {
+                    try await sessionStore.createReply(
+                        topicID: topicId,
+                        raw: trimmed,
+                        replyToPostNumber: replyToPostNumber
+                    )
+                }
             }
             if let snapshot = try? await sessionStore.snapshot() {
                 await applySession(snapshot)
@@ -1103,10 +1123,12 @@ final class FireAppViewModel: ObservableObject {
         isLoadingNotifications = true
         defer { isLoadingNotifications = false }
         do {
-            let list = try await sessionStore.fetchRecentNotifications()
-            recentNotifications = list.notifications
-            if let state = try? await sessionStore.notificationState() {
-                notificationUnreadCount = Int(state.counters.allUnread)
+            try await FireAPMManager.shared.withSpan(.notificationsRefresh) {
+                let list = try await sessionStore.fetchRecentNotifications()
+                recentNotifications = list.notifications
+                if let state = try? await sessionStore.notificationState() {
+                    notificationUnreadCount = Int(state.counters.allUnread)
+                }
             }
         } catch {
             _ = await handleRecoverableSessionErrorIfNeeded(error)
@@ -1389,6 +1411,29 @@ final class FireAppViewModel: ObservableObject {
         )
     }
 
+    func apmDiagnosticsSummary() async throws -> FireAPMDiagnosticsSummary {
+        try await FireAPMManager.shared.diagnosticsSummary()
+    }
+
+    func exportFullAPMSupportBundle(scenePhase: String?) async throws -> FireAPMSupportBundleExport {
+        let rustBundleURL: URL?
+        if let sessionStore = try? await sessionStoreValue() {
+            let rustBundle = try? await sessionStore.exportSupportBundle(
+                platform: "ios",
+                appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+                buildNumber: Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String,
+                scenePhase: scenePhase
+            )
+            rustBundleURL = rustBundle.map { URL(fileURLWithPath: $0.absolutePath) }
+        } else {
+            rustBundleURL = nil
+        }
+        return try await FireAPMManager.shared.exportSupportBundle(
+            rustSupportBundleURL: rustBundleURL,
+            scenePhase: scenePhase
+        )
+    }
+
     func flushDiagnosticsLogs(sync: Bool = true) async throws {
         let sessionStore = try await sessionStoreValue()
         try await sessionStore.flushLogs(sync: sync)
@@ -1409,6 +1454,34 @@ final class FireAppViewModel: ObservableObject {
         errorMessage = nil
     }
 
+    func updateTopLevelAPMRoute(selectedTab: Int, isAuthenticated: Bool) {
+        let route: String
+        if !isAuthenticated {
+            route = "session.onboarding"
+        } else {
+            switch selectedTab {
+            case 0:
+                route = "tab.home"
+            case 1:
+                route = "tab.notifications"
+            case 2:
+                route = "tab.profile"
+            default:
+                route = "tab.unknown"
+            }
+        }
+        topLevelAPMRoute = route
+        FireAPMManager.shared.setCurrentRoute(route)
+    }
+
+    func restoreTopLevelAPMRoute() {
+        FireAPMManager.shared.setCurrentRoute(topLevelAPMRoute)
+    }
+
+    func setAPMRoute(_ route: String) {
+        FireAPMManager.shared.setCurrentRoute(route)
+    }
+
     // MARK: - MessageBus lifecycle
 
     private func startMessageBus() async {
@@ -1425,7 +1498,9 @@ final class FireAppViewModel: ObservableObject {
         messageBusCoordinator = coordinator
 
         do {
-            _ = try await sessionStore.startMessageBus(handler: coordinator)
+            _ = try await FireAPMManager.shared.withSpan(.messageBusStart) {
+                try await sessionStore.startMessageBus(handler: coordinator)
+            }
             isMessageBusActive = true
             messageBusStartRetryCount = 0
             clearMessageBusError()
@@ -1710,21 +1785,37 @@ final class FireAppViewModel: ObservableObject {
                 && !incrementalTopicIDs.isEmpty
                 && requestedScope.supportsIncrementalMessageBusRefresh
                 && !topicRows.isEmpty
-            let response = try await sessionStore.fetchTopicList(
-                query: TopicListQueryState(
-                    kind: requestedKind,
-                    page: page,
-                    topicIds: usesIncrementalRefresh ? incrementalTopicIDs : [],
-                    order: nil,
-                    ascending: nil,
-                    categorySlug: categorySlug,
-                    categoryId: categoryId,
-                    parentCategorySlug: parentSlug,
-                    tag: primaryTag,
-                    additionalTags: additionalTags,
-                    matchAllTags: !additionalTags.isEmpty
+            let fetch: () async throws -> TopicListState = {
+                try await sessionStore.fetchTopicList(
+                    query: TopicListQueryState(
+                        kind: requestedKind,
+                        page: page,
+                        topicIds: usesIncrementalRefresh ? incrementalTopicIDs : [],
+                        order: nil,
+                        ascending: nil,
+                        categorySlug: categorySlug,
+                        categoryId: categoryId,
+                        parentCategorySlug: parentSlug,
+                        tag: primaryTag,
+                        additionalTags: additionalTags,
+                        matchAllTags: !additionalTags.isEmpty
+                    )
                 )
-            )
+            }
+            let response: TopicListState
+            if reset && page == nil && requestedKind == .latest {
+                response = try await FireAPMManager.shared.withSpan(
+                    .feedLatestInitialLoad,
+                    metadata: [
+                        "category_id": categoryId.map(String.init) ?? "none",
+                        "tag": primaryTag ?? "none",
+                        "incremental": usesIncrementalRefresh ? "true" : "false"
+                    ],
+                    operation: fetch
+                )
+            } else {
+                response = try await fetch()
+            }
             guard requestedScope == currentTopicListRefreshScope else {
                 return false
             }
@@ -2472,6 +2563,7 @@ final class FireAppViewModel: ObservableObject {
         if let sessionStoreInitializationTask {
             let sessionStore = try await sessionStoreInitializationTask.value
             self.sessionStore = sessionStore
+            await FireAPMManager.shared.attachSessionStore(sessionStore)
             return sessionStore
         }
 
@@ -2484,6 +2576,7 @@ final class FireAppViewModel: ObservableObject {
             let sessionStore = try await initializationTask.value
             sessionStoreInitializationTask = nil
             self.sessionStore = sessionStore
+            await FireAPMManager.shared.attachSessionStore(sessionStore)
             return sessionStore
         } catch {
             sessionStoreInitializationTask = nil

--- a/native/ios-app/App/FireDiagnosticsView.swift
+++ b/native/ios-app/App/FireDiagnosticsView.swift
@@ -137,8 +137,11 @@ final class FireDiagnosticsViewModel: ObservableObject {
     @Published private(set) var requestTraces: [NetworkTraceSummaryState] = []
     @Published private(set) var requestTraceDetails: [UInt64: NetworkTraceDetailState] = [:]
     @Published private(set) var traceBodyDocuments: [UInt64: FireDiagnosticsPagedTextDocument] = [:]
+    @Published private(set) var apmSummary: FireAPMDiagnosticsSummary = .empty
     @Published private(set) var latestSupportBundle: SupportBundleExportState?
+    @Published private(set) var latestFullAPMSupportBundle: FireAPMSupportBundleExport?
     @Published private(set) var isExportingSupportBundle = false
+    @Published private(set) var isExportingFullAPMSupportBundle = false
     @Published private(set) var isLoading = false
     @Published var errorMessage: String?
 
@@ -171,9 +174,11 @@ final class FireDiagnosticsViewModel: ObservableObject {
                 async let diagnosticSessionID = appViewModel.diagnosticSessionID()
                 async let files = appViewModel.listLogFiles()
                 async let traces = appViewModel.listNetworkTraces(limit: 200)
+                async let apmSummary = appViewModel.apmDiagnosticsSummary()
                 let latestTraces = try await traces
                 self.diagnosticSessionID = try await diagnosticSessionID
                 logFiles = try await files
+                self.apmSummary = try await apmSummary
                 applyTraceSummaries(latestTraces)
                 await refreshCachedTraceDetails(using: latestTraces)
             } catch {
@@ -376,6 +381,29 @@ final class FireDiagnosticsViewModel: ObservableObject {
         latestSupportBundle.map { URL(fileURLWithPath: $0.absolutePath) }
     }
 
+    func exportFullAPMSupportBundle(scenePhase: String) {
+        guard !isExportingFullAPMSupportBundle else {
+            return
+        }
+
+        Task {
+            isExportingFullAPMSupportBundle = true
+            defer { isExportingFullAPMSupportBundle = false }
+            do {
+                errorMessage = nil
+                latestFullAPMSupportBundle = try await appViewModel.exportFullAPMSupportBundle(
+                    scenePhase: scenePhase
+                )
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func fullAPMSupportBundleURL() -> URL? {
+        latestFullAPMSupportBundle?.absoluteURL
+    }
+
     private func loadTraceBodyPage(
         traceID: UInt64,
         cursor: UInt64?,
@@ -569,6 +597,7 @@ struct FireDiagnosticsView: View {
                     logCard
                 }
 
+                apmCard
                 supportBundleCard
             }
             .listRowSeparator(.hidden)
@@ -717,6 +746,33 @@ struct FireDiagnosticsView: View {
                 }
             }
 
+            HStack(spacing: 10) {
+                Button {
+                    diagnosticsViewModel.exportFullAPMSupportBundle(
+                        scenePhase: scenePhaseLabel(scenePhase)
+                    )
+                } label: {
+                    Label(
+                        diagnosticsViewModel.isExportingFullAPMSupportBundle ? "导出中…" : "导出完整 APM 包",
+                        systemImage: "archivebox"
+                    )
+                }
+                .buttonStyle(.bordered)
+                .disabled(diagnosticsViewModel.isExportingFullAPMSupportBundle)
+
+                if let bundleURL = diagnosticsViewModel.fullAPMSupportBundleURL() {
+                    ShareLink(item: bundleURL) {
+                        Label("分享 APM 包", systemImage: "square.and.arrow.up")
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                if diagnosticsViewModel.isExportingFullAPMSupportBundle {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
             if let export = diagnosticsViewModel.latestSupportBundle {
                 VStack(alignment: .leading, spacing: 4) {
                     Text("\(export.fileName) · \(FireDiagnosticsPresentation.byteSize(export.sizeBytes))")
@@ -729,6 +785,82 @@ struct FireDiagnosticsView: View {
                         .foregroundStyle(.secondary)
                         .textSelection(.enabled)
                 }
+            }
+
+            if let export = diagnosticsViewModel.latestFullAPMSupportBundle {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("\(export.fileName) · \(FireDiagnosticsPresentation.byteSize(export.sizeBytes))")
+                        .font(.caption.monospaced())
+                    Text(FireDiagnosticsPresentation.timestamp(export.createdAtUnixMs))
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    Text(export.absoluteURL.path)
+                        .font(.caption2.monospaced())
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color(.secondarySystemGroupedBackground))
+        )
+    }
+
+    private var apmCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label("APM 概览", systemImage: "waveform.path.ecg")
+                .font(.headline)
+
+            HStack(spacing: 0) {
+                miniStat(
+                    value: diagnosticsViewModel.apmSummary.currentSample?.cpuPercent.map {
+                        String(format: "%.1f%%", $0)
+                    } ?? "N/A",
+                    label: "CPU",
+                    color: .primary
+                )
+                miniStat(
+                    value: diagnosticsViewModel.apmSummary.currentSample?.physicalFootprintBytes.map {
+                        FireDiagnosticsPresentation.byteSize($0)
+                    } ?? "N/A",
+                    label: "Footprint",
+                    color: .secondary
+                )
+                miniStat(
+                    value: "\(diagnosticsViewModel.apmSummary.recentCrashes.count)",
+                    label: "Crash",
+                    color: diagnosticsViewModel.apmSummary.recentCrashes.isEmpty ? .secondary : .red
+                )
+                miniStat(
+                    value: "\(diagnosticsViewModel.apmSummary.recentStalls.count)",
+                    label: "卡顿",
+                    color: diagnosticsViewModel.apmSummary.recentStalls.isEmpty ? .secondary : .orange
+                )
+            }
+
+            if !diagnosticsViewModel.apmSummary.recentEvents.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(diagnosticsViewModel.apmSummary.recentEvents.prefix(4)) { event in
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(event.title)
+                                .font(.caption.weight(.semibold))
+                            if let subtitle = event.subtitle {
+                                Text(subtitle)
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                            }
+                            Text(FireDiagnosticsPresentation.timestamp(event.timestampUnixMs))
+                                .font(.caption2.monospaced())
+                                .foregroundStyle(.secondary)
+                        }
+                    }
+                }
+            } else {
+                Text("暂无 APM 事件。")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
         }
         .padding(14)

--- a/native/ios-app/App/FireLoginWebView.swift
+++ b/native/ios-app/App/FireLoginWebView.swift
@@ -158,6 +158,12 @@ struct FireLoginScreen: View {
                     }
                 )
             }
+            .onAppear {
+                viewModel.setAPMRoute("auth.login")
+            }
+            .onDisappear {
+                viewModel.restoreTopLevelAPMRoute()
+            }
         }
     }
 }

--- a/native/ios-app/App/FireTabRoot.swift
+++ b/native/ios-app/App/FireTabRoot.swift
@@ -54,6 +54,11 @@ struct FireTabRoot: View {
         }
         .task {
             viewModel.loadInitialState()
+            viewModel.updateTopLevelAPMRoute(
+                selectedTab: navigationState.selectedTab,
+                isAuthenticated: isAuthenticated
+            )
+            FireAPMManager.shared.setScenePhase(scenePhaseLabel(scenePhase))
         }
         .task(id: isAuthenticated) {
             if isAuthenticated {
@@ -61,8 +66,13 @@ struct FireTabRoot: View {
             } else {
                 FireBackgroundNotificationAlertScheduler.cancelRefresh()
             }
+            viewModel.updateTopLevelAPMRoute(
+                selectedTab: navigationState.selectedTab,
+                isAuthenticated: isAuthenticated
+            )
         }
         .onChange(of: scenePhase) { _, phase in
+            FireAPMManager.shared.setScenePhase(scenePhaseLabel(phase))
             viewModel.handleDiagnosticsScenePhaseChange(
                 scenePhaseLabel(phase),
                 isAuthenticated: isAuthenticated
@@ -89,7 +99,17 @@ struct FireTabRoot: View {
         .onChange(of: navigationState.pendingDeepLink) { _, deepLink in
             consumeDeepLinkIfReady(deepLink)
         }
+        .onChange(of: navigationState.selectedTab) { _, selectedTab in
+            viewModel.updateTopLevelAPMRoute(
+                selectedTab: selectedTab,
+                isAuthenticated: isAuthenticated
+            )
+        }
         .onChange(of: isAuthenticated) { _, authenticated in
+            viewModel.updateTopLevelAPMRoute(
+                selectedTab: navigationState.selectedTab,
+                isAuthenticated: authenticated
+            )
             if authenticated, let deepLink = navigationState.pendingDeepLink {
                 consumeDeepLinkIfReady(deepLink)
             }

--- a/native/ios-app/App/FireTopicDetailView.swift
+++ b/native/ios-app/App/FireTopicDetailView.swift
@@ -451,6 +451,7 @@ struct FireTopicDetailView: View {
         }
         .onAppear {
             viewModel.beginTopicDetailLifecycle(topicId: topic.id, ownerToken: detailOwnerToken)
+            viewModel.setAPMRoute("topic.detail.\(topic.id)")
         }
         .task(id: topic.id) {
             timingTracker.start { topicId, topicTimeMs, timings in
@@ -485,6 +486,7 @@ struct FireTopicDetailView: View {
         }
         .onDisappear {
             viewModel.endTopicDetailLifecycle(topicId: topic.id, ownerToken: detailOwnerToken)
+            viewModel.restoreTopLevelAPMRoute()
             Task {
                 await timingTracker.stop()
                 await viewModel.endTopicReplyPresence(topicId: topic.id)

--- a/native/ios-app/Configs/Fire-Shared.xcconfig
+++ b/native/ios-app/Configs/Fire-Shared.xcconfig
@@ -1,2 +1,3 @@
 FIRE_CODE_SIGN_STYLE = Automatic
+FIRE_GIT_SHA = unknown
 FIRE_PRODUCT_BUNDLE_IDENTIFIER = com.fire.app.ios

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -13,16 +13,19 @@
 		0ED224A3C2B64ED1DE67CA99 /* FireTopicPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14122231F5DBCCFFC5AD36C /* FireTopicPresentation.swift */; };
 		12ED42BB059E1EFA35A00827 /* FireTopicEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA800E223882F74B7EB5812 /* FireTopicEditorView.swift */; };
 		178E55B850EED60EE530A0F2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B970247E0258DD4D4F34101 /* Foundation.framework */; };
+		180BEE1FEF5E76FF92403C34 /* FireAPMEventStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFBB6F3B1D7E3DD79D98C17 /* FireAPMEventStoreTests.swift */; };
 		1F1EEDCE0B4FEAE2880DC061 /* FireWebViewLoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E5271F93B7DF18859B101F /* FireWebViewLoginCoordinator.swift */; };
 		217BC99CE792BDFA88ED89FC /* FireTabRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05507C09C3878752BCC013E3 /* FireTabRoot.swift */; };
 		23B6D938A84DB421F8549AD0 /* FireBackgroundNotificationAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51431D8CC0EBCA6C0E79380C /* FireBackgroundNotificationAlert.swift */; };
 		2C5CE663E30B00720A75CD0A /* FireProfileHeaderComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8372AD9A5A2CC34FBD3AEF /* FireProfileHeaderComponents.swift */; };
 		34DC539E6C32931D4743C75F /* FireBadgeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467E95A2109D81DB456F64A9 /* FireBadgeDetailView.swift */; };
+		390219653B0C0A96C81D8962 /* FireAPMEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373861687BBCD8EB8E350DA4 /* FireAPMEventStore.swift */; };
 		428170833590DCF14AEEA64C /* FireTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFC5F5EA7CD05C23FBEB9A2 /* FireTheme.swift */; };
 		48C404692D8F5FA7471852BF /* FireSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08AB12E53EB29136A0946A /* FireSearchView.swift */; };
 		55B4C9E127A547A1514C9C16 /* FireInviteLinksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74DDD4D388827A202662DB78 /* FireInviteLinksView.swift */; };
 		5A95F9C29909968BF4B17AD7 /* FireAuthCookieKeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313FFDD8D569FA6D9B1C0E0 /* FireAuthCookieKeychainStore.swift */; };
 		5B4072DC893E7612141A8F34 /* FireComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77FD6C1C577852A9B0EC2532 /* FireComposerView.swift */; };
+		5E556FC12993F27449D2B973 /* FireAPMManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129694A5F35FF78B3F810049 /* FireAPMManager.swift */; };
 		5FA66113E53795C8DC6D0563 /* FireProfileActivityTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35E67F65FB748821001726D /* FireProfileActivityTimelineView.swift */; };
 		6A8BA8AACC4ED45E311894CE /* FireTopicDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67647993BFF688FB02B71DBB /* FireTopicDetailView.swift */; };
 		6A93EC6F3D79F51A9CB66A58 /* FireAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300B5894E4B597FC94E645D3 /* FireAppDelegate.swift */; };
@@ -40,6 +43,7 @@
 		8D3E53867C1B21D940FB765A /* FireProfileActivityRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292A9A11D19C39A02BC00B38 /* FireProfileActivityRow.swift */; };
 		8D77430DC1266A1EDEF3A6E4 /* FireAppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA66CA083BF4889AE258926 /* FireAppViewModel.swift */; };
 		8F10E1B26BE2D5FC5F2D6C1B /* FireProfileStatsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6210541C2E8219CE500CFC04 /* FireProfileStatsRow.swift */; };
+		91BA9CDF0E86830FEB1951B0 /* FireAPMMainThreadStallMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20BDF82CCD1BF22BB3C7729 /* FireAPMMainThreadStallMonitor.swift */; };
 		944A9CD4343088D2E1BABF5A /* FireMessageBusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5394EEC6957C140D8189FA /* FireMessageBusCoordinator.swift */; };
 		954D2C7BD4B371CA41536C0F /* FireTopicTimingTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD6D7178B2622B10A5644E2 /* FireTopicTimingTracker.swift */; };
 		9726B24BBA832290EA063E8F /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = FD5A94769988E39B8BEA7B56 /* libiconv.tbd */; };
@@ -49,6 +53,7 @@
 		9FDB03E99AB569E64A17BE3B /* FireSessionSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6840B06FC02F67318B0991 /* FireSessionSecurityTests.swift */; };
 		A1991999F769CF1B701DEFA4 /* FireMyBadgesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F63CDBE0BC6524D17AB00C /* FireMyBadgesView.swift */; };
 		A29E21413FA011161D518004 /* FireSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8834ADE6E3ADB8A03391560C /* FireSessionStore.swift */; };
+		A7657EA99808CEBE3F038176 /* CrashReporter in Frameworks */ = {isa = PBXBuildFile; productRef = 601B450FB4E87A5243FAE5F9 /* CrashReporter */; };
 		B21E0A6B519EA414B836E4BE /* FireProfileTrustLevelPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F02D3C136EFF0589DC131FB9 /* FireProfileTrustLevelPill.swift */; };
 		BACF637B5B2F0C0C8EDA3048 /* fire_uniffi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588B3F8CFD76DF758BE3A242 /* fire_uniffi.swift */; };
 		C02B0FA4DC635EE4FF05F19F /* SessionState+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F3291447D7DA0AEF9AA413 /* SessionState+Helpers.swift */; };
@@ -59,7 +64,9 @@
 		CFF789D0907079D9365F031E /* FireLoginWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6725F42C679E922AA3DD1FBF /* FireLoginWebView.swift */; };
 		D7055404526257A9C288B052 /* FireNotificationHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75C8AF749DA8EF7CB5E3A64 /* FireNotificationHistoryView.swift */; };
 		DAF8F172C614FCDFB6E0BA1C /* FireProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568D9F64260FB53D957BE41C /* FireProfileView.swift */; };
+		E44A45038AA722685149ACA1 /* FireAPMModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5264103A412DF3C9798D470 /* FireAPMModels.swift */; };
 		E56F67E343C97A5F77A3068E /* FireProfileBadgeChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = BABD32407FB273553E9394B3 /* FireProfileBadgeChip.swift */; };
+		E60D57A49519AD07A4834489 /* FireAPMResourceSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DEF53357E681E40E482813 /* FireAPMResourceSampler.swift */; };
 		E67F86DADDE88559438DE849 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08F96260D49AF4E41AB4739C /* CoreFoundation.framework */; };
 		F171E34C843A4BD06FB50408 /* FireBookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE19EEF18F20BE710E4B7E4 /* FireBookmarksView.swift */; };
 		FA462FF0334E77051F227943 /* FirePublicProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F67B40FC02230AFEC2A562 /* FirePublicProfileView.swift */; };
@@ -84,12 +91,15 @@
 		0D1C4D30FB92D47F801B64D4 /* FireTopicRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicRow.swift; sourceTree = "<group>"; };
 		0DB69FD096A581A18D9D16C5 /* Fire-Local-Release.example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Fire-Local-Release.example.xcconfig"; sourceTree = "<group>"; };
 		0F4A54860996435FDDF40EBE /* FireDiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDiagnosticsView.swift; sourceTree = "<group>"; };
+		129694A5F35FF78B3F810049 /* FireAPMManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMManager.swift; sourceTree = "<group>"; };
 		19F67B40FC02230AFEC2A562 /* FirePublicProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePublicProfileView.swift; sourceTree = "<group>"; };
 		27F174773C4A2B3D0A4D29DD /* FireComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireComponents.swift; sourceTree = "<group>"; };
 		292A9A11D19C39A02BC00B38 /* FireProfileActivityRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileActivityRow.swift; sourceTree = "<group>"; };
 		2E5394EEC6957C140D8189FA /* FireMessageBusCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireMessageBusCoordinator.swift; sourceTree = "<group>"; };
+		2EFBB6F3B1D7E3DD79D98C17 /* FireAPMEventStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMEventStoreTests.swift; sourceTree = "<group>"; };
 		300B5894E4B597FC94E645D3 /* FireAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppDelegate.swift; sourceTree = "<group>"; };
 		33F63CDBE0BC6524D17AB00C /* FireMyBadgesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireMyBadgesView.swift; sourceTree = "<group>"; };
+		373861687BBCD8EB8E350DA4 /* FireAPMEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMEventStore.swift; sourceTree = "<group>"; };
 		3CE19EEF18F20BE710E4B7E4 /* FireBookmarksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireBookmarksView.swift; sourceTree = "<group>"; };
 		3FA800E223882F74B7EB5812 /* FireTopicEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicEditorView.swift; sourceTree = "<group>"; };
 		419222F55DFE2BC290CD5335 /* FireProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileViewModel.swift; sourceTree = "<group>"; };
@@ -120,11 +130,14 @@
 		9B970247E0258DD4D4F34101 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
 		A0AFFF5DCC989B801C9DF88E /* Fire-Debug.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Fire-Debug.xcconfig"; sourceTree = "<group>"; };
 		A14122231F5DBCCFFC5AD36C /* FireTopicPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicPresentation.swift; sourceTree = "<group>"; };
+		A5264103A412DF3C9798D470 /* FireAPMModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMModels.swift; sourceTree = "<group>"; };
 		AE6087FA4E6DF2034C9E6D77 /* FireReadHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireReadHistoryView.swift; sourceTree = "<group>"; };
 		B5E5271F93B7DF18859B101F /* FireWebViewLoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWebViewLoginCoordinator.swift; sourceTree = "<group>"; };
 		BABD32407FB273553E9394B3 /* FireProfileBadgeChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileBadgeChip.swift; sourceTree = "<group>"; };
 		BFA66CA083BF4889AE258926 /* FireAppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppViewModel.swift; sourceTree = "<group>"; };
+		C20BDF82CCD1BF22BB3C7729 /* FireAPMMainThreadStallMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMMainThreadStallMonitor.swift; sourceTree = "<group>"; };
 		C313FFDD8D569FA6D9B1C0E0 /* FireAuthCookieKeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAuthCookieKeychainStore.swift; sourceTree = "<group>"; };
+		C6DEF53357E681E40E482813 /* FireAPMResourceSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMResourceSampler.swift; sourceTree = "<group>"; };
 		C810E3D0B2CF415495A3D5C4 /* FireFilteredTopicListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireFilteredTopicListView.swift; sourceTree = "<group>"; };
 		CC6840B06FC02F67318B0991 /* FireSessionSecurityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSessionSecurityTests.swift; sourceTree = "<group>"; };
 		CEBEB262C9A5B9B7348537B8 /* FireNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNavigationState.swift; sourceTree = "<group>"; };
@@ -152,6 +165,7 @@
 				178E55B850EED60EE530A0F2 /* Foundation.framework in Frameworks */,
 				E67F86DADDE88559438DE849 /* CoreFoundation.framework in Frameworks */,
 				9726B24BBA832290EA063E8F /* libiconv.tbd in Frameworks */,
+				A7657EA99808CEBE3F038176 /* CrashReporter in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -173,9 +187,22 @@
 				C313FFDD8D569FA6D9B1C0E0 /* FireAuthCookieKeychainStore.swift */,
 				8834ADE6E3ADB8A03391560C /* FireSessionStore.swift */,
 				B5E5271F93B7DF18859B101F /* FireWebViewLoginCoordinator.swift */,
+				410518D5B5DA1358F677892E /* APM */,
 			);
 			name = FireAppSession;
 			path = Sources/FireAppSession;
+			sourceTree = "<group>";
+		};
+		410518D5B5DA1358F677892E /* APM */ = {
+			isa = PBXGroup;
+			children = (
+				373861687BBCD8EB8E350DA4 /* FireAPMEventStore.swift */,
+				C20BDF82CCD1BF22BB3C7729 /* FireAPMMainThreadStallMonitor.swift */,
+				129694A5F35FF78B3F810049 /* FireAPMManager.swift */,
+				A5264103A412DF3C9798D470 /* FireAPMModels.swift */,
+				C6DEF53357E681E40E482813 /* FireAPMResourceSampler.swift */,
+			);
+			path = APM;
 			sourceTree = "<group>";
 		};
 		73EB36381D2DB9DA74378162 /* App */ = {
@@ -234,6 +261,7 @@
 		8FCD2C1B029D07F4C1B82746 /* Unit */ = {
 			isa = PBXGroup;
 			children = (
+				2EFBB6F3B1D7E3DD79D98C17 /* FireAPMEventStoreTests.swift */,
 				CC6840B06FC02F67318B0991 /* FireSessionSecurityTests.swift */,
 				859219285EC36B189AF68256 /* FireTopicListMessageBusRefreshTests.swift */,
 				9189433D7C9260885742A5BA /* FireTopicPresentationTests.swift */,
@@ -321,6 +349,7 @@
 			);
 			name = Fire;
 			packageProductDependencies = (
+				601B450FB4E87A5243FAE5F9 /* CrashReporter */,
 			);
 			productName = Fire;
 			productReference = 48CAB0E38556929FC140E25D /* Fire.app */;
@@ -350,6 +379,9 @@
 			);
 			mainGroup = 9C1D09FDC0177122C191D595;
 			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				9F8D6D7CFB3643BCA8C9F545 /* XCRemoteSwiftPackageReference "plcrashreporter" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1D88C155B3075FF19641DF3E /* Products */;
 			projectDirPath = "";
@@ -399,6 +431,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				180BEE1FEF5E76FF92403C34 /* FireAPMEventStoreTests.swift in Sources */,
 				9FDB03E99AB569E64A17BE3B /* FireSessionSecurityTests.swift in Sources */,
 				9F734046F02B45409AD5F1C6 /* FireTopicListMessageBusRefreshTests.swift in Sources */,
 				FFCC342F97F349220632A787 /* FireTopicPresentationTests.swift in Sources */,
@@ -409,6 +442,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				390219653B0C0A96C81D8962 /* FireAPMEventStore.swift in Sources */,
+				91BA9CDF0E86830FEB1951B0 /* FireAPMMainThreadStallMonitor.swift in Sources */,
+				5E556FC12993F27449D2B973 /* FireAPMManager.swift in Sources */,
+				E44A45038AA722685149ACA1 /* FireAPMModels.swift in Sources */,
+				E60D57A49519AD07A4834489 /* FireAPMResourceSampler.swift in Sources */,
 				0006B08A873FC6192E616F01 /* FireApp.swift in Sources */,
 				6A93EC6F3D79F51A9CB66A58 /* FireAppDelegate.swift in Sources */,
 				8D77430DC1266A1EDEF3A6E4 /* FireAppViewModel.swift in Sources */,
@@ -481,11 +519,13 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = "$(FIRE_CODE_SIGN_STYLE)";
 				DEVELOPMENT_TEAM = "$(FIRE_DEVELOPMENT_TEAM)";
+				FIRE_GIT_SHA = "$(FIRE_GIT_SHA)";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = (
 					"com.fire.app.ios.notification-alert-refresh",
 				);
 				INFOPLIST_KEY_CFBundleDisplayName = Fire;
+				INFOPLIST_KEY_FireGitSha = "$(FIRE_GIT_SHA)";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIBackgroundModes = (
 					fetch,
@@ -683,11 +723,13 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = "$(FIRE_CODE_SIGN_STYLE)";
 				DEVELOPMENT_TEAM = "$(FIRE_DEVELOPMENT_TEAM)";
+				FIRE_GIT_SHA = "$(FIRE_GIT_SHA)";
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = (
 					"com.fire.app.ios.notification-alert-refresh",
 				);
 				INFOPLIST_KEY_CFBundleDisplayName = Fire;
+				INFOPLIST_KEY_FireGitSha = "$(FIRE_GIT_SHA)";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIBackgroundModes = (
 					fetch,
@@ -749,6 +791,25 @@
 			defaultConfigurationName = Debug;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		9F8D6D7CFB3643BCA8C9F545 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/microsoft/plcrashreporter.git";
+			requirement = {
+				kind = exactVersion;
+				version = 1.12.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		601B450FB4E87A5243FAE5F9 /* CrashReporter */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 9F8D6D7CFB3643BCA8C9F545 /* XCRemoteSwiftPackageReference "plcrashreporter" */;
+			productName = CrashReporter;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 9AB7FC66AC31A04F54C77B79 /* Project object */;
 }

--- a/native/ios-app/Fire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/native/ios-app/Fire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "606c3f9d0bc26236a2f60c78aaf8310eddc6e69d6f8a37c89e7f238cf246d3d6",
+  "pins" : [
+    {
+      "identity" : "plcrashreporter",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/microsoft/plcrashreporter.git",
+      "state" : {
+        "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
+        "version" : "1.12.2"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -28,6 +28,11 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - persists the latest Rust session snapshot as a full `Application Support/Fire/session.json` and mirrors the current Rust-owned auth cookie batch back into Keychain whenever it changes
   - lets Rust initialize shared logs under `Application Support/Fire/logs`
   - wraps `syncLoginContext`, async `refreshBootstrap`, async `refreshCsrfToken`, async topic fetches, and async logout
+- `Sources/FireAppSession/APM/*`
+  - owns the beta-phase iOS crash/APM runtime
+  - installs `PLCrashReporter` at launch, harvests pending crash reports on next cold start, and persists raw `.plcrash` payloads under `Application Support/Fire/ios-apm/crashes`
+  - registers `MetricKit`, stores raw metric/diagnostic payload JSON under `Application Support/Fire/ios-apm/metrickit`, and keeps a durable `runtime-state.json` snapshot for route / scene / breadcrumb recovery
+  - samples foreground CPU / memory / thermal state, detects main-thread stalls, tracks host-owned route/span breadcrumbs, and exports shareable `.firesupportbundle` packages under `Application Support/Fire/ios-apm/exports`
 - `FireAuthCookieKeychainStore.swift`
   - stores the full same-site LinuxDo browser cookie batch in Keychain using a host-scoped generic-password entry, preserving domain variants and cookie expiry
   - preserves non-login browser context cookies, including `cf_clearance`, across explicit logout so Cloudflare challenge state stays aligned with the host shell
@@ -54,6 +59,7 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - coordinates native reply, like, custom reaction, and topic-timing reporting on top of the shared Rust interaction APIs
   - now owns the foreground MessageBus lifecycle on iOS, including topic-detail reaction/presence subscriptions, shared notification-state sync, and reply-presence heartbeats while the quick composer is focused
   - now treats Rust-owned `CloudflareChallenge` errors as the signal to clear the local authenticated snapshot, return the shell to onboarding, and auto-present the login WebView so challenge recovery stays inside the browser flow
+  - now also emits host-owned APM spans for cold-start restore, login sync, bootstrap refresh, latest-feed load, topic-detail load, reply submit, notification refresh, and MessageBus start
 - `App/FireSearchView.swift`
   - provides a native search workspace with keyword input, topic/post/user scope switching, paginated result loading, and topic-detail navigation reuse
 - `App/FireTopicDetailView.swift`
@@ -64,14 +70,15 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - schedules iOS `BGAppRefreshTask` runs for `/notification-alert/{userId}` polling
   - restores the Rust session plus Keychain cookies in the background, performs a one-shot shared MessageBus alert poll, and turns the result into host-owned local notifications
 - `App/FireAppDelegate.swift`
-  - registers the background refresh task at launch and keeps `UNUserNotificationCenter` delegate ownership on the host side
+  - registers the background refresh task at launch, starts the host-owned APM runtime, and keeps `UNUserNotificationCenter` delegate ownership on the host side
 - `App/FireDiagnosticsView.swift`
   - renders a native diagnostics screen on top of the shared Rust diagnostics APIs
   - lists workspace log files plus reverse-chronological network request traces
   - opens tail-first log pages, preview-first network body viewers, and per-request execution chains without pushing full diagnostic text across the UniFFI boundary by default
-  - exports local support bundles containing the full session state, recent log windows, and recent trace summaries for share-sheet based escalation during the current development phase
+  - exports both the Rust-owned diagnostics bundle and a host-owned full APM `.firesupportbundle` package containing local crash / MetricKit / route / span artifacts for share-sheet based escalation during beta
 - `App/FireTabRoot.swift`
   - forwards scene-phase transitions into shared diagnostics lifecycle logging and flushes logs before `inactive` / `background` so exported diagnostics stay durable
+  - keeps the current top-level route synchronized into the host-owned APM runtime
 - `App/FireTopicPresentation.swift`
   - normalizes topic/post timestamps for native presentation
   - extracts inline cooked-image attachments plus enabled reaction options from bootstrap/topic HTML so the native detail view can render media and interaction affordances without a WebView
@@ -130,6 +137,7 @@ Workspace note:
 - Rust can resolve relative paths inside that workspace for shared file ownership such as logs, caches, or exports.
 - The current persisted session file remains `Application Support/Fire/session.json`, and iOS currently writes the full session snapshot there during the active diagnostics-heavy development phase.
 - iOS keeps the full same-site LinuxDo browser cookie batch in Keychain, including expiry metadata and distinct host/domain variants, re-injects it into Rust during cold start before any authenticated refresh path runs, and refreshes the Keychain copy when Rust receives newer auth cookies from the network.
+- iOS now also keeps host-owned beta crash/APM files under `Application Support/Fire/ios-apm/`. That tree is not Rust-owned and should be treated as native-only operational state.
 
 Current UX note:
 
@@ -172,6 +180,15 @@ Verified local commands:
 - `xcodegen generate --spec native/ios-app/project.yml`
 - `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'generic/platform=iOS Simulator' build`
 - `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' -derivedDataPath /tmp/fire-ios-ui CODE_SIGNING_ALLOWED=NO test`
+
+Operational archive command:
+
+- `./scripts/ios/archive_release.sh`
+
+Release artifact note:
+
+- `native/ios-app/project.yml` now carries a user-defined `FIRE_GIT_SHA` build setting and writes it into the generated Info.plist as `FireGitSha`.
+- `.github/workflows/ios-release-artifacts.yml` produces an unsigned release archive, collected `dSYMs/`, and `build-metadata.json` for beta crash symbolication rehearsal.
 
 Current build note:
 

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -31,8 +31,8 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
 - `Sources/FireAppSession/APM/*`
   - owns the beta-phase iOS crash/APM runtime
   - installs `PLCrashReporter` at launch, harvests pending crash reports on next cold start, and persists raw `.plcrash` payloads under `Application Support/Fire/ios-apm/crashes`
-  - registers `MetricKit`, stores raw metric/diagnostic payload JSON under `Application Support/Fire/ios-apm/metrickit`, and keeps a durable `runtime-state.json` snapshot for route / scene / breadcrumb recovery
-  - samples foreground CPU / memory / thermal state, detects main-thread stalls, tracks host-owned route/span breadcrumbs, and exports shareable `.firesupportbundle` packages under `Application Support/Fire/ios-apm/exports`
+  - registers `MetricKit`, stores raw metric/diagnostic payload JSON under `Application Support/Fire/ios-apm/metrickit`, and keeps per-launch runtime-state snapshots under `Application Support/Fire/ios-apm/runtime-states` for route / scene / breadcrumb recovery
+  - samples foreground CPU / memory / thermal state, detects main-thread stalls, tracks host-owned route/span breadcrumbs, and exports shareable `.firesupportbundle` packages under `Application Support/Fire/ios-apm-exports`
 - `FireAuthCookieKeychainStore.swift`
   - stores the full same-site LinuxDo browser cookie batch in Keychain using a host-scoped generic-password entry, preserving domain variants and cookie expiry
   - preserves non-login browser context cookies, including `cf_clearance`, across explicit logout so Cloudflare challenge state stays aligned with the host shell
@@ -137,7 +137,7 @@ Workspace note:
 - Rust can resolve relative paths inside that workspace for shared file ownership such as logs, caches, or exports.
 - The current persisted session file remains `Application Support/Fire/session.json`, and iOS currently writes the full session snapshot there during the active diagnostics-heavy development phase.
 - iOS keeps the full same-site LinuxDo browser cookie batch in Keychain, including expiry metadata and distinct host/domain variants, re-injects it into Rust during cold start before any authenticated refresh path runs, and refreshes the Keychain copy when Rust receives newer auth cookies from the network.
-- iOS now also keeps host-owned beta crash/APM files under `Application Support/Fire/ios-apm/`. That tree is not Rust-owned and should be treated as native-only operational state.
+- iOS now also keeps host-owned beta crash/APM runtime state under `Application Support/Fire/ios-apm/` plus exported full APM bundles under `Application Support/Fire/ios-apm-exports/`. Those trees are not Rust-owned and should be treated as native-only operational state.
 
 Current UX note:
 

--- a/native/ios-app/Sources/FireAppSession/APM/FireAPMEventStore.swift
+++ b/native/ios-app/Sources/FireAppSession/APM/FireAPMEventStore.swift
@@ -1,0 +1,361 @@
+import Foundation
+
+actor FireAPMEventStore {
+    private enum Constants {
+        static let maxTotalBytes: UInt64 = 32 * 1024 * 1024
+        static let retentionWindow: TimeInterval = 7 * 24 * 60 * 60
+    }
+
+    private let baseURL: URL
+    private let buildInfo: FireAPMBuildInfo
+    private let fileManager: FileManager
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
+
+    init(
+        buildInfo: FireAPMBuildInfo,
+        baseURL: URL? = nil,
+        fileManager: FileManager = .default
+    ) async throws {
+        self.buildInfo = buildInfo
+        self.baseURL = try baseURL ?? Self.defaultBaseURL(fileManager: fileManager)
+        self.fileManager = fileManager
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        self.encoder = encoder
+        self.decoder = JSONDecoder()
+        try ensureDirectories()
+    }
+
+    static func defaultBaseURL(fileManager: FileManager = .default) throws -> URL {
+        let supportURL = try fileManager.url(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask,
+            appropriateFor: nil,
+            create: true
+        )
+        return supportURL
+            .appendingPathComponent("Fire", isDirectory: true)
+            .appendingPathComponent("ios-apm", isDirectory: true)
+    }
+
+    func baseDirectoryURL() -> URL {
+        baseURL
+    }
+
+    func record(
+        eventType: FireAPMEventType,
+        launchID: String?,
+        diagnosticSessionID: String?,
+        route: String?,
+        scenePhase: String?,
+        privacyTier: FireAPMPrivacyTier,
+        payloadSummary: [String: String],
+        payloadData: Data? = nil,
+        payloadSubdirectory: String? = nil,
+        payloadFileName: String? = nil
+    ) async throws -> FireAPMEventEnvelope {
+        let payloadPath: String?
+        if let payloadData, let payloadSubdirectory, let payloadFileName {
+            payloadPath = try persistAttachment(
+                data: payloadData,
+                subdirectory: payloadSubdirectory,
+                fileName: payloadFileName
+            )
+        } else {
+            payloadPath = nil
+        }
+
+        let envelope = FireAPMEventEnvelope(
+            eventID: UUID().uuidString.lowercased(),
+            eventType: eventType,
+            capturedAtUnixMs: FireAPMClock.nowUnixMs(),
+            launchID: launchID,
+            diagnosticSessionID: diagnosticSessionID,
+            appVersion: buildInfo.appVersion,
+            buildNumber: buildInfo.buildNumber,
+            gitSha: buildInfo.gitSha,
+            route: route,
+            scenePhase: scenePhase,
+            privacyTier: privacyTier,
+            payloadPath: payloadPath,
+            payloadSummary: payloadSummary
+        )
+        try appendEvent(envelope)
+        try pruneIfNeeded()
+        return envelope
+    }
+
+    func updateRuntimeState(_ state: FireAPMRuntimeState) throws {
+        try ensureDirectories()
+        let data = try encoder.encode(state)
+        try data.write(to: runtimeStateURL(), options: .atomic)
+    }
+
+    func runtimeState(launchID: String) throws -> FireAPMRuntimeState {
+        let url = runtimeStateURL()
+        guard fileManager.fileExists(atPath: url.path) else {
+            return .empty(launchID: launchID)
+        }
+        return try decoder.decode(FireAPMRuntimeState.self, from: Data(contentsOf: url))
+    }
+
+    func recentEvents(
+        limit: Int,
+        matching types: Set<FireAPMEventType>? = nil
+    ) throws -> [FireAPMEventEnvelope] {
+        let events = try loadAllEvents()
+        let filtered = events.filter { envelope in
+            guard let types else { return true }
+            return types.contains(envelope.eventType)
+        }
+        return Array(filtered.sorted { $0.capturedAtUnixMs > $1.capturedAtUnixMs }.prefix(limit))
+    }
+
+    func diagnosticsSummary(currentSample: FireAPMResourceSample?) throws -> FireAPMDiagnosticsSummary {
+        let recent = try recentEvents(limit: 24)
+        return FireAPMDiagnosticsSummary(
+            currentSample: currentSample,
+            recentCrashes: recentEvents(
+                from: recent,
+                matching: [.crash]
+            ),
+            recentMetricPayloads: recentEvents(
+                from: recent,
+                matching: [.metrickitMetric]
+            ),
+            recentDiagnostics: recentEvents(
+                from: recent,
+                matching: [.metrickitDiagnostic]
+            ),
+            recentStalls: recentEvents(
+                from: recent,
+                matching: [.stall]
+            ),
+            recentEvents: recent.map(Self.makeRecentEvent)
+        )
+    }
+
+    func exportBundle(
+        rustSupportBundleURL: URL?,
+        runtimeState: FireAPMRuntimeState?,
+        scenePhase: String?
+    ) throws -> FireAPMSupportBundleExport {
+        let timestamp = FireAPMClock.nowUnixMs()
+        let fileName = "fire-ios-apm-\(timestamp).firesupportbundle"
+        let exportURL = baseURL
+            .appendingPathComponent("exports", isDirectory: true)
+            .appendingPathComponent(fileName, isDirectory: true)
+
+        if fileManager.fileExists(atPath: exportURL.path) {
+            try fileManager.removeItem(at: exportURL)
+        }
+        try fileManager.createDirectory(at: exportURL, withIntermediateDirectories: true)
+
+        for component in ["events", "crashes", "metrickit"] {
+            let source = baseURL.appendingPathComponent(component, isDirectory: true)
+            guard fileManager.fileExists(atPath: source.path) else { continue }
+            let destination = exportURL.appendingPathComponent(component, isDirectory: true)
+            try fileManager.copyItem(at: source, to: destination)
+        }
+
+        if let rustSupportBundleURL, fileManager.fileExists(atPath: rustSupportBundleURL.path) {
+            try fileManager.copyItem(
+                at: rustSupportBundleURL,
+                to: exportURL.appendingPathComponent(rustSupportBundleURL.lastPathComponent)
+            )
+        }
+
+        let manifest = FireAPMSupportBundleManifest(
+            exportedAtUnixMs: timestamp,
+            scenePhase: scenePhase,
+            buildInfo: buildInfo,
+            runtimeState: runtimeState,
+            rustSupportBundleFileName: rustSupportBundleURL?.lastPathComponent
+        )
+        let manifestData = try encoder.encode(manifest)
+        try manifestData.write(
+            to: exportURL.appendingPathComponent("manifest.json"),
+            options: .atomic
+        )
+
+        let sizeBytes = try Self.directorySize(at: exportURL, fileManager: fileManager)
+        try pruneIfNeeded()
+        return FireAPMSupportBundleExport(
+            fileName: fileName,
+            absoluteURL: exportURL,
+            sizeBytes: sizeBytes,
+            createdAtUnixMs: timestamp
+        )
+    }
+
+    private func appendEvent(_ envelope: FireAPMEventEnvelope) throws {
+        try ensureDirectories()
+        let eventURL = todayEventsURL()
+        if !fileManager.fileExists(atPath: eventURL.path) {
+            fileManager.createFile(atPath: eventURL.path, contents: nil)
+        }
+        let data = try encoder.encode(envelope)
+        guard let handle = try? FileHandle(forWritingTo: eventURL) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: data)
+        try handle.write(contentsOf: Data([0x0A]))
+    }
+
+    private func persistAttachment(
+        data: Data,
+        subdirectory: String,
+        fileName: String
+    ) throws -> String {
+        try ensureDirectories()
+        let directory = baseURL.appendingPathComponent(subdirectory, isDirectory: true)
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent(fileName, isDirectory: false)
+        try data.write(to: url, options: .atomic)
+        return url.path.replacingOccurrences(of: "\(baseURL.path)/", with: "")
+    }
+
+    private func loadAllEvents() throws -> [FireAPMEventEnvelope] {
+        let eventFiles = try fileManager.contentsOfDirectory(
+            at: baseURL.appendingPathComponent("events", isDirectory: true),
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        )
+        .sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        var events: [FireAPMEventEnvelope] = []
+        for url in eventFiles where url.pathExtension == "ndjson" {
+            let data = try Data(contentsOf: url)
+            guard !data.isEmpty else { continue }
+            let lines = String(decoding: data, as: UTF8.self).split(separator: "\n")
+            for line in lines {
+                guard let lineData = line.data(using: .utf8) else { continue }
+                if let event = try? decoder.decode(FireAPMEventEnvelope.self, from: lineData) {
+                    events.append(event)
+                }
+            }
+        }
+        return events
+    }
+
+    private func pruneIfNeeded() throws {
+        let expirationCutoff = Date().addingTimeInterval(-Constants.retentionWindow)
+        let enumerator = fileManager.enumerator(
+            at: baseURL,
+            includingPropertiesForKeys: [
+                .contentModificationDateKey,
+                .fileSizeKey,
+                .isRegularFileKey,
+                .isDirectoryKey
+            ]
+        )
+
+        var files: [URL] = []
+        while let item = enumerator?.nextObject() as? URL {
+            let values = try item.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey])
+            guard values.isRegularFile == true else { continue }
+            if let modifiedAt = values.contentModificationDate, modifiedAt < expirationCutoff {
+                try? fileManager.removeItem(at: item)
+                continue
+            }
+            files.append(item)
+        }
+
+        var totalBytes = try files.reduce(UInt64.zero) { partialResult, url in
+            partialResult + (try Self.fileSize(at: url, fileManager: fileManager))
+        }
+        guard totalBytes > Constants.maxTotalBytes else { return }
+
+        let sorted = try files.sorted {
+            let lhs = try $0.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate ?? .distantPast
+            let rhs = try $1.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate ?? .distantPast
+            return lhs < rhs
+        }
+
+        for file in sorted where totalBytes > Constants.maxTotalBytes {
+            let fileBytes = try Self.fileSize(at: file, fileManager: fileManager)
+            try? fileManager.removeItem(at: file)
+            totalBytes = totalBytes > fileBytes ? totalBytes - fileBytes : 0
+        }
+    }
+
+    private func ensureDirectories() throws {
+        try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
+        for component in ["events", "crashes", "metrickit", "exports", "tmp"] {
+            try fileManager.createDirectory(
+                at: baseURL.appendingPathComponent(component, isDirectory: true),
+                withIntermediateDirectories: true
+            )
+        }
+    }
+
+    private func runtimeStateURL() -> URL {
+        baseURL.appendingPathComponent("runtime-state.json", isDirectory: false)
+    }
+
+    private func todayEventsURL() -> URL {
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd"
+        let fileName = "\(formatter.string(from: Date())).ndjson"
+        return baseURL
+            .appendingPathComponent("events", isDirectory: true)
+            .appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    private static func directorySize(at url: URL, fileManager: FileManager) throws -> UInt64 {
+        let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.isRegularFileKey, .fileSizeKey]
+        )
+        var total: UInt64 = 0
+        while let item = enumerator?.nextObject() as? URL {
+            let values = try item.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey])
+            guard values.isRegularFile == true else { continue }
+            total += UInt64(values.fileSize ?? 0)
+        }
+        return total
+    }
+
+    private static func fileSize(at url: URL, fileManager: FileManager) throws -> UInt64 {
+        let values = try url.resourceValues(forKeys: [.fileSizeKey])
+        return UInt64(values.fileSize ?? 0)
+    }
+
+    private func recentEvents(
+        from events: [FireAPMEventEnvelope],
+        matching types: Set<FireAPMEventType>
+    ) -> [FireAPMRecentEvent] {
+        events.filter { types.contains($0.eventType) }.prefix(4).map(Self.makeRecentEvent)
+    }
+
+    private static func makeRecentEvent(_ envelope: FireAPMEventEnvelope) -> FireAPMRecentEvent {
+        let title = envelope.payloadSummary["title"]
+            ?? envelope.payloadSummary["name"]
+            ?? envelope.eventType.rawValue
+        let subtitle = envelope.payloadSummary["subtitle"]
+            ?? envelope.payloadSummary["reason"]
+            ?? envelope.payloadSummary["error"]
+            ?? envelope.route
+        return FireAPMRecentEvent(
+            id: envelope.eventID,
+            type: envelope.eventType,
+            title: title,
+            subtitle: subtitle,
+            timestampUnixMs: envelope.capturedAtUnixMs
+        )
+    }
+}
+
+private struct FireAPMSupportBundleManifest: Codable {
+    let exportedAtUnixMs: UInt64
+    let scenePhase: String?
+    let buildInfo: FireAPMBuildInfo
+    let runtimeState: FireAPMRuntimeState?
+    let rustSupportBundleFileName: String?
+}

--- a/native/ios-app/Sources/FireAppSession/APM/FireAPMEventStore.swift
+++ b/native/ios-app/Sources/FireAppSession/APM/FireAPMEventStore.swift
@@ -7,6 +7,7 @@ actor FireAPMEventStore {
     }
 
     private let baseURL: URL
+    private let exportBaseURL: URL
     private let buildInfo: FireAPMBuildInfo
     private let fileManager: FileManager
     private let encoder: JSONEncoder
@@ -15,10 +16,13 @@ actor FireAPMEventStore {
     init(
         buildInfo: FireAPMBuildInfo,
         baseURL: URL? = nil,
+        exportBaseURL: URL? = nil,
         fileManager: FileManager = .default
     ) async throws {
         self.buildInfo = buildInfo
-        self.baseURL = try baseURL ?? Self.defaultBaseURL(fileManager: fileManager)
+        let resolvedBaseURL = try baseURL ?? Self.defaultBaseURL(fileManager: fileManager)
+        self.baseURL = resolvedBaseURL
+        self.exportBaseURL = exportBaseURL ?? Self.defaultExportBaseURL(baseURL: resolvedBaseURL)
         self.fileManager = fileManager
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
@@ -37,6 +41,12 @@ actor FireAPMEventStore {
         return supportURL
             .appendingPathComponent("Fire", isDirectory: true)
             .appendingPathComponent("ios-apm", isDirectory: true)
+    }
+
+    static func defaultExportBaseURL(baseURL: URL) -> URL {
+        baseURL
+            .deletingLastPathComponent()
+            .appendingPathComponent("ios-apm-exports", isDirectory: true)
     }
 
     func baseDirectoryURL() -> URL {
@@ -89,15 +99,27 @@ actor FireAPMEventStore {
     func updateRuntimeState(_ state: FireAPMRuntimeState) throws {
         try ensureDirectories()
         let data = try encoder.encode(state)
-        try data.write(to: runtimeStateURL(), options: .atomic)
+        try data.write(to: runtimeStateURL(launchID: state.launchID), options: .atomic)
     }
 
     func runtimeState(launchID: String) throws -> FireAPMRuntimeState {
-        let url = runtimeStateURL()
-        guard fileManager.fileExists(atPath: url.path) else {
-            return .empty(launchID: launchID)
+        if let state = try loadRuntimeState(forLaunchID: launchID) {
+            return state
         }
-        return try decoder.decode(FireAPMRuntimeState.self, from: Data(contentsOf: url))
+        if let state = try latestRuntimeState(excludingLaunchID: nil) {
+            return state
+        }
+        if let state = try legacyRuntimeState() {
+            return state
+        }
+        return .empty(launchID: launchID)
+    }
+
+    func previousRuntimeState(excludingLaunchID launchID: String) throws -> FireAPMRuntimeState? {
+        if let state = try latestRuntimeState(excludingLaunchID: launchID) {
+            return state
+        }
+        return try legacyRuntimeState()
     }
 
     func recentEvents(
@@ -143,8 +165,7 @@ actor FireAPMEventStore {
     ) throws -> FireAPMSupportBundleExport {
         let timestamp = FireAPMClock.nowUnixMs()
         let fileName = "fire-ios-apm-\(timestamp).firesupportbundle"
-        let exportURL = baseURL
-            .appendingPathComponent("exports", isDirectory: true)
+        let exportURL = exportBaseURL
             .appendingPathComponent(fileName, isDirectory: true)
 
         if fileManager.fileExists(atPath: exportURL.path) {
@@ -180,7 +201,6 @@ actor FireAPMEventStore {
         )
 
         let sizeBytes = try Self.directorySize(at: exportURL, fileManager: fileManager)
-        try pruneIfNeeded()
         return FireAPMSupportBundleExport(
             fileName: fileName,
             absoluteURL: exportURL,
@@ -243,6 +263,7 @@ actor FireAPMEventStore {
 
     private func pruneIfNeeded() throws {
         let expirationCutoff = Date().addingTimeInterval(-Constants.retentionWindow)
+        let legacyExportsURL = legacyExportsDirectoryURL().standardizedFileURL
         let enumerator = fileManager.enumerator(
             at: baseURL,
             includingPropertiesForKeys: [
@@ -255,7 +276,17 @@ actor FireAPMEventStore {
 
         var files: [URL] = []
         while let item = enumerator?.nextObject() as? URL {
-            let values = try item.resourceValues(forKeys: [.isRegularFileKey, .contentModificationDateKey])
+            let values = try item.resourceValues(
+                forKeys: [.isRegularFileKey, .isDirectoryKey, .contentModificationDateKey]
+            )
+            let standardizedItem = item.standardizedFileURL
+            if standardizedItem == legacyExportsURL
+                || standardizedItem.path.hasPrefix(legacyExportsURL.path + "/") {
+                if values.isDirectory == true {
+                    enumerator?.skipDescendants()
+                }
+                continue
+            }
             guard values.isRegularFile == true else { continue }
             if let modifiedAt = values.contentModificationDate, modifiedAt < expirationCutoff {
                 try? fileManager.removeItem(at: item)
@@ -284,16 +315,31 @@ actor FireAPMEventStore {
 
     private func ensureDirectories() throws {
         try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
-        for component in ["events", "crashes", "metrickit", "exports", "tmp"] {
+        for component in ["events", "crashes", "metrickit", "runtime-states", "tmp"] {
             try fileManager.createDirectory(
                 at: baseURL.appendingPathComponent(component, isDirectory: true),
                 withIntermediateDirectories: true
             )
         }
+        try fileManager.createDirectory(at: exportBaseURL, withIntermediateDirectories: true)
     }
 
-    private func runtimeStateURL() -> URL {
+    private func runtimeStatesDirectoryURL() -> URL {
+        baseURL.appendingPathComponent("runtime-states", isDirectory: true)
+    }
+
+    private func runtimeStateURL(launchID: String) -> URL {
+        runtimeStatesDirectoryURL()
+            .appendingPathComponent(launchID, isDirectory: false)
+            .appendingPathExtension("json")
+    }
+
+    private func legacyRuntimeStateURL() -> URL {
         baseURL.appendingPathComponent("runtime-state.json", isDirectory: false)
+    }
+
+    private func legacyExportsDirectoryURL() -> URL {
+        baseURL.appendingPathComponent("exports", isDirectory: true)
     }
 
     private func todayEventsURL() -> URL {
@@ -325,6 +371,47 @@ actor FireAPMEventStore {
     private static func fileSize(at url: URL, fileManager: FileManager) throws -> UInt64 {
         let values = try url.resourceValues(forKeys: [.fileSizeKey])
         return UInt64(values.fileSize ?? 0)
+    }
+
+    private func loadRuntimeState(forLaunchID launchID: String) throws -> FireAPMRuntimeState? {
+        let url = runtimeStateURL(launchID: launchID)
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        return try loadRuntimeState(at: url)
+    }
+
+    private func latestRuntimeState(excludingLaunchID launchID: String?) throws -> FireAPMRuntimeState? {
+        let files = try fileManager.contentsOfDirectory(
+            at: runtimeStatesDirectoryURL(),
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        )
+        .filter { $0.pathExtension == "json" }
+        .filter { launchID == nil || $0.deletingPathExtension().lastPathComponent != launchID }
+        .sorted { lhs, rhs in
+            let lhsDate = try? lhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+            let rhsDate = try? rhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate
+            if lhsDate != rhsDate {
+                return (lhsDate ?? .distantPast) > (rhsDate ?? .distantPast)
+            }
+            return lhs.lastPathComponent > rhs.lastPathComponent
+        }
+
+        for file in files {
+            if let state = try? loadRuntimeState(at: file) {
+                return state
+            }
+        }
+        return nil
+    }
+
+    private func legacyRuntimeState() throws -> FireAPMRuntimeState? {
+        let url = legacyRuntimeStateURL()
+        guard fileManager.fileExists(atPath: url.path) else { return nil }
+        return try loadRuntimeState(at: url)
+    }
+
+    private func loadRuntimeState(at url: URL) throws -> FireAPMRuntimeState {
+        try decoder.decode(FireAPMRuntimeState.self, from: Data(contentsOf: url))
     }
 
     private func recentEvents(

--- a/native/ios-app/Sources/FireAppSession/APM/FireAPMMainThreadStallMonitor.swift
+++ b/native/ios-app/Sources/FireAppSession/APM/FireAPMMainThreadStallMonitor.swift
@@ -1,0 +1,86 @@
+import Foundation
+import QuartzCore
+
+final class FireAPMMainThreadStallMonitor {
+    private enum Constants {
+        static let heartbeatInterval: TimeInterval = 0.25
+        static let stallThresholdMs: Double = 500
+        static let severeThresholdMs: Double = 2_000
+    }
+
+    private let monitorQueue = DispatchQueue(label: "com.fire.apm.main-thread-stall", qos: .utility)
+    private let onStall: @Sendable (_ durationMs: UInt64, _ severe: Bool) -> Void
+    private var monitorTimer: DispatchSourceTimer?
+    private var heartbeatScheduled = false
+    private var isSceneActive = true
+    private var lastHeartbeat = CACurrentMediaTime()
+    private var emittedStall = false
+    private var emittedSevere = false
+
+    init(onStall: @escaping @Sendable (_ durationMs: UInt64, _ severe: Bool) -> Void) {
+        self.onStall = onStall
+    }
+
+    func start() {
+        guard monitorTimer == nil else { return }
+        lastHeartbeat = CACurrentMediaTime()
+        scheduleHeartbeat()
+
+        let timer = DispatchSource.makeTimerSource(queue: monitorQueue)
+        timer.schedule(deadline: .now() + Constants.heartbeatInterval, repeating: Constants.heartbeatInterval)
+        timer.setEventHandler { [weak self] in
+            self?.checkForStall()
+        }
+        monitorTimer = timer
+        timer.resume()
+    }
+
+    func stop() {
+        monitorTimer?.cancel()
+        monitorTimer = nil
+        heartbeatScheduled = false
+    }
+
+    func setSceneActive(_ active: Bool) {
+        monitorQueue.async {
+            self.isSceneActive = active
+            if active {
+                self.lastHeartbeat = CACurrentMediaTime()
+                self.emittedStall = false
+                self.emittedSevere = false
+            }
+        }
+    }
+
+    private func scheduleHeartbeat() {
+        guard !heartbeatScheduled else { return }
+        heartbeatScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + Constants.heartbeatInterval) { [weak self] in
+            guard let self else { return }
+            self.monitorQueue.async {
+                self.lastHeartbeat = CACurrentMediaTime()
+                self.heartbeatScheduled = false
+                self.scheduleHeartbeat()
+            }
+        }
+    }
+
+    private func checkForStall() {
+        guard isSceneActive else { return }
+
+        let deltaMs = max((CACurrentMediaTime() - lastHeartbeat) * 1_000, 0)
+        if deltaMs >= Constants.stallThresholdMs {
+            let severe = deltaMs >= Constants.severeThresholdMs
+            if !emittedStall || (severe && !emittedSevere) {
+                onStall(UInt64(deltaMs.rounded()), severe)
+                emittedStall = true
+                if severe {
+                    emittedSevere = true
+                }
+            }
+        } else {
+            emittedStall = false
+            emittedSevere = false
+        }
+    }
+}

--- a/native/ios-app/Sources/FireAppSession/APM/FireAPMManager.swift
+++ b/native/ios-app/Sources/FireAppSession/APM/FireAPMManager.swift
@@ -62,6 +62,7 @@ final class FireAPMManager: NSObject {
     func start() {
         guard !started else { return }
         started = true
+        installCrashReporterIfNeeded()
 
         Task {
             await bootstrap()
@@ -177,14 +178,14 @@ final class FireAPMManager: NSObject {
     private func bootstrap() async {
         let previousState: FireAPMRuntimeState
         do {
-            previousState = try await storeValue().runtimeState(launchID: runtimeState.launchID)
+            previousState = try await storeValue().previousRuntimeState(
+                excludingLaunchID: runtimeState.launchID
+            ) ?? .empty(launchID: runtimeState.launchID)
         } catch {
             previousState = .empty(launchID: runtimeState.launchID)
         }
 
         await harvestPendingCrashReportIfNeeded(previousState: previousState)
-
-        runtimeState = .empty(launchID: UUID().uuidString.lowercased())
         await persistRuntimeState()
 
         registerObservers()
@@ -203,7 +204,6 @@ final class FireAPMManager: NSObject {
                 "git_sha": buildInfo.gitSha
             ]
         )
-        installCrashReporterIfNeeded()
     }
 
     private func beginSpan(

--- a/native/ios-app/Sources/FireAppSession/APM/FireAPMManager.swift
+++ b/native/ios-app/Sources/FireAppSession/APM/FireAPMManager.swift
@@ -1,0 +1,556 @@
+import Foundation
+import MetricKit
+import UIKit
+import os.log
+import os.signpost
+import CrashReporter
+
+@MainActor
+final class FireAPMManager: NSObject {
+    private struct ActiveSpan {
+        let id: String
+        let span: FireAPMSpanName
+        let signpostID: OSSignpostID
+        let startedAtUnixMs: UInt64
+        let metadata: [String: String]
+    }
+
+    static let shared = FireAPMManager()
+
+    private let buildInfo = FireAPMBuildInfo.current()
+    private lazy var storeTask = Task {
+        try await FireAPMEventStore(buildInfo: buildInfo)
+    }
+    private lazy var signpostLog = MXMetricManager.makeLogHandle(category: "fire.apm")
+    private lazy var metricSubscriber = FireAPMMetricSubscriber(
+        onMetricPayloads: { payloads in
+            Task { @MainActor in
+                await FireAPMManager.shared.handleMetricPayloads(payloads)
+            }
+        },
+        onDiagnosticPayloads: { payloads in
+            Task { @MainActor in
+                await FireAPMManager.shared.handleDiagnosticPayloads(payloads)
+            }
+        }
+    )
+    private lazy var resourceSampler = FireAPMResourceSampler { sample in
+        Task { @MainActor in
+            await FireAPMManager.shared.handleResourceSample(sample)
+        }
+    }
+    private lazy var stallMonitor = FireAPMMainThreadStallMonitor { durationMs, severe in
+        Task { @MainActor in
+            await FireAPMManager.shared.handleMainThreadStall(
+                durationMs: durationMs,
+                severe: severe
+            )
+        }
+    }
+
+    private var started = false
+    private var sessionLogger: FireHostLogger?
+    private var crashReporter: PLCrashReporter?
+    private var observers: [NSObjectProtocol] = []
+    private var runtimeState = FireAPMRuntimeState.empty(launchID: UUID().uuidString.lowercased())
+    private var latestResourceSample: FireAPMResourceSample?
+    private var lastRecordedResourceSampleAtUnixMs: UInt64 = 0
+    private var activeSpans: [String: ActiveSpan] = [:]
+    private var extendedLaunchTaskActive = false
+    private let launchMeasurementTaskID: MXLaunchTaskID = MXLaunchTaskID(rawValue: "app.launch.restore_session")
+
+    func start() {
+        guard !started else { return }
+        started = true
+
+        Task {
+            await bootstrap()
+        }
+    }
+
+    func attachSessionStore(_ sessionStore: FireSessionStore) async {
+        sessionLogger = sessionStore.makeLogger(target: "ios.apm")
+        let diagnosticSessionID = try? await sessionStore.diagnosticSessionID()
+        if runtimeState.diagnosticSessionID != diagnosticSessionID {
+            runtimeState.diagnosticSessionID = diagnosticSessionID
+            await persistRuntimeState()
+            await recordEvent(
+                type: .sessionLink,
+                privacy: .summary,
+                summary: [
+                    "title": "Attached shared diagnostics session",
+                    "diagnostic_session_id": diagnosticSessionID ?? "unknown"
+                ]
+            )
+        }
+    }
+
+    func setScenePhase(_ phase: String) {
+        guard runtimeState.scenePhase != phase else { return }
+        runtimeState.scenePhase = phase
+        resourceSampler.setSceneActive(phase == "active")
+        stallMonitor.setSceneActive(phase == "active")
+        if phase == "active" {
+            resourceSampler.boostSamplingWindow(duration: 20)
+        }
+        Task {
+            await persistRuntimeState()
+            await recordEvent(
+                type: .scenePhase,
+                privacy: .summary,
+                summary: [
+                    "title": "Scene phase changed",
+                    "phase": phase
+                ]
+            )
+        }
+    }
+
+    func setCurrentRoute(_ route: String?) {
+        guard runtimeState.currentRoute != route else { return }
+        runtimeState.currentRoute = route
+        Task {
+            await persistRuntimeState()
+            await recordEvent(
+                type: .route,
+                privacy: .summary,
+                summary: [
+                    "title": "Route changed",
+                    "route": route ?? "unknown"
+                ]
+            )
+        }
+    }
+
+    func recordBreadcrumb(level: String = "info", target: String, message: String) {
+        let breadcrumb = FireAPMBreadcrumb(level: level, target: target, message: message)
+        runtimeState.breadcrumbs.append(breadcrumb)
+        runtimeState.breadcrumbs = Array(runtimeState.breadcrumbs.suffix(50))
+        sessionLogger?.info("[\(level)] \(target): \(message)")
+        Task {
+            await persistRuntimeState()
+            await recordEvent(
+                type: .breadcrumb,
+                privacy: .summary,
+                summary: [
+                    "title": message,
+                    "target": target,
+                    "level": level
+                ]
+            )
+        }
+    }
+
+    func withSpan<T>(
+        _ span: FireAPMSpanName,
+        metadata: [String: String] = [:],
+        operation: () async throws -> T
+    ) async rethrows -> T {
+        let token = beginSpan(span, metadata: metadata)
+        do {
+            let value = try await operation()
+            endSpan(token, outcome: "succeeded", errorMessage: nil)
+            return value
+        } catch {
+            endSpan(token, outcome: "failed", errorMessage: error.localizedDescription)
+            throw error
+        }
+    }
+
+    func diagnosticsSummary() async throws -> FireAPMDiagnosticsSummary {
+        let store = try await storeValue()
+        return try await store.diagnosticsSummary(currentSample: latestResourceSample)
+    }
+
+    func exportSupportBundle(
+        rustSupportBundleURL: URL?,
+        scenePhase: String?
+    ) async throws -> FireAPMSupportBundleExport {
+        let store = try await storeValue()
+        return try await store.exportBundle(
+            rustSupportBundleURL: rustSupportBundleURL,
+            runtimeState: runtimeState,
+            scenePhase: scenePhase
+        )
+    }
+
+    private func bootstrap() async {
+        let previousState: FireAPMRuntimeState
+        do {
+            previousState = try await storeValue().runtimeState(launchID: runtimeState.launchID)
+        } catch {
+            previousState = .empty(launchID: runtimeState.launchID)
+        }
+
+        await harvestPendingCrashReportIfNeeded(previousState: previousState)
+
+        runtimeState = .empty(launchID: UUID().uuidString.lowercased())
+        await persistRuntimeState()
+
+        registerObservers()
+        metricSubscriber.start()
+        resourceSampler.start()
+        stallMonitor.start()
+        startExtendedLaunchMeasurementIfNeeded()
+
+        recordBreadcrumb(target: "ios.apm", message: "APM runtime started")
+        await recordEvent(
+            type: .launch,
+            privacy: .summary,
+            summary: [
+                "title": "APM launch started",
+                "bundle_id": buildInfo.bundleIdentifier,
+                "git_sha": buildInfo.gitSha
+            ]
+        )
+        installCrashReporterIfNeeded()
+    }
+
+    private func beginSpan(
+        _ span: FireAPMSpanName,
+        metadata: [String: String]
+    ) -> ActiveSpan {
+        let active = ActiveSpan(
+            id: UUID().uuidString.lowercased(),
+            span: span,
+            signpostID: OSSignpostID(log: signpostLog),
+            startedAtUnixMs: FireAPMClock.nowUnixMs(),
+            metadata: metadata
+        )
+        activeSpans[active.id] = active
+        runtimeState.activeSpans = activeSpans.values.map(\.span.rawValue).sorted()
+        resourceSampler.boostSamplingWindow()
+        os_signpost(.begin, log: signpostLog, name: span.signpostName, signpostID: active.signpostID)
+        Task {
+            await persistRuntimeState()
+        }
+        return active
+    }
+
+    private func endSpan(
+        _ active: ActiveSpan,
+        outcome: String,
+        errorMessage: String?
+    ) {
+        os_signpost(.end, log: signpostLog, name: active.span.signpostName, signpostID: active.signpostID)
+        activeSpans.removeValue(forKey: active.id)
+        runtimeState.activeSpans = activeSpans.values.map(\.span.rawValue).sorted()
+        Task {
+            await persistRuntimeState()
+            var summary = active.metadata
+            summary["title"] = active.span.rawValue
+            summary["name"] = active.span.rawValue
+            summary["outcome"] = outcome
+            summary["duration_ms"] = String(FireAPMClock.nowUnixMs().saturatingSubtract(active.startedAtUnixMs))
+            if let errorMessage, !errorMessage.isEmpty {
+                summary["error"] = errorMessage
+            }
+            await recordEvent(type: .span, privacy: .summary, summary: summary)
+            if active.span == .appLaunchRestoreSession {
+                finishExtendedLaunchMeasurementIfNeeded()
+            }
+        }
+    }
+
+    private func handleResourceSample(_ sample: FireAPMResourceSample) async {
+        latestResourceSample = sample
+        let shouldPersist = sample.timestampUnixMs.saturatingSubtract(lastRecordedResourceSampleAtUnixMs) >= 30_000
+            || (sample.cpuPercent ?? 0) >= 80
+            || (sample.physicalFootprintBytes ?? 0) >= 350 * 1024 * 1024
+        guard shouldPersist else { return }
+        lastRecordedResourceSampleAtUnixMs = sample.timestampUnixMs
+        await recordEvent(
+            type: .resourceSample,
+            privacy: .summary,
+            summary: [
+                "title": "Resource sample",
+                "cpu_percent": sample.cpuPercent.map { String(format: "%.1f", $0) } ?? "unknown",
+                "resident_bytes": sample.residentSizeBytes.map(String.init) ?? "unknown",
+                "physical_footprint_bytes": sample.physicalFootprintBytes.map(String.init) ?? "unknown",
+                "thermal_state": sample.thermalState
+            ]
+        )
+    }
+
+    private func handleMainThreadStall(durationMs: UInt64, severe: Bool) async {
+        await recordEvent(
+            type: .stall,
+            privacy: .summary,
+            summary: [
+                "title": severe ? "Severe main-thread stall" : "Main-thread stall",
+                "duration_ms": String(durationMs),
+                "severity": severe ? "severe" : "stall",
+                "route": runtimeState.currentRoute ?? "unknown"
+            ]
+        )
+    }
+
+    private func handleMetricPayloads(_ payloads: [MXMetricPayload]) async {
+        for payload in payloads {
+            let data = payload.jsonRepresentation()
+            let fileName = "metric-\(FireAPMClock.nowUnixMs())-\(UUID().uuidString.lowercased()).json"
+            await recordEvent(
+                type: .metrickitMetric,
+                privacy: .diagnostic,
+                summary: [
+                    "title": "MetricKit metric payload",
+                    "time_begin": ISO8601DateFormatter().string(from: payload.timeStampBegin),
+                    "time_end": ISO8601DateFormatter().string(from: payload.timeStampEnd),
+                    "latest_application_version": payload.latestApplicationVersion,
+                    "includes_multiple_application_versions": payload.includesMultipleApplicationVersions ? "true" : "false"
+                ],
+                payloadData: data,
+                payloadSubdirectory: "metrickit",
+                payloadFileName: fileName
+            )
+        }
+    }
+
+    private func handleDiagnosticPayloads(_ payloads: [MXDiagnosticPayload]) async {
+        for payload in payloads {
+            let data = payload.jsonRepresentation()
+            let fileName = "diagnostic-\(FireAPMClock.nowUnixMs())-\(UUID().uuidString.lowercased()).json"
+            await recordEvent(
+                type: .metrickitDiagnostic,
+                privacy: .diagnostic,
+                summary: [
+                    "title": "MetricKit diagnostic payload",
+                    "hang_count": payload.hangDiagnostics?.count.description ?? "0",
+                    "crash_count": payload.crashDiagnostics?.count.description ?? "0",
+                    "cpu_exception_count": payload.cpuExceptionDiagnostics?.count.description ?? "0",
+                    "disk_write_exception_count": payload.diskWriteExceptionDiagnostics?.count.description ?? "0"
+                ],
+                payloadData: data,
+                payloadSubdirectory: "metrickit",
+                payloadFileName: fileName
+            )
+        }
+    }
+
+    private func installCrashReporterIfNeeded() {
+        guard isCrashReporterEnabled else { return }
+        guard crashReporter == nil else { return }
+
+        let config = PLCrashReporterConfig(
+            signalHandlerType: .mach,
+            symbolicationStrategy: [],
+            shouldRegisterUncaughtExceptionHandler: true,
+            basePath: crashBasePath(),
+            maxReportBytes: 512 * 1024
+        )
+        guard let reporter = PLCrashReporter(configuration: config) else {
+            sessionLogger?.error("Failed to create PLCrashReporter instance")
+            return
+        }
+        do {
+            try reporter.enableAndReturnError()
+            crashReporter = reporter
+            sessionLogger?.info("PLCrashReporter enabled")
+        } catch {
+            sessionLogger?.error("Failed to enable PLCrashReporter: \(error.localizedDescription)")
+        }
+    }
+
+    private func harvestPendingCrashReportIfNeeded(previousState: FireAPMRuntimeState) async {
+        guard isCrashReporterEnabled else { return }
+        let config = PLCrashReporterConfig(
+            signalHandlerType: .mach,
+            symbolicationStrategy: [],
+            shouldRegisterUncaughtExceptionHandler: true,
+            basePath: crashBasePath(),
+            maxReportBytes: 512 * 1024
+        )
+        guard let reporter = PLCrashReporter(configuration: config) else {
+            return
+        }
+        guard reporter.hasPendingCrashReport() else { return }
+
+        do {
+            let data = try reporter.loadPendingCrashReportDataAndReturnError()
+            let report = try PLCrashReport(data: data)
+            let fileName = "crash-\(FireAPMClock.nowUnixMs())-\(UUID().uuidString.lowercased()).plcrash"
+            let summary = makeCrashSummary(report: report, previousState: previousState)
+            await recordEvent(
+                type: .crash,
+                privacy: .diagnostic,
+                launchID: previousState.launchID,
+                diagnosticSessionID: previousState.diagnosticSessionID,
+                route: previousState.currentRoute,
+                scenePhase: previousState.scenePhase,
+                summary: summary,
+                payloadData: data,
+                payloadSubdirectory: "crashes",
+                payloadFileName: fileName
+            )
+            try reporter.purgePendingCrashReportAndReturnError()
+        } catch {
+            await recordEvent(
+                type: .crash,
+                privacy: .summary,
+                launchID: previousState.launchID,
+                diagnosticSessionID: previousState.diagnosticSessionID,
+                route: previousState.currentRoute,
+                scenePhase: previousState.scenePhase,
+                summary: [
+                    "title": "Pending crash report could not be decoded",
+                    "error": error.localizedDescription
+                ]
+            )
+        }
+    }
+
+    private func makeCrashSummary(
+        report: PLCrashReport,
+        previousState: FireAPMRuntimeState
+    ) -> [String: String] {
+        var summary: [String: String] = [
+            "title": "Pending crash report",
+            "signal_name": report.signalInfo.name,
+            "signal_code": String(report.signalInfo.code),
+            "threads": String(report.threads.count),
+            "route": previousState.currentRoute ?? "unknown",
+            "breadcrumbs": String(previousState.breadcrumbs.count)
+        ]
+        if report.hasExceptionInfo {
+            summary["exception_name"] = report.exceptionInfo.exceptionName
+        }
+        return summary
+    }
+
+    private func persistRuntimeState() async {
+        runtimeState.lastUpdatedUnixMs = FireAPMClock.nowUnixMs()
+        do {
+            try await storeValue().updateRuntimeState(runtimeState)
+        } catch {
+            sessionLogger?.error("Failed to persist APM runtime state: \(error.localizedDescription)")
+        }
+    }
+
+    private func recordEvent(
+        type: FireAPMEventType,
+        privacy: FireAPMPrivacyTier,
+        launchID: String? = nil,
+        diagnosticSessionID: String? = nil,
+        route: String? = nil,
+        scenePhase: String? = nil,
+        summary: [String: String],
+        payloadData: Data? = nil,
+        payloadSubdirectory: String? = nil,
+        payloadFileName: String? = nil
+    ) async {
+        do {
+            _ = try await storeValue().record(
+                eventType: type,
+                launchID: launchID ?? runtimeState.launchID,
+                diagnosticSessionID: diagnosticSessionID ?? runtimeState.diagnosticSessionID,
+                route: route ?? runtimeState.currentRoute,
+                scenePhase: scenePhase ?? runtimeState.scenePhase,
+                privacyTier: privacy,
+                payloadSummary: summary,
+                payloadData: payloadData,
+                payloadSubdirectory: payloadSubdirectory,
+                payloadFileName: payloadFileName
+            )
+        } catch {
+            sessionLogger?.error("Failed to record APM event \(type.rawValue): \(error.localizedDescription)")
+        }
+    }
+
+    private func registerObservers() {
+        let center = NotificationCenter.default
+        observers.append(
+            center.addObserver(
+                forName: UIApplication.didReceiveMemoryWarningNotification,
+                object: nil,
+                queue: nil
+            ) { _ in
+                Task { @MainActor in
+                    await FireAPMManager.shared.handleLowMemoryWarning()
+                }
+            }
+        )
+    }
+
+    private func handleLowMemoryWarning() async {
+        resourceSampler.boostSamplingWindow(duration: 30)
+        await recordEvent(
+            type: .memoryWarning,
+            privacy: .summary,
+            summary: [
+                "title": "UIApplication memory warning",
+                "route": runtimeState.currentRoute ?? "unknown"
+            ]
+        )
+    }
+
+    private func storeValue() async throws -> FireAPMEventStore {
+        try await storeTask.value
+    }
+
+    private func startExtendedLaunchMeasurementIfNeeded() {
+        guard !extendedLaunchTaskActive else { return }
+        do {
+            try MXMetricManager.extendLaunchMeasurement(forTaskID: launchMeasurementTaskID)
+            extendedLaunchTaskActive = true
+        } catch {
+            sessionLogger?.warning("Failed to extend launch measurement: \(error.localizedDescription)")
+        }
+    }
+
+    private func finishExtendedLaunchMeasurementIfNeeded() {
+        guard extendedLaunchTaskActive else { return }
+        do {
+            try MXMetricManager.finishExtendedLaunchMeasurement(forTaskID: launchMeasurementTaskID)
+        } catch {
+            sessionLogger?.warning("Failed to finish launch measurement: \(error.localizedDescription)")
+        }
+        extendedLaunchTaskActive = false
+    }
+
+    private func crashBasePath() -> String {
+        (try? FireAPMEventStore.defaultBaseURL().appendingPathComponent("tmp", isDirectory: true).path)
+            ?? NSTemporaryDirectory()
+    }
+
+    private var isCrashReporterEnabled: Bool {
+        #if DEBUG
+        return false
+        #else
+        return ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] == nil
+        #endif
+    }
+}
+
+private final class FireAPMMetricSubscriber: NSObject, MXMetricManagerSubscriber {
+    private let onMetricPayloads: @Sendable ([MXMetricPayload]) -> Void
+    private let onDiagnosticPayloads: @Sendable ([MXDiagnosticPayload]) -> Void
+    private var started = false
+
+    init(
+        onMetricPayloads: @escaping @Sendable ([MXMetricPayload]) -> Void,
+        onDiagnosticPayloads: @escaping @Sendable ([MXDiagnosticPayload]) -> Void
+    ) {
+        self.onMetricPayloads = onMetricPayloads
+        self.onDiagnosticPayloads = onDiagnosticPayloads
+    }
+
+    func start() {
+        guard !started else { return }
+        started = true
+        MXMetricManager.shared.add(self)
+    }
+
+    func didReceive(_ payloads: [MXMetricPayload]) {
+        onMetricPayloads(payloads)
+    }
+
+    func didReceive(_ payloads: [MXDiagnosticPayload]) {
+        onDiagnosticPayloads(payloads)
+    }
+}
+
+private extension UInt64 {
+    func saturatingSubtract(_ other: UInt64) -> UInt64 {
+        self >= other ? self - other : 0
+    }
+}

--- a/native/ios-app/Sources/FireAppSession/APM/FireAPMModels.swift
+++ b/native/ios-app/Sources/FireAppSession/APM/FireAPMModels.swift
@@ -1,0 +1,203 @@
+import Foundation
+
+enum FireAPMPrivacyTier: String, Codable {
+    case summary
+    case diagnostic
+}
+
+enum FireAPMEventType: String, Codable, CaseIterable {
+    case launch = "launch"
+    case sessionLink = "session_link"
+    case scenePhase = "scene_phase"
+    case route = "route"
+    case breadcrumb = "breadcrumb"
+    case span = "span"
+    case crash = "crash"
+    case metrickitMetric = "metrickit_metric"
+    case metrickitDiagnostic = "metrickit_diagnostic"
+    case resourceSample = "resource_sample"
+    case memoryWarning = "memory_warning"
+    case stall = "stall"
+}
+
+struct FireAPMBuildInfo: Codable, Equatable {
+    let appVersion: String
+    let buildNumber: String
+    let bundleIdentifier: String
+    let gitSha: String
+
+    static func current(bundle: Bundle = .main) -> FireAPMBuildInfo {
+        let appVersion = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+            ?? "unknown"
+        let buildNumber = bundle.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String
+            ?? "unknown"
+        let bundleIdentifier = bundle.bundleIdentifier ?? "unknown"
+        let gitSha = bundle.object(forInfoDictionaryKey: "FireGitSha") as? String
+            ?? "unknown"
+        return FireAPMBuildInfo(
+            appVersion: appVersion,
+            buildNumber: buildNumber,
+            bundleIdentifier: bundleIdentifier,
+            gitSha: gitSha
+        )
+    }
+}
+
+struct FireAPMEventEnvelope: Codable, Identifiable, Equatable {
+    let eventID: String
+    let eventType: FireAPMEventType
+    let capturedAtUnixMs: UInt64
+    let launchID: String?
+    let diagnosticSessionID: String?
+    let appVersion: String
+    let buildNumber: String
+    let gitSha: String
+    let route: String?
+    let scenePhase: String?
+    let privacyTier: FireAPMPrivacyTier
+    let payloadPath: String?
+    let payloadSummary: [String: String]
+
+    var id: String { eventID }
+
+    enum CodingKeys: String, CodingKey {
+        case eventID = "event_id"
+        case eventType = "event_type"
+        case capturedAtUnixMs = "captured_at_unix_ms"
+        case launchID = "launch_id"
+        case diagnosticSessionID = "diagnostic_session_id"
+        case appVersion = "app_version"
+        case buildNumber = "build_number"
+        case gitSha = "git_sha"
+        case route
+        case scenePhase = "scene_phase"
+        case privacyTier = "privacy_tier"
+        case payloadPath = "payload_path"
+        case payloadSummary = "payload_summary"
+    }
+}
+
+struct FireAPMBreadcrumb: Codable, Equatable, Identifiable {
+    let id: String
+    let timestampUnixMs: UInt64
+    let level: String
+    let target: String
+    let message: String
+
+    init(
+        id: String = UUID().uuidString.lowercased(),
+        timestampUnixMs: UInt64 = FireAPMClock.nowUnixMs(),
+        level: String,
+        target: String,
+        message: String
+    ) {
+        self.id = id
+        self.timestampUnixMs = timestampUnixMs
+        self.level = level
+        self.target = target
+        self.message = message
+    }
+}
+
+struct FireAPMRuntimeState: Codable, Equatable {
+    var launchID: String
+    var diagnosticSessionID: String?
+    var currentRoute: String?
+    var scenePhase: String?
+    var activeSpans: [String]
+    var breadcrumbs: [FireAPMBreadcrumb]
+    var lastUpdatedUnixMs: UInt64
+
+    static func empty(launchID: String) -> FireAPMRuntimeState {
+        FireAPMRuntimeState(
+            launchID: launchID,
+            diagnosticSessionID: nil,
+            currentRoute: nil,
+            scenePhase: nil,
+            activeSpans: [],
+            breadcrumbs: [],
+            lastUpdatedUnixMs: FireAPMClock.nowUnixMs()
+        )
+    }
+}
+
+struct FireAPMResourceSample: Codable, Equatable {
+    let timestampUnixMs: UInt64
+    let cpuPercent: Double?
+    let residentSizeBytes: UInt64?
+    let physicalFootprintBytes: UInt64?
+    let thermalState: String
+    let batteryState: String
+    let lowPowerModeEnabled: Bool
+}
+
+struct FireAPMRecentEvent: Identifiable, Equatable {
+    let id: String
+    let type: FireAPMEventType
+    let title: String
+    let subtitle: String?
+    let timestampUnixMs: UInt64
+}
+
+struct FireAPMDiagnosticsSummary: Equatable {
+    let currentSample: FireAPMResourceSample?
+    let recentCrashes: [FireAPMRecentEvent]
+    let recentMetricPayloads: [FireAPMRecentEvent]
+    let recentDiagnostics: [FireAPMRecentEvent]
+    let recentStalls: [FireAPMRecentEvent]
+    let recentEvents: [FireAPMRecentEvent]
+
+    static let empty = FireAPMDiagnosticsSummary(
+        currentSample: nil,
+        recentCrashes: [],
+        recentMetricPayloads: [],
+        recentDiagnostics: [],
+        recentStalls: [],
+        recentEvents: []
+    )
+}
+
+struct FireAPMSupportBundleExport: Equatable {
+    let fileName: String
+    let absoluteURL: URL
+    let sizeBytes: UInt64
+    let createdAtUnixMs: UInt64
+}
+
+enum FireAPMSpanName: String, CaseIterable {
+    case appLaunchRestoreSession = "app.launch.restore_session"
+    case authLoginSync = "auth.login.sync"
+    case bootstrapRefresh = "bootstrap.refresh"
+    case feedLatestInitialLoad = "feed.latest.initial_load"
+    case topicDetailInitialLoad = "topic.detail.initial_load"
+    case topicReplySubmit = "topic.reply.submit"
+    case notificationsRefresh = "notifications.refresh"
+    case messageBusStart = "messagebus.start"
+
+    var signpostName: StaticString {
+        switch self {
+        case .appLaunchRestoreSession:
+            "app.launch.restore_session"
+        case .authLoginSync:
+            "auth.login.sync"
+        case .bootstrapRefresh:
+            "bootstrap.refresh"
+        case .feedLatestInitialLoad:
+            "feed.latest.initial_load"
+        case .topicDetailInitialLoad:
+            "topic.detail.initial_load"
+        case .topicReplySubmit:
+            "topic.reply.submit"
+        case .notificationsRefresh:
+            "notifications.refresh"
+        case .messageBusStart:
+            "messagebus.start"
+        }
+    }
+}
+
+enum FireAPMClock {
+    static func nowUnixMs(date: Date = Date()) -> UInt64 {
+        UInt64(max(date.timeIntervalSince1970 * 1_000, 0))
+    }
+}

--- a/native/ios-app/Sources/FireAppSession/APM/FireAPMResourceSampler.swift
+++ b/native/ios-app/Sources/FireAppSession/APM/FireAPMResourceSampler.swift
@@ -1,0 +1,168 @@
+import Foundation
+import UIKit
+
+#if canImport(Darwin)
+import Darwin.Mach
+#endif
+
+final class FireAPMResourceSampler {
+    private enum Constants {
+        static let defaultInterval: TimeInterval = 5
+        static let boostedInterval: TimeInterval = 1
+        static let bootstrapBoostWindow: TimeInterval = 60
+    }
+
+    private let queue = DispatchQueue(label: "com.fire.apm.resource-sampler", qos: .utility)
+    private let onSample: @Sendable (FireAPMResourceSample) -> Void
+    private var timer: DispatchSourceTimer?
+    private var isSceneActive = true
+    private var boostedUntil = Date().addingTimeInterval(Constants.bootstrapBoostWindow)
+
+    init(onSample: @escaping @Sendable (FireAPMResourceSample) -> Void) {
+        self.onSample = onSample
+    }
+
+    func start() {
+        guard timer == nil else { return }
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        let timer = DispatchSource.makeTimerSource(queue: queue)
+        timer.schedule(deadline: .now() + 1, repeating: 1)
+        timer.setEventHandler { [weak self] in
+            self?.tick()
+        }
+        self.timer = timer
+        timer.resume()
+    }
+
+    func stop() {
+        timer?.cancel()
+        timer = nil
+    }
+
+    func setSceneActive(_ active: Bool) {
+        queue.async {
+            self.isSceneActive = active
+        }
+    }
+
+    func boostSamplingWindow(duration: TimeInterval = Constants.bootstrapBoostWindow) {
+        queue.async {
+            self.boostedUntil = max(self.boostedUntil, Date().addingTimeInterval(duration))
+        }
+    }
+
+    private func tick() {
+        guard isSceneActive else { return }
+
+        let now = Date()
+        let interval = now < boostedUntil ? Constants.boostedInterval : Constants.defaultInterval
+        timer?.schedule(deadline: .now() + interval, repeating: interval)
+
+        let sample = FireAPMResourceSample(
+            timestampUnixMs: FireAPMClock.nowUnixMs(date: now),
+            cpuPercent: Self.currentCPUPercent(),
+            residentSizeBytes: Self.currentResidentSize(),
+            physicalFootprintBytes: Self.currentPhysicalFootprint(),
+            thermalState: Self.thermalStateDescription(ProcessInfo.processInfo.thermalState),
+            batteryState: Self.batteryStateDescription(UIDevice.current.batteryState),
+            lowPowerModeEnabled: ProcessInfo.processInfo.isLowPowerModeEnabled
+        )
+        onSample(sample)
+    }
+
+    private static func currentResidentSize() -> UInt64? {
+        var info = mach_task_basic_info()
+        var count = mach_msg_type_number_t(MemoryLayout<mach_task_basic_info>.size) / 4
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(MACH_TASK_BASIC_INFO), $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            return nil
+        }
+        return UInt64(info.resident_size)
+    }
+
+    private static func currentPhysicalFootprint() -> UInt64? {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(
+            MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<natural_t>.size
+        )
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else {
+            return nil
+        }
+        return UInt64(info.phys_footprint)
+    }
+
+    private static func currentCPUPercent() -> Double? {
+        var threadList: thread_act_array_t?
+        var threadCount: mach_msg_type_number_t = 0
+        let result = task_threads(mach_task_self_, &threadList, &threadCount)
+        guard result == KERN_SUCCESS, let threadList else {
+            return nil
+        }
+
+        defer {
+            vm_deallocate(
+                mach_task_self_,
+                vm_address_t(bitPattern: threadList),
+                vm_size_t(threadCount) * vm_size_t(MemoryLayout<thread_t>.stride)
+            )
+        }
+
+        var totalCPU: Double = 0
+        for index in 0..<Int(threadCount) {
+            var info = thread_basic_info()
+            var infoCount = mach_msg_type_number_t(THREAD_INFO_MAX)
+            let thread = threadList[index]
+            let infoResult = withUnsafeMutablePointer(to: &info) { pointer in
+                pointer.withMemoryRebound(to: integer_t.self, capacity: Int(infoCount)) {
+                    thread_info(thread, thread_flavor_t(THREAD_BASIC_INFO), $0, &infoCount)
+                }
+            }
+            guard infoResult == KERN_SUCCESS else {
+                continue
+            }
+            if (info.flags & TH_FLAGS_IDLE) == 0 {
+                totalCPU += Double(info.cpu_usage) / Double(TH_USAGE_SCALE) * 100.0
+            }
+        }
+        return totalCPU
+    }
+
+    private static func thermalStateDescription(_ state: ProcessInfo.ThermalState) -> String {
+        switch state {
+        case .nominal:
+            return "nominal"
+        case .fair:
+            return "fair"
+        case .serious:
+            return "serious"
+        case .critical:
+            return "critical"
+        @unknown default:
+            return "unknown"
+        }
+    }
+
+    private static func batteryStateDescription(_ state: UIDevice.BatteryState) -> String {
+        switch state {
+        case .unknown:
+            return "unknown"
+        case .unplugged:
+            return "unplugged"
+        case .charging:
+            return "charging"
+        case .full:
+            return "full"
+        @unknown default:
+            return "unknown"
+        }
+    }
+}

--- a/native/ios-app/Tests/Unit/FireAPMEventStoreTests.swift
+++ b/native/ios-app/Tests/Unit/FireAPMEventStoreTests.swift
@@ -2,21 +2,23 @@ import XCTest
 @testable import Fire
 
 final class FireAPMEventStoreTests: XCTestCase {
+    private let buildInfo = FireAPMBuildInfo(
+        appVersion: "1.0.0",
+        buildNumber: "42",
+        bundleIdentifier: "com.fire.tests",
+        gitSha: "deadbeef"
+    )
+
     func testEventStorePersistsEventsAndBuildsSummary() async throws {
         let fileManager = FileManager.default
-        let rootURL = fileManager.temporaryDirectory
+        let sandboxURL = fileManager.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        defer { try? fileManager.removeItem(at: rootURL) }
+        defer { try? fileManager.removeItem(at: sandboxURL) }
 
-        let store = try await FireAPMEventStore(
-            buildInfo: FireAPMBuildInfo(
-                appVersion: "1.0.0",
-                buildNumber: "42",
-                bundleIdentifier: "com.fire.tests",
-                gitSha: "deadbeef"
-            ),
-            baseURL: rootURL,
-            fileManager: fileManager
+        let store = try await makeStore(
+            fileManager: fileManager,
+            baseURL: sandboxURL.appendingPathComponent("ios-apm", isDirectory: true),
+            exportBaseURL: sandboxURL.appendingPathComponent("ios-apm-exports", isDirectory: true)
         )
 
         _ = try await store.record(
@@ -64,19 +66,16 @@ final class FireAPMEventStoreTests: XCTestCase {
 
     func testEventStoreRoundTripsRuntimeStateAndExportsBundle() async throws {
         let fileManager = FileManager.default
-        let rootURL = fileManager.temporaryDirectory
+        let sandboxURL = fileManager.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        defer { try? fileManager.removeItem(at: rootURL) }
+        defer { try? fileManager.removeItem(at: sandboxURL) }
+        let rootURL = sandboxURL.appendingPathComponent("ios-apm", isDirectory: true)
+        let exportBaseURL = sandboxURL.appendingPathComponent("ios-apm-exports", isDirectory: true)
 
-        let store = try await FireAPMEventStore(
-            buildInfo: FireAPMBuildInfo(
-                appVersion: "1.0.0",
-                buildNumber: "42",
-                bundleIdentifier: "com.fire.tests",
-                gitSha: "deadbeef"
-            ),
+        let store = try await makeStore(
+            fileManager: fileManager,
             baseURL: rootURL,
-            fileManager: fileManager
+            exportBaseURL: exportBaseURL
         )
 
         let runtimeState = FireAPMRuntimeState(
@@ -103,5 +102,135 @@ final class FireAPMEventStoreTests: XCTestCase {
         )
         XCTAssertTrue(fileManager.fileExists(atPath: export.absoluteURL.path))
         XCTAssertGreaterThan(export.sizeBytes, 0)
+        XCTAssertTrue(export.absoluteURL.path.hasPrefix(exportBaseURL.path + "/"))
+        XCTAssertFalse(export.absoluteURL.path.hasPrefix(rootURL.path + "/"))
+    }
+
+    func testPreviousRuntimeStateSkipsCurrentLaunchState() async throws {
+        let fileManager = FileManager.default
+        let sandboxURL = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? fileManager.removeItem(at: sandboxURL) }
+
+        let store = try await makeStore(
+            fileManager: fileManager,
+            baseURL: sandboxURL.appendingPathComponent("ios-apm", isDirectory: true),
+            exportBaseURL: sandboxURL.appendingPathComponent("ios-apm-exports", isDirectory: true)
+        )
+
+        let previousState = FireAPMRuntimeState(
+            launchID: "launch-prev",
+            diagnosticSessionID: "session-prev",
+            currentRoute: "tab.profile",
+            scenePhase: "background",
+            activeSpans: [],
+            breadcrumbs: [],
+            lastUpdatedUnixMs: 1
+        )
+        let currentState = FireAPMRuntimeState(
+            launchID: "launch-current",
+            diagnosticSessionID: "session-current",
+            currentRoute: "tab.home",
+            scenePhase: "active",
+            activeSpans: [],
+            breadcrumbs: [],
+            lastUpdatedUnixMs: 2
+        )
+
+        try await store.updateRuntimeState(previousState)
+        try await store.updateRuntimeState(currentState)
+
+        let previousRuntimeState = try await store.previousRuntimeState(
+            excludingLaunchID: "launch-current"
+        )
+        let restoredPrevious = try XCTUnwrap(previousRuntimeState)
+        XCTAssertEqual(restoredPrevious.launchID, "launch-prev")
+        XCTAssertEqual(restoredPrevious.diagnosticSessionID, "session-prev")
+        XCTAssertEqual(restoredPrevious.currentRoute, "tab.profile")
+    }
+
+    func testExportBundleDoesNotPruneLiveDiagnosticsOrReturnedBundle() async throws {
+        let fileManager = FileManager.default
+        let sandboxURL = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? fileManager.removeItem(at: sandboxURL) }
+        let rootURL = sandboxURL.appendingPathComponent("ios-apm", isDirectory: true)
+        let exportBaseURL = sandboxURL.appendingPathComponent("ios-apm-exports", isDirectory: true)
+
+        let store = try await makeStore(
+            fileManager: fileManager,
+            baseURL: rootURL,
+            exportBaseURL: exportBaseURL
+        )
+
+        _ = try await store.record(
+            eventType: .crash,
+            launchID: "launch-3",
+            diagnosticSessionID: "session-3",
+            route: "topic.detail.3",
+            scenePhase: "active",
+            privacyTier: .diagnostic,
+            payloadSummary: ["title": "Pending crash report"],
+            payloadData: Data(repeating: 0x41, count: 15 * 1024 * 1024),
+            payloadSubdirectory: "crashes",
+            payloadFileName: "crash.plcrash"
+        )
+        _ = try await store.record(
+            eventType: .metrickitDiagnostic,
+            launchID: "launch-3",
+            diagnosticSessionID: "session-3",
+            route: "topic.detail.3",
+            scenePhase: "active",
+            privacyTier: .diagnostic,
+            payloadSummary: ["title": "MetricKit payload"],
+            payloadData: Data(repeating: 0x42, count: 14 * 1024 * 1024),
+            payloadSubdirectory: "metrickit",
+            payloadFileName: "metric.json"
+        )
+
+        let rustBundleURL = sandboxURL.appendingPathComponent("rust-support.firesupportbundle")
+        try Data(repeating: 0x43, count: 10 * 1024 * 1024).write(to: rustBundleURL, options: .atomic)
+
+        let export = try await store.exportBundle(
+            rustSupportBundleURL: rustBundleURL,
+            runtimeState: nil,
+            scenePhase: "active"
+        )
+
+        XCTAssertTrue(fileManager.fileExists(atPath: rootURL.appendingPathComponent("crashes/crash.plcrash").path))
+        XCTAssertTrue(fileManager.fileExists(atPath: rootURL.appendingPathComponent("metrickit/metric.json").path))
+        XCTAssertTrue(
+            fileManager.fileExists(
+                atPath: export.absoluteURL.appendingPathComponent("crashes/crash.plcrash").path
+            )
+        )
+        XCTAssertTrue(
+            fileManager.fileExists(
+                atPath: export.absoluteURL.appendingPathComponent("metrickit/metric.json").path
+            )
+        )
+        XCTAssertTrue(
+            fileManager.fileExists(
+                atPath: export.absoluteURL.appendingPathComponent(rustBundleURL.lastPathComponent).path
+            )
+        )
+        XCTAssertTrue(
+            fileManager.fileExists(
+                atPath: export.absoluteURL.appendingPathComponent("manifest.json").path
+            )
+        )
+    }
+
+    private func makeStore(
+        fileManager: FileManager,
+        baseURL: URL,
+        exportBaseURL: URL
+    ) async throws -> FireAPMEventStore {
+        try await FireAPMEventStore(
+            buildInfo: buildInfo,
+            baseURL: baseURL,
+            exportBaseURL: exportBaseURL,
+            fileManager: fileManager
+        )
     }
 }

--- a/native/ios-app/Tests/Unit/FireAPMEventStoreTests.swift
+++ b/native/ios-app/Tests/Unit/FireAPMEventStoreTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import Fire
+
+final class FireAPMEventStoreTests: XCTestCase {
+    func testEventStorePersistsEventsAndBuildsSummary() async throws {
+        let fileManager = FileManager.default
+        let rootURL = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? fileManager.removeItem(at: rootURL) }
+
+        let store = try await FireAPMEventStore(
+            buildInfo: FireAPMBuildInfo(
+                appVersion: "1.0.0",
+                buildNumber: "42",
+                bundleIdentifier: "com.fire.tests",
+                gitSha: "deadbeef"
+            ),
+            baseURL: rootURL,
+            fileManager: fileManager
+        )
+
+        _ = try await store.record(
+            eventType: .crash,
+            launchID: "launch-1",
+            diagnosticSessionID: "session-1",
+            route: "topic.detail.1",
+            scenePhase: "active",
+            privacyTier: .diagnostic,
+            payloadSummary: [
+                "title": "Pending crash report",
+                "signal_name": "SIGABRT"
+            ],
+            payloadData: Data("boom".utf8),
+            payloadSubdirectory: "crashes",
+            payloadFileName: "crash.plcrash"
+        )
+        _ = try await store.record(
+            eventType: .stall,
+            launchID: "launch-1",
+            diagnosticSessionID: "session-1",
+            route: "tab.home",
+            scenePhase: "active",
+            privacyTier: .summary,
+            payloadSummary: [
+                "title": "Main-thread stall",
+                "duration_ms": "900"
+            ]
+        )
+
+        let summary = try await store.diagnosticsSummary(currentSample: FireAPMResourceSample(
+            timestampUnixMs: 1,
+            cpuPercent: 12.5,
+            residentSizeBytes: 1_024,
+            physicalFootprintBytes: 2_048,
+            thermalState: "nominal",
+            batteryState: "charging",
+            lowPowerModeEnabled: false
+        ))
+
+        XCTAssertEqual(summary.recentCrashes.count, 1)
+        XCTAssertEqual(summary.recentStalls.count, 1)
+        XCTAssertEqual(summary.currentSample?.physicalFootprintBytes, 2_048)
+    }
+
+    func testEventStoreRoundTripsRuntimeStateAndExportsBundle() async throws {
+        let fileManager = FileManager.default
+        let rootURL = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? fileManager.removeItem(at: rootURL) }
+
+        let store = try await FireAPMEventStore(
+            buildInfo: FireAPMBuildInfo(
+                appVersion: "1.0.0",
+                buildNumber: "42",
+                bundleIdentifier: "com.fire.tests",
+                gitSha: "deadbeef"
+            ),
+            baseURL: rootURL,
+            fileManager: fileManager
+        )
+
+        let runtimeState = FireAPMRuntimeState(
+            launchID: "launch-2",
+            diagnosticSessionID: "session-2",
+            currentRoute: "tab.home",
+            scenePhase: "active",
+            activeSpans: ["feed.latest.initial_load"],
+            breadcrumbs: [
+                FireAPMBreadcrumb(level: "info", target: "tests", message: "hello")
+            ],
+            lastUpdatedUnixMs: 2
+        )
+        try await store.updateRuntimeState(runtimeState)
+
+        let restored = try await store.runtimeState(launchID: "unused")
+        XCTAssertEqual(restored.launchID, "launch-2")
+        XCTAssertEqual(restored.currentRoute, "tab.home")
+
+        let export = try await store.exportBundle(
+            rustSupportBundleURL: nil,
+            runtimeState: restored,
+            scenePhase: "active"
+        )
+        XCTAssertTrue(fileManager.fileExists(atPath: export.absoluteURL.path))
+        XCTAssertGreaterThan(export.sizeBytes, 0)
+    }
+}

--- a/native/ios-app/project.yml
+++ b/native/ios-app/project.yml
@@ -1,6 +1,10 @@
 name: Fire
 options:
   minimumXcodeGenVersion: 2.45.3
+packages:
+  CrashReporter:
+    url: https://github.com/microsoft/plcrashreporter.git
+    exactVersion: 1.12.2
 fileGroups:
   - Configs/Fire-Debug.xcconfig
   - Configs/Fire-Local-Debug.example.xcconfig
@@ -42,16 +46,20 @@ targets:
       - sdk: Foundation.framework
       - sdk: CoreFoundation.framework
       - sdk: libiconv.tbd
+      - package: CrashReporter
+        product: CrashReporter
     settings:
       base:
         CODE_SIGN_STYLE: $(FIRE_CODE_SIGN_STYLE)
         DEVELOPMENT_TEAM: $(FIRE_DEVELOPMENT_TEAM)
+        FIRE_GIT_SHA: $(FIRE_GIT_SHA)
         PRODUCT_BUNDLE_IDENTIFIER: $(FIRE_PRODUCT_BUNDLE_IDENTIFIER)
         PROVISIONING_PROFILE_SPECIFIER: $(FIRE_PROVISIONING_PROFILE_SPECIFIER)
         PRODUCT_NAME: Fire
         TARGETED_DEVICE_FAMILY: "1,2"
         GENERATE_INFOPLIST_FILE: YES
         INFOPLIST_KEY_CFBundleDisplayName: Fire
+        INFOPLIST_KEY_FireGitSha: $(FIRE_GIT_SHA)
         INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers:
           - com.fire.app.ios.notification-alert-refresh
         INFOPLIST_KEY_UIBackgroundModes:

--- a/scripts/ios/archive_release.sh
+++ b/scripts/ios/archive_release.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+IOS_DIR="$ROOT_DIR/native/ios-app"
+SCHEME="${SCHEME:-Fire}"
+CONFIGURATION="${CONFIGURATION:-Release}"
+DESTINATION="${DESTINATION:-generic/platform=iOS}"
+STAMP="$(date +"%Y%m%d-%H%M%S")"
+OUT_ROOT="${OUT_ROOT:-$ROOT_DIR/artifacts/ios-release/$STAMP}"
+ARCHIVE_PATH="${ARCHIVE_PATH:-$OUT_ROOT/Fire.xcarchive}"
+DERIVED_DATA_PATH="${DERIVED_DATA_PATH:-$OUT_ROOT/DerivedData}"
+CODE_SIGNING_ALLOWED="${CODE_SIGNING_ALLOWED:-NO}"
+GIT_SHA="${FIRE_GIT_SHA:-$(git -C "$ROOT_DIR" rev-parse HEAD)}"
+METADATA_PATH="$OUT_ROOT/build-metadata.json"
+DSYMS_DIR="$OUT_ROOT/dSYMs"
+
+mkdir -p "$OUT_ROOT"
+
+if ! command -v xcodegen >/dev/null 2>&1; then
+  echo "xcodegen is required but not installed" >&2
+  exit 1
+fi
+
+pushd "$ROOT_DIR" >/dev/null
+git submodule update --init --recursive
+./scripts/check_clean_submodules.sh
+popd >/dev/null
+
+pushd "$ROOT_DIR" >/dev/null
+xcodegen generate --spec native/ios-app/project.yml
+popd >/dev/null
+
+xcodebuild \
+  -project "$IOS_DIR/Fire.xcodeproj" \
+  -scheme "$SCHEME" \
+  -configuration "$CONFIGURATION" \
+  -destination "$DESTINATION" \
+  -archivePath "$ARCHIVE_PATH" \
+  -derivedDataPath "$DERIVED_DATA_PATH" \
+  CODE_SIGNING_ALLOWED="$CODE_SIGNING_ALLOWED" \
+  FIRE_GIT_SHA="$GIT_SHA" \
+  archive
+
+mkdir -p "$DSYMS_DIR"
+if [[ -d "$ARCHIVE_PATH/dSYMs" ]]; then
+  cp -R "$ARCHIVE_PATH/dSYMs/." "$DSYMS_DIR/"
+fi
+
+if [[ -d "$DSYMS_DIR" ]] && compgen -G "$DSYMS_DIR/*.dSYM" >/dev/null; then
+  ditto -c -k --sequesterRsrc --keepParent "$DSYMS_DIR" "$OUT_ROOT/dSYMs.zip"
+fi
+
+cat >"$METADATA_PATH" <<EOF
+{
+  "scheme": "$SCHEME",
+  "configuration": "$CONFIGURATION",
+  "destination": "$DESTINATION",
+  "git_sha": "$GIT_SHA",
+  "archive_path": "$ARCHIVE_PATH",
+  "derived_data_path": "$DERIVED_DATA_PATH",
+  "code_signing_allowed": "$CODE_SIGNING_ALLOWED",
+  "created_at_utc": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+}
+EOF
+
+echo "archive_path=$ARCHIVE_PATH"
+echo "metadata_path=$METADATA_PATH"
+if [[ -f "$OUT_ROOT/dSYMs.zip" ]]; then
+  echo "dsyms_zip=$OUT_ROOT/dSYMs.zip"
+fi


### PR DESCRIPTION
## Summary
- add the iOS beta APM runtime foundation with PLCrashReporter, MetricKit capture, resource sampling, stall detection, route/span breadcrumbs, and full support-bundle export
- add the iOS release archive + dSYM artifact pipeline and document the new host-owned APM runtime layout
- fix the review findings by enabling crash capture before async bootstrap, preserving launch-time runtime context, and isolating exported `.firesupportbundle` output from store pruning

## Testing
- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' -derivedDataPath /tmp/fire-ios-apm-review CODE_SIGNING_ALLOWED=NO -only-testing:FireTests/FireAPMEventStoreTests test`