### PR TITLE
ios: split feature stores and migrate home feed to list kit

### DIFF
--- a/docs/architecture/ios-listkit-home.md
+++ b/docs/architecture/ios-listkit-home.md
@@ -1,0 +1,84 @@
+# iOS ListKit Home Migration
+
+This note records the first W3 migration slice on `refactor/ios-store-split`:
+the authenticated home feed now runs on the new collection-host ListKit
+foundation instead of SwiftUI `List`.
+
+## Scope
+
+- add reusable collection-host primitives under `native/ios-app/App/ListKit/`
+- keep SwiftUI navigation / sheets / toolbar ownership in `FireHomeView`
+- move the home feed's hot-path list rendering into
+  `native/ios-app/App/ListKit/Home/FireHomeCollectionView.swift`
+- preserve existing home behavior:
+  - feed/category/tag filtering
+  - pull-to-refresh
+  - pagination prefetch near the bottom
+  - "fill viewport" auto-prefetch when the first page is short
+  - topic navigation into `FireTopicDetailView`
+
+This slice does not yet migrate notifications/history or topic detail to
+collection-backed hosts.
+
+## Runtime Shape
+
+- `FireHomeView` now owns:
+  - navigation destinations
+  - create-topic / category / tag sheet presentation
+  - top-level pagination coordination from collection scroll metrics
+- `FireHomeCollectionView` now owns:
+  - diffable section/item modeling for the home screen
+  - home row rendering through `FireTopicRow`
+  - content-state switching across:
+    - filters chrome
+    - loading skeletons
+    - empty state
+    - topic rows
+    - append-loading footer
+- `FireHomeFeedStore` remains the source of truth for:
+  - selected filters
+  - topic ordering and entities
+  - home bootstrap metadata
+  - refresh / append loading state
+
+## ListKit Foundation
+
+The new shared ListKit layer currently provides:
+
+- `FireCollectionHost`
+  - SwiftUI wrapper around a generic collection-backed controller
+- `FireDiffableListController`
+  - diffable snapshot apply
+  - top-visible-item + relative-offset preservation across updates
+  - visible-item publication
+  - scroll-metrics publication
+  - native `UIRefreshControl` bridge
+- `FireListSectionModel`
+  - minimal typed section/item container shared by future migrations
+
+The controller intentionally stays generic and small so later W3 screens can
+reuse it without inheriting home-specific behavior.
+
+## Behavior Notes
+
+- The home feed no longer depends on SwiftUI `List` row lifecycle for legacy
+  pagination prefetch.
+- Pagination now keys off collection scroll metrics for all supported OS
+  versions.
+- Topic row selection is collection-driven, but topic-detail navigation still
+  resolves through SwiftUI `NavigationStack`.
+- Snapshot updates preserve the user's top visible item instead of jumping
+  back to the start when home rows patch after refresh.
+
+## Verification
+
+Verified on this branch with:
+
+- `xcodegen generate --spec native/ios-app/project.yml`
+- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' -derivedDataPath /tmp/fire-ios-w3-home CODE_SIGNING_ALLOWED=NO test`
+
+That run covers:
+
+- unit tests
+- the W3 UI smoke target (`FireUITests`)
+- app launch after the home-feed collection migration

--- a/docs/architecture/ios-store-split.md
+++ b/docs/architecture/ios-store-split.md
@@ -1,76 +1,139 @@
 # iOS Store Split
 
-This note records the early W2 extractions after private-message closure.
+This note records the completed W2 store split on
+`refactor/ios-store-split`.
 
-## Problem
+## Outcome
 
-`FireAppViewModel` currently owns session lifecycle plus home feed, topic
-detail, notifications, search, diagnostics hooks, and write-side transient
-state. That means isolated search input and pagination changes still emit
-`objectWillChange` from the app-wide root object.
+`FireAppViewModel` no longer owns home-feed and topic-detail feature state.
+The iOS host now follows a consistent split:
 
-## First extraction
+- `FireAppViewModel` is the session/runtime facade.
+- screen-level feature state lives in dedicated stores.
+- hot list state uses explicit entity indexing instead of implicit array-only
+  replacement.
 
-The first W2 slice moves search-screen state into
-`native/ios-app/App/Stores/FireSearchStore.swift`.
+The root wiring now happens in `FireTabRoot`:
 
-`FireSearchStore` now owns:
+- `FireHomeFeedStore`
+- `FireSearchStore`
+- `FireNotificationStore`
+- `FireTopicDetailStore`
+- `FireProfileViewModel`
 
-- query text
-- selected search scope
-- current `SearchResultState`
-- pagination cursor
-- loading / append-loading flags
-- search-screen error state
+Home and topic detail consume their store state directly through environment
+injection, while search and notifications continue to observe their existing
+dedicated stores.
 
-`FireAppViewModel` still owns:
+## Store Ownership
 
-- session bootstrap and authenticated-shell lifecycle
-- `FireSessionStore` initialization and shared Rust API access
-- recoverable auth handling (`LoginRequired`, Cloudflare challenge)
-- helper request methods used by feature stores, such as `search`, `searchTags`,
-  and `searchUsers`
+### `FireAppViewModel`
 
-## Why search first
+`FireAppViewModel` now retains only cross-cutting responsibilities:
 
-- The boundary is narrow and screen-local.
-- Search already has a dedicated screen.
-- It reduces one of the largest unrelated invalidation sources without touching
-  topic detail retention or MessageBus ownership yet.
-- It establishes the transitional pattern for later W2 stores: feature state
-  moves out first, while `FireAppViewModel` temporarily remains the shared
-  session facade.
+- `SessionState` publication
+- `FireSessionStore` initialization and access
+- login / logout / Cloudflare recovery
+- MessageBus transport lifecycle
+- diagnostics and APM route coordination
+- thin helper APIs used by stores and non-store screens
 
-## Second extraction
+It binds feature stores but no longer publishes home-list or topic-detail
+state itself.
 
-The second W2 slice moves notification-screen state into
-`native/ios-app/App/Stores/FireNotificationStore.swift`.
+### `FireHomeFeedStore`
 
-`FireNotificationStore` now owns:
+`native/ios-app/App/Stores/FireHomeFeedStore.swift` owns:
 
-- unread badge count
-- recent notification list state
-- full-history notification list state
-- full-history paging cursor
-- notification-specific loading flags
-- delayed MessageBus/runtime notification refresh scheduling
+- selected feed kind
+- selected home category and tags
+- home topic rows
+- paging metadata (`moreTopicsUrl`, `nextTopicsPage`)
+- category/tag bootstrap snapshots used by home/category/tag screens
+- home loading / append-loading flags
+- topic-list MessageBus refresh debounce and incremental merge behavior
 
-`FireAppViewModel` still owns:
+Home rows are backed internally by:
 
-- MessageBus transport lifecycle itself
-- notification API helper methods backed by `FireSessionStore`
-- recoverable auth handling used by the store when notification requests fail
+- `FireEntityIndex<UInt64, FireTopicRowPresentation>`
+- `FireOrderedIDList<UInt64>`
 
-This keeps the badge and notification list churn off the app-wide root
-`ObservableObject` while leaving the shared session/runtime ownership unchanged.
+That keeps entity patching and append order explicit while still exposing
+materialized rows to SwiftUI.
 
-## Follow-up order
+### `FireTopicDetailStore`
 
-The next W2 slices should keep the same pattern:
+`native/ios-app/App/Stores/FireTopicDetailStore.swift` owns:
 
-1. home feed filters, pagination, and list refresh ownership
-2. topic detail cache and presence/reaction lifecycle
-3. any remaining tab/profile-local state that still lives on `FireAppViewModel`
+- `TopicDetailState` cache by topic id
+- anchor post numbers for routed detail loads
+- active detail owner tokens
+- post hydration / pagination state
+- reply-presence users
+- detail loading flags
+- reply submission and post-mutation flags
+- topic-detail MessageBus refresh scheduling
 
-Only after those slices are stable should `FireAppViewModel` shrink further
-from "feature owner" to a mostly session-scoped coordinator.
+All detail-specific mutations now reconcile through this store:
+
+- quick reply
+- post edit refresh path
+- like / unlike
+- non-heart reaction toggles
+- detail refresh after topic vote / poll vote / topic edit
+
+### Existing W2 Stores
+
+The earlier W2 slices remain unchanged in role:
+
+- `FireSearchStore` owns query, scope, result state, pagination, and
+  search-screen errors.
+- `FireNotificationStore` owns unread count, recent/full notification state,
+  paging, and delayed runtime refresh.
+
+## Shared Primitives
+
+Two small shared state helpers now back entity-first list management:
+
+- `native/ios-app/App/Stores/Shared/FireEntityIndex.swift`
+- `native/ios-app/App/Stores/Shared/FireOrderedIDList.swift`
+
+They are intentionally minimal:
+
+- `FireEntityIndex` replaces/upserts payloads by stable business id.
+- `FireOrderedIDList` preserves first-seen order while deduplicating ids.
+
+W2 uses them first on the home feed, which is the highest-churn list that
+still needed stable incremental patching after search/notification extraction.
+
+## Scoped Observation Changes
+
+The following screens now observe feature stores instead of the app-wide root
+object for their primary state:
+
+- `FireHomeView`
+- `FireCategoryBrowserSheet`
+- `FireCategoriesView`
+- `FireTagPickerSheet`
+- `FireTopicDetailView`
+
+This means:
+
+- search input changes do not invalidate the home feed
+- notification badge/list churn does not invalidate topic detail
+- topic-detail post hydration and reaction changes do not invalidate the full
+  tab root through `FireAppViewModel`
+
+`FireAppViewModel` is still passed into many screens for session-aware helper
+methods, but those screens no longer depend on it for the extracted feature
+state.
+
+## Verification
+
+Verified on this branch with:
+
+- `xcodegen generate --spec native/ios-app/project.yml`
+- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'id=EF568FD9-DF26-4B62-B7AB-7C66851CF3D9' -derivedDataPath /tmp/fire-ios-w2 CODE_SIGNING_ALLOWED=NO test`
+
+The test run now includes the new entity-state coverage in
+`native/ios-app/Tests/Unit/FireEntityStateTests.swift`.

--- a/docs/architecture/ios-store-split.md
+++ b/docs/architecture/ios-store-split.md
@@ -1,0 +1,53 @@
+# iOS Store Split
+
+This note records the first W2 extraction after private-message closure.
+
+## Problem
+
+`FireAppViewModel` currently owns session lifecycle plus home feed, topic
+detail, notifications, search, diagnostics hooks, and write-side transient
+state. That means isolated search input and pagination changes still emit
+`objectWillChange` from the app-wide root object.
+
+## First extraction
+
+The first W2 slice moves search-screen state into
+`native/ios-app/App/Stores/FireSearchStore.swift`.
+
+`FireSearchStore` now owns:
+
+- query text
+- selected search scope
+- current `SearchResultState`
+- pagination cursor
+- loading / append-loading flags
+- search-screen error state
+
+`FireAppViewModel` still owns:
+
+- session bootstrap and authenticated-shell lifecycle
+- `FireSessionStore` initialization and shared Rust API access
+- recoverable auth handling (`LoginRequired`, Cloudflare challenge)
+- helper request methods used by feature stores, such as `search`, `searchTags`,
+  and `searchUsers`
+
+## Why search first
+
+- The boundary is narrow and screen-local.
+- Search already has a dedicated screen.
+- It reduces one of the largest unrelated invalidation sources without touching
+  topic detail retention or MessageBus ownership yet.
+- It establishes the transitional pattern for later W2 stores: feature state
+  moves out first, while `FireAppViewModel` temporarily remains the shared
+  session facade.
+
+## Follow-up order
+
+The next W2 slices should keep the same pattern:
+
+1. notification list/full-history state
+2. home feed filters, pagination, and list refresh ownership
+3. topic detail cache and presence/reaction lifecycle
+
+Only after those slices are stable should `FireAppViewModel` shrink further
+from "feature owner" to a mostly session-scoped coordinator.

--- a/docs/architecture/ios-store-split.md
+++ b/docs/architecture/ios-store-split.md
@@ -1,6 +1,6 @@
 # iOS Store Split
 
-This note records the first W2 extraction after private-message closure.
+This note records the early W2 extractions after private-message closure.
 
 ## Problem
 
@@ -41,13 +41,36 @@ The first W2 slice moves search-screen state into
   moves out first, while `FireAppViewModel` temporarily remains the shared
   session facade.
 
+## Second extraction
+
+The second W2 slice moves notification-screen state into
+`native/ios-app/App/Stores/FireNotificationStore.swift`.
+
+`FireNotificationStore` now owns:
+
+- unread badge count
+- recent notification list state
+- full-history notification list state
+- full-history paging cursor
+- notification-specific loading flags
+- delayed MessageBus/runtime notification refresh scheduling
+
+`FireAppViewModel` still owns:
+
+- MessageBus transport lifecycle itself
+- notification API helper methods backed by `FireSessionStore`
+- recoverable auth handling used by the store when notification requests fail
+
+This keeps the badge and notification list churn off the app-wide root
+`ObservableObject` while leaving the shared session/runtime ownership unchanged.
+
 ## Follow-up order
 
 The next W2 slices should keep the same pattern:
 
-1. notification list/full-history state
-2. home feed filters, pagination, and list refresh ownership
-3. topic detail cache and presence/reaction lifecycle
+1. home feed filters, pagination, and list refresh ownership
+2. topic detail cache and presence/reaction lifecycle
+3. any remaining tab/profile-local state that still lives on `FireAppViewModel`
 
 Only after those slices are stable should `FireAppViewModel` shrink further
 from "feature owner" to a mostly session-scoped coordinator.

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -130,16 +130,6 @@ final class FireAppViewModel: ObservableObject {
     @Published private(set) var isLoadingNotificationFullPage = false
     @Published private(set) var hasMoreNotificationFull = false
 
-    // MARK: - Search
-
-    @Published var searchQuery = ""
-    @Published private(set) var searchScope: FireSearchScope = .all
-    @Published private(set) var searchResult: SearchResultState?
-    @Published private(set) var searchCurrentPage: UInt32 = 1
-    @Published private(set) var isSearching = false
-    @Published private(set) var isAppendingSearch = false
-    @Published private(set) var searchErrorMessage: String?
-
     // MARK: - General UI state
 
     @Published var errorMessage: String?
@@ -176,8 +166,6 @@ final class FireAppViewModel: ObservableObject {
     private var topicPostPaginationStates: [UInt64: FireTopicPostPaginationState] = [:]
     private var topicDetailTargetPostNumbers: [UInt64: UInt32] = [:]
     private var activeTopicDetailOwnerTokens: [UInt64: Set<String>] = [:]
-    private var searchTask: Task<Void, Never>?
-    private var latestSearchRequestID: UInt64 = 0
     private var filterChangeRefreshTask: Task<Void, Never>?
     private var topLevelAPMRoute = "session.onboarding"
 
@@ -342,7 +330,6 @@ final class FireAppViewModel: ObservableObject {
                 selectedTopicKind = .latest
                 clearTopicState()
                 clearNotificationState()
-                clearSearchState(resetQuery: true)
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -1258,100 +1245,7 @@ final class FireAppViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Search
-
-    var canLoadMoreSearchResults: Bool {
-        guard let searchResult else { return false }
-        switch searchScope {
-        case .all:
-            return searchResult.groupedResult.moreFullPageResults
-                || searchResult.groupedResult.morePosts
-                || searchResult.groupedResult.moreUsers
-        case .topic, .post:
-            return searchResult.groupedResult.moreFullPageResults
-                || searchResult.groupedResult.morePosts
-        case .user:
-            return searchResult.groupedResult.moreUsers
-        }
-    }
-
-    func resetSearch() {
-        clearSearchState(resetQuery: true)
-    }
-
-    func setSearchScope(_ scope: FireSearchScope) {
-        guard searchScope != scope else {
-            return
-        }
-        searchScope = scope
-        guard searchResult != nil else {
-            return
-        }
-        submitSearch(reset: true)
-    }
-
-    func submitSearch(reset: Bool) {
-        let trimmedQuery = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedQuery.isEmpty else {
-            clearSearchState(resetQuery: false)
-            return
-        }
-        if !reset && (isSearching || isAppendingSearch) {
-            return
-        }
-
-        searchTask?.cancel()
-        let nextPage = reset ? UInt32(1) : searchCurrentPage + 1
-        let requestID = latestSearchRequestID &+ 1
-        latestSearchRequestID = requestID
-        let scope = searchScope
-
-        if reset {
-            isSearching = true
-            isAppendingSearch = false
-        } else {
-            isAppendingSearch = true
-        }
-
-        searchTask = Task { [weak self] in
-            guard let self else { return }
-
-            do {
-                let response = try await self.search(
-                    query: trimmedQuery,
-                    typeFilter: scope.typeFilter,
-                    page: nextPage
-                )
-                guard !Task.isCancelled, requestID == self.latestSearchRequestID else {
-                    return
-                }
-
-                self.searchErrorMessage = nil
-                self.searchCurrentPage = nextPage
-                self.searchResult = reset
-                    ? response
-                    : self.mergeSearchResult(existing: self.searchResult, incoming: response)
-            } catch is CancellationError {
-                return
-            } catch {
-                guard !Task.isCancelled, requestID == self.latestSearchRequestID else {
-                    return
-                }
-                if await self.handleRecoverableSessionErrorIfNeeded(error) {
-                    self.searchErrorMessage = nil
-                } else {
-                    self.searchErrorMessage = error.localizedDescription
-                }
-            }
-
-            guard requestID == self.latestSearchRequestID else {
-                return
-            }
-            self.isSearching = false
-            self.isAppendingSearch = false
-            self.searchTask = nil
-        }
-    }
+    // MARK: - Search helpers
 
     func search(
         query: String,
@@ -1967,19 +1861,23 @@ final class FireAppViewModel: ObservableObject {
         recentNotifications = []
     }
 
-    private func clearSearchState(resetQuery: Bool) {
-        searchTask?.cancel()
-        searchTask = nil
-        latestSearchRequestID = latestSearchRequestID &+ 1
-        if resetQuery {
-            searchQuery = ""
+    private func mergeItemsByID<Item>(
+        _ existing: [Item],
+        _ incoming: [Item],
+        keyPath: KeyPath<Item, UInt64>
+    ) -> [Item] {
+        var merged = Dictionary(uniqueKeysWithValues: existing.map { ($0[keyPath: keyPath], $0) })
+        var orderedIDs = existing.map { $0[keyPath: keyPath] }
+
+        for item in incoming {
+            let id = item[keyPath: keyPath]
+            if merged[id] == nil {
+                orderedIDs.append(id)
+            }
+            merged[id] = item
         }
-        searchResult = nil
-        searchCurrentPage = 1
-        isSearching = false
-        isAppendingSearch = false
-        searchErrorMessage = nil
-        searchScope = .all
+
+        return orderedIDs.compactMap { merged[$0] }
     }
 
     private func finishInitialStateLoading(generation: UInt64) {
@@ -2101,7 +1999,7 @@ final class FireAppViewModel: ObservableObject {
     }
 
     @discardableResult
-    private func handleRecoverableSessionErrorIfNeeded(_ error: Error) async -> Bool {
+    func handleRecoverableSessionErrorIfNeeded(_ error: Error) async -> Bool {
         if await handleLoginRequiredIfNeeded(error) {
             return true
         }
@@ -2161,7 +2059,6 @@ final class FireAppViewModel: ObservableObject {
         selectedTopicKind = .latest
         clearTopicState()
         clearNotificationState()
-        clearSearchState(resetQuery: true)
         errorMessage = message
         isPresentingLogin = true
     }
@@ -2585,41 +2482,6 @@ final class FireAppViewModel: ObservableObject {
 
         detail.postStream.posts[postIndex] = post
         topicDetails[topicId] = FireTopicPresentation.recomposedDetail(detail)
-    }
-
-    private func mergeSearchResult(
-        existing: SearchResultState?,
-        incoming: SearchResultState
-    ) -> SearchResultState {
-        guard let existing else {
-            return incoming
-        }
-
-        return SearchResultState(
-            posts: mergeItemsByID(existing.posts, incoming.posts, keyPath: \.id),
-            topics: mergeItemsByID(existing.topics, incoming.topics, keyPath: \.id),
-            users: mergeItemsByID(existing.users, incoming.users, keyPath: \.id),
-            groupedResult: incoming.groupedResult
-        )
-    }
-
-    private func mergeItemsByID<Item>(
-        _ existing: [Item],
-        _ incoming: [Item],
-        keyPath: KeyPath<Item, UInt64>
-    ) -> [Item] {
-        var merged = Dictionary(uniqueKeysWithValues: existing.map { ($0[keyPath: keyPath], $0) })
-        var orderedIDs = existing.map { $0[keyPath: keyPath] }
-
-        for item in incoming {
-            let id = item[keyPath: keyPath]
-            if merged[id] == nil {
-                orderedIDs.append(id)
-            }
-            merged[id] = item
-        }
-
-        return orderedIDs.compactMap { merged[$0] }
     }
 
     private func sessionStoreValue() async throws -> FireSessionStore {

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -122,14 +122,6 @@ final class FireAppViewModel: ObservableObject {
 
     // MARK: - Notifications
 
-    @Published private(set) var notificationUnreadCount: Int = 0
-    @Published private(set) var recentNotifications: [NotificationItemState] = []
-    @Published private(set) var isLoadingNotifications = false
-    @Published private(set) var notificationFullList: [NotificationItemState] = []
-    @Published private(set) var notificationFullNextOffset: UInt32?
-    @Published private(set) var isLoadingNotificationFullPage = false
-    @Published private(set) var hasMoreNotificationFull = false
-
     // MARK: - General UI state
 
     @Published var errorMessage: String?
@@ -160,7 +152,6 @@ final class FireAppViewModel: ObservableObject {
     private var pendingTopicListRefreshTask: Task<Void, Never>?
     private var topicListMessageBusRefreshController = FireTopicListMessageBusRefreshController()
     private var pendingTopicDetailRefreshTasks: [UInt64: Task<Void, Never>] = [:]
-    private var pendingNotificationStateRefreshTask: Task<Void, Never>?
     private var topicPresenceHeartbeatTasks: [UInt64: Task<Void, Never>] = [:]
     private var topicPostPreloadTasks: [UInt64: Task<Void, Never>] = [:]
     private var topicPostPaginationStates: [UInt64: FireTopicPostPaginationState] = [:]
@@ -168,6 +159,7 @@ final class FireAppViewModel: ObservableObject {
     private var activeTopicDetailOwnerTokens: [UInt64: Set<String>] = [:]
     private var filterChangeRefreshTask: Task<Void, Never>?
     private var topLevelAPMRoute = "session.onboarding"
+    private weak var notificationStore: FireNotificationStore?
 
     init(
         initialSession: SessionState = .placeholder(),
@@ -175,6 +167,10 @@ final class FireAppViewModel: ObservableObject {
     ) {
         self.session = initialSession
         self.challengeRecoveryStore = challengeRecoveryStore
+    }
+
+    func bindNotificationStore(_ store: FireNotificationStore) {
+        notificationStore = store
     }
 
     // MARK: - Lifecycle
@@ -218,7 +214,7 @@ final class FireAppViewModel: ObservableObject {
                     guard self.initialStateLoadGeneration == generation else { return }
                     await self.refreshTopicsIfPossible(force: true)
                     guard self.initialStateLoadGeneration == generation else { return }
-                    await self.loadRecentNotifications(force: false)
+                    await self.notificationStore?.loadRecent(force: false)
                 }
             } catch {
                 guard self.initialStateLoadGeneration == generation else { return }
@@ -329,7 +325,7 @@ final class FireAppViewModel: ObservableObject {
                 await applySession(try await loginCoordinator.logout())
                 selectedTopicKind = .latest
                 clearTopicState()
-                clearNotificationState()
+                notificationStore?.reset()
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -1167,82 +1163,34 @@ final class FireAppViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Notifications
+    // MARK: - Notification helpers
 
-    func loadRecentNotifications(force: Bool = true) async {
-        guard let sessionStore else { return }
-        guard session.readiness.canReadAuthenticatedApi else { return }
-        guard !isLoadingNotifications || force else { return }
-
-        isLoadingNotifications = true
-        defer { isLoadingNotifications = false }
-        do {
-            try await FireAPMManager.shared.withSpan(.notificationsRefresh) {
-                let list = try await sessionStore.fetchRecentNotifications()
-                recentNotifications = list.notifications
-                if let state = try? await sessionStore.notificationState() {
-                    notificationUnreadCount = Int(state.counters.allUnread)
-                }
-            }
-        } catch {
-            _ = await handleRecoverableSessionErrorIfNeeded(error)
-            // Silent: notification failures shouldn't interrupt UX
-        }
+    func notificationCenterState() async throws -> NotificationCenterState {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.notificationState()
     }
 
-    func markNotificationRead(id: UInt64) {
-        guard let sessionStore else { return }
-        Task {
-            do {
-                let state = try await sessionStore.markNotificationRead(id: id)
-                notificationUnreadCount = Int(state.counters.allUnread)
-                if let idx = recentNotifications.firstIndex(where: { $0.id == id }) {
-                    recentNotifications[idx].read = true
-                }
-                if state.hasLoadedFull {
-                    notificationFullList = state.full
-                }
-            } catch {
-                _ = await self.handleRecoverableSessionErrorIfNeeded(error)
-            }
-        }
+    func fetchRecentNotificationsData(limit: UInt32? = nil) async throws -> NotificationListState {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.fetchRecentNotifications(limit: limit)
     }
 
-    func markAllNotificationsRead() {
-        guard let sessionStore else { return }
-        Task {
-            do {
-                let state = try await sessionStore.markAllNotificationsRead()
-                notificationUnreadCount = Int(state.counters.allUnread)
-                recentNotifications = recentNotifications.map {
-                    var n = $0; n.read = true; return n
-                }
-                if state.hasLoadedFull {
-                    notificationFullList = state.full
-                }
-            } catch {
-                _ = await self.handleRecoverableSessionErrorIfNeeded(error)
-            }
-        }
+    func fetchNotificationsData(
+        limit: UInt32? = nil,
+        offset: UInt32? = nil
+    ) async throws -> NotificationListState {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.fetchNotifications(limit: limit, offset: offset)
     }
 
-    func loadNotificationFullPage(offset: UInt32?) async {
-        guard let sessionStore else { return }
-        guard session.readiness.canReadAuthenticatedApi else { return }
-        guard !isLoadingNotificationFullPage else { return }
+    func markNotificationReadState(id: UInt64) async throws -> NotificationCenterState {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.markNotificationRead(id: id)
+    }
 
-        isLoadingNotificationFullPage = true
-        defer { isLoadingNotificationFullPage = false }
-        do {
-            _ = try await sessionStore.fetchNotifications(limit: nil, offset: offset)
-            let state = try await sessionStore.notificationState()
-            notificationFullList = state.full
-            notificationFullNextOffset = state.fullNextOffset
-            hasMoreNotificationFull = state.fullNextOffset != nil
-            notificationUnreadCount = Int(state.counters.allUnread)
-        } catch {
-            _ = await handleRecoverableSessionErrorIfNeeded(error)
-        }
+    func markAllNotificationsReadState() async throws -> NotificationCenterState {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.markAllNotificationsRead()
     }
 
     // MARK: - Search helpers
@@ -1479,8 +1427,7 @@ final class FireAppViewModel: ObservableObject {
         messageBusRetryTask?.cancel()
         messageBusRetryTask = nil
         messageBusStartRetryCount = 0
-        pendingNotificationStateRefreshTask?.cancel()
-        pendingNotificationStateRefreshTask = nil
+        notificationStore?.cancelScheduledRefresh()
         clearMessageBusError()
         guard isMessageBusActive else { return }
         pendingTopicListRefreshTask?.cancel()
@@ -1517,7 +1464,7 @@ final class FireAppViewModel: ObservableObject {
             refreshTopicPresenceState(topicId: topicId)
 
         case .notification:
-            scheduleNotificationStateRefresh()
+            notificationStore?.scheduleStateRefresh()
 
         case .notificationAlert:
             break
@@ -1602,19 +1549,6 @@ final class FireAppViewModel: ObservableObject {
                     return
                 }
             }
-        }
-    }
-
-    private func scheduleNotificationStateRefresh() {
-        pendingNotificationStateRefreshTask?.cancel()
-        pendingNotificationStateRefreshTask = Task { [weak self] in
-            try? await Task.sleep(for: .milliseconds(150))
-            guard !Task.isCancelled else { return }
-            guard let self, let store = self.sessionStore else { return }
-            guard let state = try? await store.notificationState() else { return }
-            self.notificationUnreadCount = Int(state.counters.allUnread)
-            self.recentNotifications = state.recent
-            self.pendingNotificationStateRefreshTask = nil
         }
     }
 
@@ -1856,11 +1790,6 @@ final class FireAppViewModel: ObservableObject {
         topicListMessageBusRefreshController.clearPending(for: scope)
     }
 
-    private func clearNotificationState() {
-        notificationUnreadCount = 0
-        recentNotifications = []
-    }
-
     private func mergeItemsByID<Item>(
         _ existing: [Item],
         _ incoming: [Item],
@@ -1915,11 +1844,10 @@ final class FireAppViewModel: ObservableObject {
         }
         topicCategories = Dictionary(uniqueKeysWithValues: session.bootstrap.categories.map { ($0.id, $0) })
 
-        // Sync notification badge from in-memory state when available
-        if session.readiness.canReadAuthenticatedApi, let store = sessionStore {
-            if let state = try? await store.notificationState() {
-                notificationUnreadCount = Int(state.counters.allUnread)
-            }
+        if session.readiness.canReadAuthenticatedApi {
+            await notificationStore?.syncStateFromRuntimeIfAvailable()
+        } else {
+            notificationStore?.reset()
         }
 
         // Reconcile MessageBus lifecycle
@@ -2058,7 +1986,7 @@ final class FireAppViewModel: ObservableObject {
 
         selectedTopicKind = .latest
         clearTopicState()
-        clearNotificationState()
+        notificationStore?.reset()
         errorMessage = message
         isPresentingLogin = true
     }

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -26,7 +26,7 @@ private enum FireDiagnosticsAccessError: LocalizedError {
     }
 }
 
-private enum FireTopicInteractionError: LocalizedError {
+enum FireTopicInteractionError: LocalizedError {
     case unavailable
     case requiresAuthenticatedWrite
     case emptyReply
@@ -46,7 +46,7 @@ private enum FireTopicInteractionError: LocalizedError {
     }
 }
 
-private struct FireTopicPostPaginationState {
+struct FireTopicPostPaginationState {
     var targetLoadedCount: Int
     var exhaustedPostIDs: Set<UInt64> = []
 }
@@ -89,38 +89,12 @@ final class FireAppViewModel: ObservableObject {
     private static let messageBusErrorPrefix = "实时同步连接失败："
     private static let loginRequiredMessage = "登录状态已失效，请重新登录。"
     private static let authDiagnosticsLogTarget = "ios.auth"
-    private static let topicPostPageSize = 30
-    private static let topicPostPrefetchThreshold = 6
     private static let topicDetailLogTarget = "ios.topic-detail"
     private static let diagnosticsLifecycleLogTarget = "ios.lifecycle"
-    private static let topicListRefreshLoadingPollInterval: Duration = .milliseconds(250)
 
     // MARK: - Session
 
     @Published private(set) var session: SessionState = .placeholder()
-
-    // MARK: - Topic list
-
-    @Published private(set) var selectedTopicKind: TopicListKindState = .latest
-    @Published private(set) var selectedHomeCategoryId: UInt64?
-    @Published private(set) var selectedHomeTags: [String] = []
-    @Published private(set) var topicRows: [FireTopicRowPresentation] = []
-    @Published private(set) var moreTopicsUrl: String?
-    @Published private(set) var nextTopicsPage: UInt32?
-    @Published private(set) var topicCategories: [UInt64: FireTopicCategoryPresentation] = [:]
-    @Published private(set) var topicDetails: [UInt64: TopicDetailState] = [:]
-    @Published private(set) var topicPresenceUsersByTopic: [UInt64: [TopicPresenceUserState]] = [:]
-    @Published private(set) var loadingMoreTopicPostIDs: Set<UInt64> = []
-    @Published private(set) var isLoadingTopics = false
-    @Published private(set) var isAppendingTopics = false
-    @Published private(set) var loadingTopicIDs: Set<UInt64> = []
-
-    // MARK: - Write interactions
-
-    @Published private(set) var submittingReplyTopicIDs: Set<UInt64> = []
-    @Published private(set) var mutatingPostIDs: Set<UInt64> = []
-
-    // MARK: - Notifications
 
     // MARK: - General UI state
 
@@ -142,24 +116,15 @@ final class FireAppViewModel: ObservableObject {
     private var initialStateLoadGeneration: UInt64 = 0
     private let loginURL = URL(string: "https://linux.do")!
     private let challengeRecoveryStore: (any FireChallengeSessionRecovering)?
-    private let topicListRefreshClock = ContinuousClock()
-
     // MessageBus
     private var messageBusCoordinator: FireMessageBusCoordinator?
     private var isMessageBusActive = false
     private var messageBusStartRetryCount = 0
     private var messageBusRetryTask: Task<Void, Never>?
-    private var pendingTopicListRefreshTask: Task<Void, Never>?
-    private var topicListMessageBusRefreshController = FireTopicListMessageBusRefreshController()
-    private var pendingTopicDetailRefreshTasks: [UInt64: Task<Void, Never>] = [:]
-    private var topicPresenceHeartbeatTasks: [UInt64: Task<Void, Never>] = [:]
-    private var topicPostPreloadTasks: [UInt64: Task<Void, Never>] = [:]
-    private var topicPostPaginationStates: [UInt64: FireTopicPostPaginationState] = [:]
-    private var topicDetailTargetPostNumbers: [UInt64: UInt32] = [:]
-    private var activeTopicDetailOwnerTokens: [UInt64: Set<String>] = [:]
-    private var filterChangeRefreshTask: Task<Void, Never>?
     private var topLevelAPMRoute = "session.onboarding"
+    private weak var homeFeedStore: FireHomeFeedStore?
     private weak var notificationStore: FireNotificationStore?
+    private weak var topicDetailStore: FireTopicDetailStore?
 
     init(
         initialSession: SessionState = .placeholder(),
@@ -169,8 +134,16 @@ final class FireAppViewModel: ObservableObject {
         self.challengeRecoveryStore = challengeRecoveryStore
     }
 
+    func bindHomeFeedStore(_ store: FireHomeFeedStore) {
+        homeFeedStore = store
+    }
+
     func bindNotificationStore(_ store: FireNotificationStore) {
         notificationStore = store
+    }
+
+    func bindTopicDetailStore(_ store: FireTopicDetailStore) {
+        topicDetailStore = store
     }
 
     // MARK: - Lifecycle
@@ -212,7 +185,7 @@ final class FireAppViewModel: ObservableObject {
                     guard self.initialStateLoadGeneration == generation else { return }
                     await self.applySession(restoredSession)
                     guard self.initialStateLoadGeneration == generation else { return }
-                    await self.refreshTopicsIfPossible(force: true)
+                    await self.refreshHomeFeedIfPossible(force: true)
                     guard self.initialStateLoadGeneration == generation else { return }
                     await self.notificationStore?.loadRecent(force: false)
                 }
@@ -233,7 +206,7 @@ final class FireAppViewModel: ObservableObject {
                 errorMessage = nil
                 await applySession(try await sessionStore.snapshot())
                 await applySession(try await sessionStore.refreshBootstrapIfNeeded())
-                await refreshTopicsIfPossible(force: false)
+                await refreshHomeFeedIfPossible(force: false)
             } catch {
                 if await handleRecoverableSessionErrorIfNeeded(error) {
                     return
@@ -279,7 +252,7 @@ final class FireAppViewModel: ObservableObject {
                     errorMessage = nil
                     await applySession(try await loginCoordinator.completeLogin(from: webView))
                     isPresentingLogin = false
-                    await refreshTopicsIfPossible(force: true)
+                    await refreshHomeFeedIfPossible(force: true)
                 }
             } catch {
                 if await handleRecoverableSessionErrorIfNeeded(error) {
@@ -297,7 +270,7 @@ final class FireAppViewModel: ObservableObject {
                     let sessionStore = try await sessionStoreValue()
                     errorMessage = nil
                     await applySession(try await sessionStore.refreshBootstrap())
-                    await refreshTopicsIfPossible(force: false)
+                    await refreshHomeFeedIfPossible(force: false)
                 }
             } catch {
                 if await handleRecoverableSessionErrorIfNeeded(error) {
@@ -323,7 +296,6 @@ final class FireAppViewModel: ObservableObject {
                 stopMessageBus()
                 errorMessage = nil
                 await applySession(try await loginCoordinator.logout())
-                selectedTopicKind = .latest
                 clearTopicState()
                 notificationStore?.reset()
             } catch {
@@ -335,71 +307,39 @@ final class FireAppViewModel: ObservableObject {
     // MARK: - Topic list
 
     func selectTopicKind(_ kind: TopicListKindState) {
-        guard selectedTopicKind != kind else {
-            return
-        }
-        selectedTopicKind = kind
-        scheduleDebouncedRefresh()
+        homeFeedStore?.selectTopicKind(kind)
     }
 
     func selectHomeCategory(_ categoryId: UInt64?) {
-        guard selectedHomeCategoryId != categoryId else { return }
-        selectedHomeCategoryId = categoryId
-        selectedHomeTags = []
-        scheduleDebouncedRefresh()
+        homeFeedStore?.selectHomeCategory(categoryId)
     }
 
     func addHomeTag(_ tag: String) {
-        guard !selectedHomeTags.contains(tag) else { return }
-        selectedHomeTags.append(tag)
-        scheduleDebouncedRefresh()
+        homeFeedStore?.addHomeTag(tag)
     }
 
     func removeHomeTag(_ tag: String) {
-        guard selectedHomeTags.contains(tag) else { return }
-        selectedHomeTags.removeAll { $0 == tag }
-        scheduleDebouncedRefresh()
+        homeFeedStore?.removeHomeTag(tag)
     }
 
     func clearHomeTags() {
-        guard !selectedHomeTags.isEmpty else { return }
-        selectedHomeTags = []
-        scheduleDebouncedRefresh()
-    }
-
-    private func scheduleDebouncedRefresh() {
-        cancelPendingTopicListRefresh()
-        filterChangeRefreshTask?.cancel()
-        filterChangeRefreshTask = Task {
-            try? await Task.sleep(for: .milliseconds(300))
-            guard !Task.isCancelled else { return }
-            await refreshTopicsIfPossible(force: true)
-        }
+        homeFeedStore?.clearHomeTags()
     }
 
     var selectedHomeCategoryPresentation: FireTopicCategoryPresentation? {
-        guard let id = selectedHomeCategoryId else { return nil }
-        return categoryPresentation(for: id)
+        homeFeedStore?.selectedHomeCategoryPresentation
     }
 
     func refreshTopics() {
-        Task {
-            await refreshTopicsIfPossible(force: true)
-        }
+        homeFeedStore?.refreshTopics()
     }
 
     func refreshTopicsAsync() async {
-        await refreshTopicsIfPossible(force: true)
+        await homeFeedStore?.refreshTopicsAsync()
     }
 
     func loadMoreTopics() {
-        guard let nextTopicsPage else {
-            return
-        }
-
-        Task {
-            await loadTopics(page: nextTopicsPage, reset: false, force: true)
-        }
+        homeFeedStore?.loadMoreTopics()
     }
 
     func loadTopicDetail(
@@ -407,97 +347,35 @@ final class FireAppViewModel: ObservableObject {
         targetPostNumber: UInt32? = nil,
         force: Bool = false
     ) async {
-        guard let sessionStore else {
-            return
-        }
-
-        if loadingTopicIDs.contains(topicId) {
-            return
-        }
-        if topicDetails[topicId] != nil && !force {
-            return
-        }
-        if !session.readiness.canReadAuthenticatedApi {
-            clearTopicState()
-            return
-        }
-
-        if let targetPostNumber {
-            topicDetailTargetPostNumbers[topicId] = targetPostNumber
-        }
-
-        let hadCachedDetail = topicDetails[topicId] != nil
-        topicDetailLogger()?.debug(
-            "loading topic detail topic_id=\(topicId) force=\(force) had_cache=\(hadCachedDetail) target_post=\(String(describing: targetPostNumber))"
+        await topicDetailStore?.loadTopicDetail(
+            topicId: topicId,
+            targetPostNumber: targetPostNumber,
+            force: force
         )
-        loadingTopicIDs.insert(topicId)
-        defer { loadingTopicIDs.remove(topicId) }
-
-        do {
-            errorMessage = nil
-            let detail = try await FireAPMManager.shared.withSpan(
-                .topicDetailInitialLoad,
-                metadata: ["topic_id": String(topicId)]
-            ) {
-                try await sessionStore.fetchTopicDetailInitial(
-                    query: TopicDetailQueryState(
-                        topicId: topicId,
-                        postNumber: targetPostNumber,
-                        trackVisit: true,
-                        filter: nil,
-                        usernameFilters: nil,
-                        filterTopLevelReplies: false
-                    )
-                )
-            }
-            applyTopicDetail(detail, topicId: topicId)
-            topicDetailLogger()?.debug(
-                "loaded topic detail topic_id=\(topicId) loaded_posts=\(detail.postStream.posts.count) stream_posts=\(detail.postStream.stream.count)"
-            )
-        } catch {
-            topicDetailLogger()?.error(
-                "topic detail load failed topic_id=\(topicId) error=\(error.localizedDescription)"
-            )
-            if await handleRecoverableSessionErrorIfNeeded(error) {
-                return
-            }
-            errorMessage = error.localizedDescription
-        }
     }
 
     func clearTopicDetailAnchor(topicId: UInt64) {
-        topicDetailTargetPostNumbers.removeValue(forKey: topicId)
+        topicDetailStore?.clearTopicDetailAnchor(topicId: topicId)
     }
 
     func topicDetail(for topicId: UInt64) -> TopicDetailState? {
-        topicDetails[topicId]
+        topicDetailStore?.topicDetail(for: topicId)
     }
 
     func topicPresenceUsers(for topicId: UInt64) -> [TopicPresenceUserState] {
-        topicPresenceUsersByTopic[topicId] ?? []
+        topicDetailStore?.topicPresenceUsers(for: topicId) ?? []
     }
 
     func isLoadingTopic(topicId: UInt64) -> Bool {
-        loadingTopicIDs.contains(topicId)
+        topicDetailStore?.isLoadingTopic(topicId: topicId) ?? false
     }
 
     func isLoadingMoreTopicPosts(topicId: UInt64) -> Bool {
-        loadingMoreTopicPostIDs.contains(topicId)
+        topicDetailStore?.isLoadingMoreTopicPosts(topicId: topicId) ?? false
     }
 
     func hasMoreTopicPosts(topicId: UInt64) -> Bool {
-        guard let detail = topicDetails[topicId] else {
-            return false
-        }
-        let loadedWindowCount = FireTopicPresentation.loadedWindowCount(detail: detail)
-        let pagination = topicPostPaginationStates[topicId]
-        let targetLoadedCount = max(pagination?.targetLoadedCount ?? loadedWindowCount, loadedWindowCount)
-        let unresolvedPostIDs = FireTopicPresentation.missingPostIDs(
-            in: detail,
-            upTo: targetLoadedCount,
-            excluding: pagination?.exhaustedPostIDs ?? Set<UInt64>()
-        )
-        return !unresolvedPostIDs.isEmpty || targetLoadedCount < detail.postStream.stream.count
+        topicDetailStore?.hasMoreTopicPosts(topicId: topicId) ?? false
     }
 
     func preloadTopicPostsIfNeeded(
@@ -505,145 +383,69 @@ final class FireAppViewModel: ObservableObject {
         visibleReplyIndex: Int,
         totalReplyCount: Int
     ) {
-        guard totalReplyCount > 0 else { return }
-        let triggerIndex = max(totalReplyCount - Self.topicPostPrefetchThreshold, 0)
-        guard visibleReplyIndex >= triggerIndex else { return }
-        guard hasMoreTopicPosts(topicId: topicId) else { return }
-        guard !loadingMoreTopicPostIDs.contains(topicId) else { return }
-        guard topicPostPreloadTasks[topicId] == nil else { return }
-
-        topicPostPreloadTasks[topicId] = Task { @MainActor [weak self] in
-            guard let self else { return }
-            defer { self.topicPostPreloadTasks[topicId] = nil }
-            await self.loadMoreTopicPostsIfNeeded(topicId: topicId)
-        }
+        topicDetailStore?.preloadTopicPostsIfNeeded(
+            topicId: topicId,
+            visibleReplyIndex: visibleReplyIndex,
+            totalReplyCount: totalReplyCount
+        )
     }
 
     // MARK: - Topic detail lifecycle
 
     func beginTopicDetailLifecycle(topicId: UInt64, ownerToken: String) {
-        var owners = activeTopicDetailOwnerTokens[topicId] ?? []
-        let inserted = owners.insert(ownerToken).inserted
-        activeTopicDetailOwnerTokens[topicId] = owners
-        guard inserted else { return }
-
-        topicDetailLogger()?.debug(
-            "registered topic detail lifecycle topic_id=\(topicId) owner_token=\(ownerToken) owner_count=\(owners.count)"
-        )
+        topicDetailStore?.beginTopicDetailLifecycle(topicId: topicId, ownerToken: ownerToken)
     }
 
     func endTopicDetailLifecycle(topicId: UInt64, ownerToken: String) {
-        guard var owners = activeTopicDetailOwnerTokens[topicId] else { return }
-        guard owners.remove(ownerToken) != nil else { return }
-
-        if owners.isEmpty {
-            activeTopicDetailOwnerTokens.removeValue(forKey: topicId)
-        } else {
-            activeTopicDetailOwnerTokens[topicId] = owners
-        }
-
-        topicDetailLogger()?.debug(
-            "released topic detail lifecycle topic_id=\(topicId) owner_token=\(ownerToken) owner_count=\(owners.count)"
+        topicDetailStore?.endTopicDetailLifecycle(
+            topicId: topicId,
+            ownerToken: ownerToken,
+            visibleTopicIDs: currentVisibleTopicIDs()
         )
-
-        guard owners.isEmpty else { return }
-        topicDetailTargetPostNumbers.removeValue(forKey: topicId)
-        let visibleTopicIDs = Set(topicRows.map(\.topic.id))
-        guard !visibleTopicIDs.contains(topicId) else { return }
-        evictTopicDetailState(topicId: topicId, reason: "detail view disappeared")
     }
 
     func retainedTopicDetailIDs(visibleTopicIDs: Set<UInt64>) -> Set<UInt64> {
-        let activeTopicIDs = activeTopicDetailOwnerTokens.compactMap { topicId, owners in
-            owners.isEmpty ? nil : topicId
-        }
-        return visibleTopicIDs.union(activeTopicIDs)
+        topicDetailStore?.retainedTopicDetailIDs(visibleTopicIDs: visibleTopicIDs)
+            ?? visibleTopicIDs
     }
 
     // MARK: - Topic detail MessageBus subscription
 
     func maintainTopicDetailSubscription(topicId: UInt64, ownerToken: String) async {
-        guard session.readiness.canOpenMessageBus else { return }
-        // Hidden/private topics can 404 while the detail view is already alive. Waiting
-        // for a successful detail load avoids bootstrapping presence on a topic we
-        // cannot read, which can cause Linux.do to clear the auth cookie.
-        guard topicDetails[topicId] != nil else {
-            topicDetailLogger()?.debug(
-                "skipping topic detail subscription bootstrap topic_id=\(topicId) reason=detail not loaded"
-            )
-            return
-        }
-        guard let store = sessionStore else { return }
-
-        do {
-            try await store.subscribeTopicDetailChannel(topicId: topicId, ownerToken: ownerToken)
-            try await store.subscribeTopicReactionChannel(topicId: topicId, ownerToken: ownerToken)
-        } catch {
-            try? await store.unsubscribeTopicReactionChannel(topicId: topicId, ownerToken: ownerToken)
-            try? await store.unsubscribeTopicDetailChannel(topicId: topicId, ownerToken: ownerToken)
-            return
-        }
-
-        do {
-            let presence = try await store.bootstrapTopicReplyPresence(
-                topicId: topicId,
-                ownerToken: ownerToken
-            )
-            applyTopicPresenceState(presence)
-        } catch {
-            topicPresenceUsersByTopic[topicId] = []
-        }
-
-        defer {
-            Task {
-                await self.endTopicReplyPresence(topicId: topicId)
-                self.topicPresenceUsersByTopic[topicId] = []
-                try? await store.unsubscribeTopicReplyPresenceChannel(topicId: topicId, ownerToken: ownerToken)
-                try? await store.unsubscribeTopicReactionChannel(topicId: topicId, ownerToken: ownerToken)
-                try? await store.unsubscribeTopicDetailChannel(topicId: topicId, ownerToken: ownerToken)
-            }
-        }
-
-        if !isMessageBusActive {
-            await startMessageBus()
-        }
-
-        while !Task.isCancelled {
-            do {
-                try await Task.sleep(for: .seconds(3600))
-            } catch {
-                break
-            }
-        }
+        await topicDetailStore?.maintainTopicDetailSubscription(
+            topicId: topicId,
+            ownerToken: ownerToken
+        )
     }
 
     // MARK: - Write interactions
 
     func isSubmittingReply(topicId: UInt64) -> Bool {
-        submittingReplyTopicIDs.contains(topicId)
+        topicDetailStore?.isSubmittingReply(topicId: topicId) ?? false
     }
 
     func isMutatingPost(postId: UInt64) -> Bool {
-        mutatingPostIDs.contains(postId)
+        topicDetailStore?.isMutatingPost(postId: postId) ?? false
     }
 
     func categoryPresentation(for categoryID: UInt64?) -> FireTopicCategoryPresentation? {
-        guard let categoryID else {
-            return nil
+        if let category = homeFeedStore?.categoryPresentation(for: categoryID) {
+            return category
         }
-        return topicCategories[categoryID]
+        guard let categoryID else { return nil }
+        return session.bootstrap.categories.first(where: { $0.id == categoryID })
     }
 
     func allCategories() -> [FireTopicCategoryPresentation] {
-        session.bootstrap.categories
+        homeFeedStore?.allCategories ?? session.bootstrap.categories
     }
 
     func topTags() -> [String] {
-        session.bootstrap.topTags
+        homeFeedStore?.topTags ?? session.bootstrap.topTags
     }
 
     var canTagTopics: Bool {
-        session.bootstrap.canTagTopics
+        homeFeedStore?.canTagTopics ?? session.bootstrap.canTagTopics
     }
 
     func fetchFilteredTopicList(query: TopicListQueryState) async throws -> TopicListState {
@@ -682,48 +484,14 @@ final class FireAppViewModel: ObservableObject {
         raw: String,
         replyToPostNumber: UInt32?
     ) async throws {
-        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            throw FireTopicInteractionError.emptyReply
+        guard let topicDetailStore else {
+            throw FireTopicInteractionError.unavailable
         }
-
-        let sessionStore = try await sessionStoreValue()
-        guard session.readiness.canWriteAuthenticatedApi else {
-            throw FireTopicInteractionError.requiresAuthenticatedWrite
-        }
-        guard !submittingReplyTopicIDs.contains(topicId) else {
-            return
-        }
-
-        submittingReplyTopicIDs.insert(topicId)
-        defer { submittingReplyTopicIDs.remove(topicId) }
-
-        do {
-            errorMessage = nil
-            let createdReply = try await FireAPMManager.shared.withSpan(
-                .topicReplySubmit,
-                metadata: [
-                    "topic_id": String(topicId),
-                    "reply_to_post_number": replyToPostNumber.map(String.init) ?? "root"
-                ]
-            ) {
-                try await performWriteWithCloudflareRetry {
-                    try await sessionStore.createReply(
-                        topicID: topicId,
-                        raw: trimmed,
-                        replyToPostNumber: replyToPostNumber
-                    )
-                }
-            }
-            if let snapshot = try? await sessionStore.snapshot() {
-                await applySession(snapshot)
-            }
-            applyCreatedReply(createdReply, topicId: topicId)
-            try? await refreshTopicDetailAfterMutation(topicId: topicId, sessionStore: sessionStore)
-        } catch {
-            _ = await handleInteractionError(error)
-            throw error
-        }
+        try await topicDetailStore.submitReply(
+            topicId: topicId,
+            raw: raw,
+            replyToPostNumber: replyToPostNumber
+        )
     }
 
     func createTopic(
@@ -756,10 +524,8 @@ final class FireAppViewModel: ObservableObject {
                     tags: tags
                 )
             }
-            if let snapshot = try? await sessionStore.snapshot() {
-                await applySession(snapshot)
-            }
-            await refreshTopicsIfPossible(force: true)
+            await syncSessionSnapshotIfAvailable(from: sessionStore)
+            await refreshHomeFeedIfPossible(force: true)
             return topicID
         } catch {
             _ = await handleInteractionError(error)
@@ -802,9 +568,7 @@ final class FireAppViewModel: ObservableObject {
                     targetRecipients: recipients
                 )
             }
-            if let snapshot = try? await sessionStore.snapshot() {
-                await applySession(snapshot)
-            }
+            await syncSessionSnapshotIfAvailable(from: sessionStore)
             return topicID
         } catch {
             _ = await handleInteractionError(error)
@@ -838,11 +602,9 @@ final class FireAppViewModel: ObservableObject {
                     tags: tags
                 )
             }
-            if let snapshot = try? await sessionStore.snapshot() {
-                await applySession(snapshot)
-            }
-            await refreshTopicsIfPossible(force: true)
-            try? await refreshTopicDetailAfterMutation(topicId: topicID, sessionStore: sessionStore)
+            await syncSessionSnapshotIfAvailable(from: sessionStore)
+            await refreshHomeFeedIfPossible(force: true)
+            await topicDetailStore?.refreshTopicDetailAfterMutation(topicId: topicID)
         } catch {
             _ = await handleInteractionError(error)
             throw error
@@ -860,41 +622,15 @@ final class FireAppViewModel: ObservableObject {
         raw: String,
         editReason: String? = nil
     ) async throws -> TopicPostState {
-        let trimmedRaw = raw.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedRaw.isEmpty else {
-            throw FireTopicInteractionError.emptyReply
+        guard let topicDetailStore else {
+            throw FireTopicInteractionError.unavailable
         }
-
-        let sessionStore = try await sessionStoreValue()
-        guard session.readiness.canWriteAuthenticatedApi else {
-            throw FireTopicInteractionError.requiresAuthenticatedWrite
-        }
-        guard !mutatingPostIDs.contains(postID) else {
-            return try await sessionStore.fetchPost(postID: postID)
-        }
-
-        mutatingPostIDs.insert(postID)
-        defer { mutatingPostIDs.remove(postID) }
-
-        do {
-            errorMessage = nil
-            let updatedPost = try await performWriteWithCloudflareRetry {
-                try await sessionStore.updatePost(
-                    postID: postID,
-                    raw: trimmedRaw,
-                    editReason: editReason
-                )
-            }
-            if let snapshot = try? await sessionStore.snapshot() {
-                await applySession(snapshot)
-            }
-            try? await refreshTopicDetailAfterMutation(topicId: topicID, sessionStore: sessionStore)
-            await refreshTopicsIfPossible(force: false)
-            return updatedPost
-        } catch {
-            _ = await handleInteractionError(error)
-            throw error
-        }
+        return try await topicDetailStore.updatePost(
+            topicID: topicID,
+            postID: postID,
+            raw: raw,
+            editReason: editReason
+        )
     }
 
     func fetchDrafts(
@@ -967,38 +703,14 @@ final class FireAppViewModel: ObservableObject {
         postId: UInt64,
         liked: Bool
     ) async throws {
-        let sessionStore = try await sessionStoreValue()
-        guard session.readiness.canWriteAuthenticatedApi else {
-            throw FireTopicInteractionError.requiresAuthenticatedWrite
+        guard let topicDetailStore else {
+            throw FireTopicInteractionError.unavailable
         }
-        guard !mutatingPostIDs.contains(postId) else {
-            return
-        }
-
-        mutatingPostIDs.insert(postId)
-        defer { mutatingPostIDs.remove(postId) }
-
-        do {
-            errorMessage = nil
-            let update = try await performWriteWithCloudflareRetry {
-                if liked {
-                    try await sessionStore.likePost(postID: postId)
-                } else {
-                    try await sessionStore.unlikePost(postID: postId)
-                }
-            }
-            if let snapshot = try? await sessionStore.snapshot() {
-                await applySession(snapshot)
-            }
-            if let update {
-                applyPostReactionUpdate(topicId: topicId, postId: postId, update: update)
-            } else {
-                try? await refreshTopicDetailAfterMutation(topicId: topicId, sessionStore: sessionStore)
-            }
-        } catch {
-            _ = await handleInteractionError(error)
-            throw error
-        }
+        try await topicDetailStore.setPostLiked(
+            topicId: topicId,
+            postId: postId,
+            liked: liked
+        )
     }
 
     func togglePostReaction(
@@ -1006,35 +718,14 @@ final class FireAppViewModel: ObservableObject {
         postId: UInt64,
         reactionId: String
     ) async throws {
-        let trimmedReactionID = reactionId.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmedReactionID.isEmpty else {
-            return
+        guard let topicDetailStore else {
+            throw FireTopicInteractionError.unavailable
         }
-
-        let sessionStore = try await sessionStoreValue()
-        guard session.readiness.canWriteAuthenticatedApi else {
-            throw FireTopicInteractionError.requiresAuthenticatedWrite
-        }
-        guard !mutatingPostIDs.contains(postId) else {
-            return
-        }
-
-        mutatingPostIDs.insert(postId)
-        defer { mutatingPostIDs.remove(postId) }
-
-        do {
-            errorMessage = nil
-            let update = try await performWriteWithCloudflareRetry {
-                try await sessionStore.togglePostReaction(
-                    postID: postId,
-                    reactionID: trimmedReactionID
-                )
-            }
-            applyPostReactionUpdate(topicId: topicId, postId: postId, update: update)
-        } catch {
-            _ = await handleInteractionError(error)
-            throw error
-        }
+        try await topicDetailStore.togglePostReaction(
+            topicId: topicId,
+            postId: postId,
+            reactionId: reactionId
+        )
     }
 
     func votePoll(
@@ -1047,12 +738,9 @@ final class FireAppViewModel: ObservableObject {
         guard session.readiness.canWriteAuthenticatedApi else {
             throw FireTopicInteractionError.requiresAuthenticatedWrite
         }
-        guard !mutatingPostIDs.contains(postID) else {
+        guard topicDetailStore?.isMutatingPost(postId: postID) != true else {
             throw FireTopicInteractionError.unavailable
         }
-
-        mutatingPostIDs.insert(postID)
-        defer { mutatingPostIDs.remove(postID) }
 
         do {
             errorMessage = nil
@@ -1063,7 +751,7 @@ final class FireAppViewModel: ObservableObject {
                     options: options
                 )
             }
-            try? await refreshTopicDetailAfterMutation(topicId: topicID, sessionStore: sessionStore)
+            await topicDetailStore?.refreshTopicDetailAfterMutation(topicId: topicID)
             return poll
         } catch {
             _ = await handleInteractionError(error)
@@ -1080,19 +768,16 @@ final class FireAppViewModel: ObservableObject {
         guard session.readiness.canWriteAuthenticatedApi else {
             throw FireTopicInteractionError.requiresAuthenticatedWrite
         }
-        guard !mutatingPostIDs.contains(postID) else {
+        guard topicDetailStore?.isMutatingPost(postId: postID) != true else {
             throw FireTopicInteractionError.unavailable
         }
-
-        mutatingPostIDs.insert(postID)
-        defer { mutatingPostIDs.remove(postID) }
 
         do {
             errorMessage = nil
             let poll = try await performWriteWithCloudflareRetry {
                 try await sessionStore.unvotePoll(postID: postID, pollName: pollName)
             }
-            try? await refreshTopicDetailAfterMutation(topicId: topicID, sessionStore: sessionStore)
+            await topicDetailStore?.refreshTopicDetailAfterMutation(topicId: topicID)
             return poll
         } catch {
             _ = await handleInteractionError(error)
@@ -1115,7 +800,7 @@ final class FireAppViewModel: ObservableObject {
                     try await sessionStore.unvoteTopic(topicID: topicID)
                 }
             }
-            try? await refreshTopicDetailAfterMutation(topicId: topicID, sessionStore: sessionStore)
+            await topicDetailStore?.refreshTopicDetailAfterMutation(topicId: topicID)
             return response
         } catch {
             _ = await handleInteractionError(error)
@@ -1428,16 +1113,10 @@ final class FireAppViewModel: ObservableObject {
         messageBusRetryTask = nil
         messageBusStartRetryCount = 0
         notificationStore?.cancelScheduledRefresh()
+        homeFeedStore?.handleMessageBusStopped()
+        topicDetailStore?.handleMessageBusStopped()
         clearMessageBusError()
         guard isMessageBusActive else { return }
-        pendingTopicListRefreshTask?.cancel()
-        pendingTopicListRefreshTask = nil
-        topicListMessageBusRefreshController.reset()
-        pendingTopicDetailRefreshTasks.values.forEach { $0.cancel() }
-        pendingTopicDetailRefreshTasks = [:]
-        topicPresenceHeartbeatTasks.values.forEach { $0.cancel() }
-        topicPresenceHeartbeatTasks = [:]
-        topicPresenceUsersByTopic = [:]
         messageBusCoordinator = nil
         isMessageBusActive = false
         guard let sessionStore else { return }
@@ -1447,21 +1126,10 @@ final class FireAppViewModel: ObservableObject {
     private func handleMessageBusEvent(_ event: MessageBusEventState) {
         switch event.kind {
         case .topicList:
-            scheduleTopicListRefresh(for: event)
+            homeFeedStore?.handleTopicListMessageBusEvent(event)
 
-        case .topicDetail:
-            guard let topicId = event.topicId else { return }
-            guard topicDetails[topicId] != nil else { return }
-            scheduleTopicDetailRefresh(topicId: topicId)
-
-        case .topicReaction:
-            guard let topicId = event.topicId else { return }
-            guard topicDetails[topicId] != nil else { return }
-            scheduleTopicDetailRefresh(topicId: topicId)
-
-        case .presence:
-            guard let topicId = event.topicId else { return }
-            refreshTopicPresenceState(topicId: topicId)
+        case .topicDetail, .topicReaction, .presence:
+            topicDetailStore?.handleMessageBusEvent(event)
 
         case .notification:
             notificationStore?.scheduleStateRefresh()
@@ -1474,126 +1142,12 @@ final class FireAppViewModel: ObservableObject {
         }
     }
 
-    private var currentTopicListRefreshScope: FireTopicListRefreshScope {
-        FireTopicListRefreshScope(
-            kind: selectedTopicKind,
-            categoryId: selectedHomeCategoryId,
-            tags: selectedHomeTags
-        )
-    }
-
-    private func scheduleTopicListRefresh(for event: MessageBusEventState) {
-        guard let busKind = event.topicListKind else { return }
-        let scope = currentTopicListRefreshScope
-        guard busKind == scope.kind else { return }
-
-        let allowIncremental = scope.supportsIncrementalMessageBusRefresh && !topicRows.isEmpty
-        guard let delay = topicListMessageBusRefreshController.register(
-            event: event,
-            for: scope,
-            now: topicListRefreshClock.now,
-            allowIncremental: allowIncremental
-        ) else {
-            return
-        }
-
-        pendingTopicListRefreshTask?.cancel()
-        pendingTopicListRefreshTask = Task { [weak self] in
-            do {
-                try await Task.sleep(for: delay)
-            } catch {
-                return
-            }
-
-            guard let self else { return }
-
-            while self.isLoadingTopics {
-                do {
-                    try await Task.sleep(for: Self.topicListRefreshLoadingPollInterval)
-                } catch {
-                    return
-                }
-            }
-
-            let scope = self.currentTopicListRefreshScope
-            let refreshMode = self.topicListMessageBusRefreshController.takePendingRefresh(for: scope)
-            self.pendingTopicListRefreshTask = nil
-
-            guard let refreshMode else { return }
-            await self.refreshTopicsFromMessageBus(refreshMode)
-        }
-    }
-
-    private func scheduleTopicDetailRefresh(topicId: UInt64) {
-        pendingTopicDetailRefreshTasks[topicId]?.cancel()
-        pendingTopicDetailRefreshTasks[topicId] = Task { [weak self] in
-            try? await Task.sleep(for: .seconds(1.5))
-            guard !Task.isCancelled else { return }
-            guard let self, let store = self.sessionStore else { return }
-            guard self.topicDetails[topicId] != nil else { return }
-            let anchorPostNumber = self.topicDetailTargetPostNumbers[topicId]
-            do {
-                let detail = try await store.fetchTopicDetailInitial(
-                    query: TopicDetailQueryState(
-                        topicId: topicId,
-                        postNumber: anchorPostNumber,
-                        trackVisit: false,
-                        filter: nil,
-                        usernameFilters: nil,
-                        filterTopLevelReplies: false
-                    )
-                )
-                self.applyTopicDetail(detail, topicId: topicId)
-            } catch {
-                if await self.handleRecoverableSessionErrorIfNeeded(error) {
-                    return
-                }
-            }
-        }
-    }
-
-    private func refreshTopicPresenceState(topicId: UInt64) {
-        guard let store = sessionStore else { return }
-        Task { [weak self] in
-            guard let self else { return }
-            guard let presence = try? await store.topicReplyPresenceState(topicId: topicId) else {
-                return
-            }
-            self.applyTopicPresenceState(presence)
-        }
-    }
-
     func beginTopicReplyPresence(topicId: UInt64) {
-        guard isMessageBusActive else { return }
-        guard session.readiness.canWriteAuthenticatedApi else { return }
-        guard topicPresenceHeartbeatTasks[topicId] == nil else { return }
-        guard let store = sessionStore else { return }
-
-        topicPresenceHeartbeatTasks[topicId] = Task { [weak self] in
-            while !Task.isCancelled {
-                do {
-                    try await store.updateTopicReplyPresence(topicId: topicId, active: true)
-                } catch {
-                    return
-                }
-
-                guard let self else { return }
-                guard self.topicPresenceHeartbeatTasks[topicId] != nil else { return }
-
-                do {
-                    try await Task.sleep(for: .seconds(30))
-                } catch {
-                    return
-                }
-            }
-        }
+        topicDetailStore?.beginTopicReplyPresence(topicId: topicId)
     }
 
     func endTopicReplyPresence(topicId: UInt64) async {
-        let task = topicPresenceHeartbeatTasks.removeValue(forKey: topicId)
-        task?.cancel()
-        guard let store = sessionStore else { return }
-        try? await store.updateTopicReplyPresence(topicId: topicId, active: false)
+        await topicDetailStore?.endTopicReplyPresence(topicId: topicId)
     }
 
     // MARK: - Private helpers
@@ -1614,199 +1168,12 @@ final class FireAppViewModel: ObservableObject {
     }
 
     private func refreshTopicsIfPossible(force: Bool) async {
-        cancelPendingTopicListRefresh()
-        await loadTopics(page: nil, reset: true, force: force, refreshMode: .full)
-    }
-
-    private func refreshTopicsFromMessageBus(_ refreshMode: FireTopicListMessageBusRefreshMode) async {
-        await loadTopics(page: nil, reset: true, force: true, refreshMode: refreshMode)
-    }
-
-    @discardableResult
-    private func loadTopics(
-        page: UInt32?,
-        reset: Bool,
-        force: Bool,
-        refreshMode: FireTopicListMessageBusRefreshMode = .full
-    ) async -> Bool {
-        if !session.readiness.canReadAuthenticatedApi {
-            clearTopicState()
-            return false
-        }
-        if isLoadingTopics {
-            return false
-        }
-        if reset && !force && !topicRows.isEmpty {
-            return false
-        }
-
-        isLoadingTopics = true
-        isAppendingTopics = !reset
-        defer {
-            isLoadingTopics = false
-            isAppendingTopics = false
-        }
-
-        do {
-            let sessionStore = try await sessionStoreValue()
-            errorMessage = nil
-            let requestedKind = selectedTopicKind
-            let categoryId = selectedHomeCategoryId
-            let requestedTags = selectedHomeTags
-            let requestedScope = FireTopicListRefreshScope(
-                kind: requestedKind,
-                categoryId: categoryId,
-                tags: requestedTags
-            )
-            let categorySlug = categoryId.flatMap { categoryPresentation(for: $0)?.slug }
-            let parentSlug: String? = categoryId.flatMap { id in
-                guard let cat = categoryPresentation(for: id),
-                      let parentId = cat.parentCategoryId else { return nil }
-                return categoryPresentation(for: parentId)?.slug
-            }
-            let primaryTag = requestedTags.first
-            let additionalTags = requestedTags.count > 1
-                ? Array(requestedTags.dropFirst())
-                : []
-            let incrementalTopicIDs: [UInt64]
-            switch refreshMode {
-            case .full:
-                incrementalTopicIDs = []
-            case .incremental(let topicIDs):
-                incrementalTopicIDs = topicIDs
-            }
-            let usesIncrementalRefresh = page == nil
-                && reset
-                && !incrementalTopicIDs.isEmpty
-                && requestedScope.supportsIncrementalMessageBusRefresh
-                && !topicRows.isEmpty
-            let fetch: () async throws -> TopicListState = {
-                try await sessionStore.fetchTopicList(
-                    query: TopicListQueryState(
-                        kind: requestedKind,
-                        page: page,
-                        topicIds: usesIncrementalRefresh ? incrementalTopicIDs : [],
-                        order: nil,
-                        ascending: nil,
-                        categorySlug: categorySlug,
-                        categoryId: categoryId,
-                        parentCategorySlug: parentSlug,
-                        tag: primaryTag,
-                        additionalTags: additionalTags,
-                        matchAllTags: !additionalTags.isEmpty
-                    )
-                )
-            }
-            let response: TopicListState
-            if reset && page == nil && requestedKind == .latest {
-                response = try await FireAPMManager.shared.withSpan(
-                    .feedLatestInitialLoad,
-                    metadata: [
-                        "category_id": categoryId.map(String.init) ?? "none",
-                        "tag": primaryTag ?? "none",
-                        "incremental": usesIncrementalRefresh ? "true" : "false"
-                    ],
-                    operation: fetch
-                )
-            } else {
-                response = try await fetch()
-            }
-            guard requestedScope == currentTopicListRefreshScope else {
-                return false
-            }
-            let mergedTopicRows = if reset {
-                if usesIncrementalRefresh {
-                    FireTopicListMessageBusRefreshMerger.merge(
-                        existing: topicRows,
-                        incoming: response.rows
-                    )
-                } else {
-                    response.rows
-                }
-            } else {
-                mergeItemsByID(topicRows, response.rows, keyPath: \.topic.id)
-            }
-            let visibleTopicIDs = Set(mergedTopicRows.map(\.topic.id))
-            topicRows = mergedTopicRows
-            if !usesIncrementalRefresh {
-                moreTopicsUrl = response.moreTopicsUrl
-                nextTopicsPage = response.nextPage
-            }
-            let retainedTopicIDs = retainedTopicDetailIDs(visibleTopicIDs: visibleTopicIDs)
-            pruneInactiveTopicDetailState(retaining: retainedTopicIDs)
-            if reset && page == nil {
-                topicListMessageBusRefreshController.markRefreshCompleted(
-                    for: requestedScope,
-                    at: topicListRefreshClock.now
-                )
-            }
-            return true
-        } catch {
-            if await handleRecoverableSessionErrorIfNeeded(error) {
-                return false
-            }
-            if reset, case .full = refreshMode {
-                topicRows = []
-                moreTopicsUrl = nil
-                nextTopicsPage = nil
-            }
-            errorMessage = error.localizedDescription
-            return false
-        }
+        await refreshHomeFeedIfPossible(force: force)
     }
 
     private func clearTopicState() {
-        cancelPendingTopicListRefresh()
-        pendingTopicDetailRefreshTasks.values.forEach { $0.cancel() }
-        pendingTopicDetailRefreshTasks = [:]
-        topicPresenceHeartbeatTasks.values.forEach { $0.cancel() }
-        topicPresenceHeartbeatTasks = [:]
-        for task in topicPostPreloadTasks.values {
-            task.cancel()
-        }
-        activeTopicDetailOwnerTokens = [:]
-        topicPostPreloadTasks = [:]
-        topicRows = []
-        moreTopicsUrl = nil
-        nextTopicsPage = nil
-        topicDetails = [:]
-        topicPostPaginationStates = [:]
-        topicPresenceUsersByTopic = [:]
-        isLoadingTopics = false
-        isAppendingTopics = false
-        loadingTopicIDs = []
-        loadingMoreTopicPostIDs = []
-        submittingReplyTopicIDs = []
-        mutatingPostIDs = []
-        selectedHomeCategoryId = nil
-        selectedHomeTags = []
-    }
-
-    private func cancelPendingTopicListRefresh() {
-        pendingTopicListRefreshTask?.cancel()
-        pendingTopicListRefreshTask = nil
-
-        let scope = currentTopicListRefreshScope
-        topicListMessageBusRefreshController.clearPending(for: scope)
-    }
-
-    private func mergeItemsByID<Item>(
-        _ existing: [Item],
-        _ incoming: [Item],
-        keyPath: KeyPath<Item, UInt64>
-    ) -> [Item] {
-        var merged = Dictionary(uniqueKeysWithValues: existing.map { ($0[keyPath: keyPath], $0) })
-        var orderedIDs = existing.map { $0[keyPath: keyPath] }
-
-        for item in incoming {
-            let id = item[keyPath: keyPath]
-            if merged[id] == nil {
-                orderedIDs.append(id)
-            }
-            merged[id] = item
-        }
-
-        return orderedIDs.compactMap { merged[$0] }
+        homeFeedStore?.reset(resetTopicKind: true)
+        topicDetailStore?.reset()
     }
 
     private func finishInitialStateLoading(generation: UInt64) {
@@ -1821,20 +1188,6 @@ final class FireAppViewModel: ObservableObject {
         initialStateTask = nil
     }
 
-    private func applyTopicPresenceState(_ state: TopicPresenceState) {
-        let currentUserID = session.bootstrap.currentUserId
-        let filteredUsers = state.users.filter { user in
-            guard let currentUserID else { return true }
-            return user.id != currentUserID
-        }
-
-        if filteredUsers.isEmpty {
-            topicPresenceUsersByTopic.removeValue(forKey: state.topicId)
-        } else {
-            topicPresenceUsersByTopic[state.topicId] = filteredUsers
-        }
-    }
-
     private func applySession(_ session: SessionState) async {
         let shouldMirrorCookies = session.cookies != self.session.cookies
             || session.bootstrap.baseUrl != self.session.bootstrap.baseUrl
@@ -1842,7 +1195,8 @@ final class FireAppViewModel: ObservableObject {
         if shouldMirrorCookies {
             await session.mirrorCookiesToNativeStorage()
         }
-        topicCategories = Dictionary(uniqueKeysWithValues: session.bootstrap.categories.map { ($0.id, $0) })
+        homeFeedStore?.applySession(session)
+        topicDetailStore?.applySession(session)
 
         if session.readiness.canReadAuthenticatedApi {
             await notificationStore?.syncStateFromRuntimeIfAvailable()
@@ -1885,24 +1239,7 @@ final class FireAppViewModel: ObservableObject {
         }
     }
 
-    private func refreshTopicDetailAfterMutation(
-        topicId: UInt64,
-        sessionStore: FireSessionStore
-    ) async throws {
-        let detail = try await sessionStore.fetchTopicDetailInitial(
-            query: TopicDetailQueryState(
-                topicId: topicId,
-                postNumber: nil,
-                trackVisit: false,
-                filter: nil,
-                usernameFilters: nil,
-                filterTopLevelReplies: false
-            )
-        )
-        applyTopicDetail(detail, topicId: topicId)
-    }
-
-    private func performWriteWithCloudflareRetry<T>(
+    func performWriteWithCloudflareRetry<T>(
         operation: () async throws -> T
     ) async throws -> T {
         do {
@@ -1984,7 +1321,6 @@ final class FireAppViewModel: ObservableObject {
             await applySession(.placeholder(baseUrl: session.bootstrap.baseUrl))
         }
 
-        selectedTopicKind = .latest
         clearTopicState()
         notificationStore?.reset()
         errorMessage = message
@@ -2104,315 +1440,46 @@ final class FireAppViewModel: ObservableObject {
         ["_t", "_forum_session", "cf_clearance"].contains(name)
     }
 
-    private func evictTopicDetailState(topicId: UInt64, reason: String) {
-        let removedDetail = topicDetails.removeValue(forKey: topicId) != nil
-        let removedPagination = topicPostPaginationStates.removeValue(forKey: topicId) != nil
-        let removedPresence = topicPresenceUsersByTopic.removeValue(forKey: topicId) != nil
-        let removedLoadingTopic = loadingTopicIDs.remove(topicId) != nil
-        let removedLoadingMore = loadingMoreTopicPostIDs.remove(topicId) != nil
-        let refreshTask = pendingTopicDetailRefreshTasks.removeValue(forKey: topicId)
-        let presenceTask = topicPresenceHeartbeatTasks.removeValue(forKey: topicId)
-        let preloadTask = topicPostPreloadTasks.removeValue(forKey: topicId)
-        refreshTask?.cancel()
-        presenceTask?.cancel()
-        preloadTask?.cancel()
-
-        guard removedDetail
-            || removedPagination
-            || removedPresence
-            || removedLoadingTopic
-            || removedLoadingMore
-            || refreshTask != nil
-            || presenceTask != nil
-            || preloadTask != nil
-        else {
-            return
-        }
-
-        topicDetailLogger()?.notice(
-            "evicted topic detail state topic_id=\(topicId) reason=\(reason)"
-        )
-    }
-
-    private func pruneInactiveTopicDetailState(retaining retainedTopicIDs: Set<UInt64>) {
-        let trackedTopicIDs = Set(topicDetails.keys)
-            .union(topicPostPaginationStates.keys)
-            .union(topicPresenceUsersByTopic.keys)
-            .union(loadingTopicIDs)
-            .union(loadingMoreTopicPostIDs)
-            .union(topicPostPreloadTasks.keys)
-            .union(pendingTopicDetailRefreshTasks.keys)
-            .union(topicPresenceHeartbeatTasks.keys)
-        let inactiveTopicIDs = trackedTopicIDs.subtracting(retainedTopicIDs)
-        guard !inactiveTopicIDs.isEmpty else {
-            return
-        }
-
-        let activeTopicIDs = retainedTopicIDs.subtracting(Set(topicRows.map(\.topic.id)))
-        topicDetailLogger()?.notice(
-            "pruning inactive topic detail state retained_active_topic_ids=\(Self.formattedTopicIDs(activeTopicIDs)) pruned_topic_ids=\(Self.formattedTopicIDs(inactiveTopicIDs))"
-        )
-
-        for topicId in inactiveTopicIDs.sorted() {
-            evictTopicDetailState(topicId: topicId, reason: "topic list refresh pruned inactive detail")
-        }
-    }
-
-    private static func formattedTopicIDs(_ topicIDs: Set<UInt64>) -> String {
-        topicIDs.sorted().map(String.init).joined(separator: ",")
-    }
-
     private func syncPlatformCookiesFromWebViewStore() async throws {
         let loginCoordinator = try await loginCoordinatorValue()
         let session = try await loginCoordinator.refreshPlatformCookies()
         await applySession(session)
     }
 
-    private func topicDetailLogger() -> FireHostLogger? {
+    func topicDetailLogger() -> FireHostLogger? {
         sessionStore?.makeLogger(target: Self.topicDetailLogTarget)
     }
 
-    private func applyTopicDetail(_ incomingDetail: TopicDetailState, topicId: UInt64) {
-        let previousDetail = topicDetails[topicId]
-        let previousTargetLoadedCount = topicPostPaginationStates[topicId]?.targetLoadedCount
-            ?? previousDetail.map { FireTopicPresentation.loadedWindowCount(detail: $0) }
-            ?? 0
-        let previousWasFullyLoaded = previousDetail.map {
-            previousTargetLoadedCount >= $0.postStream.stream.count
-        } ?? false
-
-        var detail = incomingDetail
-        if let previousDetail {
-            detail.postStream.posts = FireTopicPresentation.mergeTopicPosts(
-                existing: previousDetail.postStream.posts,
-                incoming: detail.postStream.posts,
-                orderedPostIDs: detail.postStream.stream
-            )
-        }
-        detail = FireTopicPresentation.recomposedDetail(detail)
-
-        let loadedWindowCount = FireTopicPresentation.loadedWindowCount(detail: detail)
-        let targetLoadedCount = min(
-            max(previousWasFullyLoaded ? detail.postStream.stream.count : previousTargetLoadedCount, loadedWindowCount),
-            detail.postStream.stream.count
-        )
-        topicDetails[topicId] = detail
-        topicPostPaginationStates[topicId] = FireTopicPostPaginationState(
-            targetLoadedCount: targetLoadedCount
-        )
-
-        let missingPostIDs = FireTopicPresentation.missingPostIDs(
-            in: detail,
-            upTo: targetLoadedCount
-        )
-        if !missingPostIDs.isEmpty {
-            Task {
-                await hydrateTopicPostsToTargetIfNeeded(topicId: topicId)
-            }
-        }
+    func currentSessionStore() -> FireSessionStore? {
+        sessionStore
     }
 
-    private func applyCreatedReply(_ reply: TopicPostState, topicId: UInt64) {
-        guard var detail = topicDetails[topicId] else {
-            return
-        }
-
-        let isNewPost = !detail.postStream.stream.contains(reply.id)
-        if isNewPost {
-            detail.postStream.stream.append(reply.id)
-        }
-
-        if let postIndex = detail.postStream.posts.firstIndex(where: { $0.id == reply.id }) {
-            detail.postStream.posts[postIndex] = reply
-        } else {
-            detail.postStream.posts.append(reply)
-        }
-
-        if isNewPost {
-            detail.postsCount = max(
-                detail.postsCount + 1,
-                UInt32(detail.postStream.stream.count)
-            )
-        }
-
-        detail = FireTopicPresentation.recomposedDetail(detail)
-        topicDetails[topicId] = detail
-
-        var pagination = topicPostPaginationStates[topicId]
-            ?? FireTopicPostPaginationState(
-                targetLoadedCount: FireTopicPresentation.loadedWindowCount(detail: detail)
-            )
-        pagination.targetLoadedCount = max(pagination.targetLoadedCount, detail.postStream.stream.count)
-        pagination.exhaustedPostIDs.remove(reply.id)
-        topicPostPaginationStates[topicId] = pagination
+    func ensureMessageBusActiveIfPossible() async {
+        guard !isMessageBusActive else { return }
+        await startMessageBus()
     }
 
-    private func loadMoreTopicPostsIfNeeded(topicId: UInt64) async {
-        guard var pagination = topicPostPaginationStates[topicId],
-              let detail = topicDetails[topicId] else {
-            return
-        }
-        guard !Task.isCancelled else {
-            return
-        }
-        guard !loadingMoreTopicPostIDs.contains(topicId) else {
-            return
-        }
-
-        let loadedWindowCount = FireTopicPresentation.loadedWindowCount(detail: detail)
-        let currentTargetLoadedCount = min(
-            max(pagination.targetLoadedCount, loadedWindowCount),
-            detail.postStream.stream.count
-        )
-        let missingPostIDs = FireTopicPresentation.missingPostIDs(
-            in: detail,
-            upTo: currentTargetLoadedCount,
-            excluding: pagination.exhaustedPostIDs
-        )
-        guard !missingPostIDs.isEmpty || currentTargetLoadedCount < detail.postStream.stream.count else {
-            return
-        }
-
-        if currentTargetLoadedCount < detail.postStream.stream.count {
-            pagination.targetLoadedCount = min(
-                currentTargetLoadedCount + Self.topicPostPageSize,
-                detail.postStream.stream.count
-            )
-            topicPostPaginationStates[topicId] = pagination
-        }
-        await hydrateTopicPostsToTargetIfNeeded(topicId: topicId)
+    func refreshHomeFeedIfPossible(force: Bool) async {
+        await homeFeedStore?.refreshTopicsIfPossible(force: force)
     }
 
-    private func hydrateTopicPostsToTargetIfNeeded(topicId: UInt64) async {
-        guard let sessionStore else {
-            return
-        }
-        guard !Task.isCancelled else {
-            return
-        }
-        guard !loadingMoreTopicPostIDs.contains(topicId) else {
-            return
-        }
-
-        loadingMoreTopicPostIDs.insert(topicId)
-        defer { loadingMoreTopicPostIDs.remove(topicId) }
-
-        var hydratedPosts: [TopicPostState] = []
-        var hydratedPostIDs: Set<UInt64> = []
-        var exhaustedPostIDs: Set<UInt64> = []
-
-        while !Task.isCancelled {
-            guard let detail = topicDetails[topicId],
-                  let pagination = topicPostPaginationStates[topicId] else {
-                return
-            }
-
-            let missingPostIDs = FireTopicPresentation.missingPostIDs(
-                orderedPostIDs: detail.postStream.stream,
-                loadedPostIDs: Set(detail.postStream.posts.map(\.id)).union(hydratedPostIDs),
-                upTo: pagination.targetLoadedCount,
-                excluding: pagination.exhaustedPostIDs.union(exhaustedPostIDs)
-            )
-            guard !missingPostIDs.isEmpty else {
-                applyHydratedTopicPostsIfNeeded(
-                    topicId: topicId,
-                    posts: hydratedPosts,
-                    exhaustedPostIDs: exhaustedPostIDs
-                )
-                return
-            }
-
-            let batchPostIDs = Array(missingPostIDs.prefix(Self.topicPostPageSize))
-
-            do {
-                let fetchedPosts = try await sessionStore.fetchTopicPosts(
-                    topicID: topicId,
-                    postIDs: batchPostIDs
-                )
-                let returnedPostIDs = Set(fetchedPosts.map(\.id))
-                exhaustedPostIDs.formUnion(
-                    batchPostIDs.filter { !returnedPostIDs.contains($0) }
-                )
-                hydratedPosts.append(contentsOf: fetchedPosts)
-                hydratedPostIDs.formUnion(returnedPostIDs)
-            } catch {
-                applyHydratedTopicPostsIfNeeded(
-                    topicId: topicId,
-                    posts: hydratedPosts,
-                    exhaustedPostIDs: exhaustedPostIDs
-                )
-                if await handleRecoverableSessionErrorIfNeeded(error) {
-                    return
-                }
-                return
-            }
-        }
-
-        applyHydratedTopicPostsIfNeeded(
-            topicId: topicId,
-            posts: hydratedPosts,
-            exhaustedPostIDs: exhaustedPostIDs
+    func pruneTopicDetailState(retainingVisibleTopicIDs visibleTopicIDs: Set<UInt64>) {
+        topicDetailStore?.pruneInactiveTopicDetailState(
+            retainingVisibleTopicIDs: visibleTopicIDs
         )
     }
 
-    private func applyHydratedTopicPostsIfNeeded(
-        topicId: UInt64,
-        posts: [TopicPostState],
-        exhaustedPostIDs: Set<UInt64>
-    ) {
-        guard !posts.isEmpty || !exhaustedPostIDs.isEmpty else {
-            return
-        }
-        guard var currentDetail = topicDetails[topicId],
-              var currentPagination = topicPostPaginationStates[topicId] else {
-            return
-        }
-
-        currentPagination.exhaustedPostIDs.formUnion(exhaustedPostIDs)
-        topicPostPaginationStates[topicId] = currentPagination
-
-        guard !posts.isEmpty else {
-            return
-        }
-
-        currentDetail.postStream.posts = FireTopicPresentation.mergeTopicPosts(
-            existing: currentDetail.postStream.posts,
-            incoming: posts,
-            orderedPostIDs: currentDetail.postStream.stream
-        )
-        topicDetails[topicId] = FireTopicPresentation.recomposedDetail(currentDetail)
+    func currentVisibleTopicIDs() -> Set<UInt64> {
+        homeFeedStore?.visibleTopicIDs ?? []
     }
 
-    private func applyPostReactionUpdate(
-        topicId: UInt64,
-        postId: UInt64,
-        update: PostReactionUpdateState
-    ) {
-        guard var detail = topicDetails[topicId] else {
-            return
+    func syncSessionSnapshotIfAvailable(from sessionStore: FireSessionStore) async {
+        if let snapshot = try? await sessionStore.snapshot() {
+            await applySession(snapshot)
         }
-        guard let postIndex = detail.postStream.posts.firstIndex(where: { $0.id == postId }) else {
-            return
-        }
-
-        var post = detail.postStream.posts[postIndex]
-        let previousHeartCount = post.reactions.first(where: { $0.id == "heart" })?.count
-        let updatedHeartCount = update.reactions.first(where: { $0.id == "heart" })?.count
-
-        post.reactions = update.reactions
-        post.currentUserReaction = update.currentUserReaction
-
-        if let updatedHeartCount {
-            post.likeCount = updatedHeartCount
-        } else if previousHeartCount != nil || post.currentUserReaction?.id == "heart" {
-            post.likeCount = 0
-        }
-
-        detail.postStream.posts[postIndex] = post
-        topicDetails[topicId] = FireTopicPresentation.recomposedDetail(detail)
     }
 
-    private func sessionStoreValue() async throws -> FireSessionStore {
+    func sessionStoreValue() async throws -> FireSessionStore {
         if let sessionStore {
             return sessionStore
         }

--- a/native/ios-app/App/FireCategoriesView.swift
+++ b/native/ios-app/App/FireCategoriesView.swift
@@ -3,19 +3,20 @@ import SwiftUI
 // MARK: - Category Browser Sheet (Home screen bottom sheet)
 
 struct FireCategoryBrowserSheet: View {
-    @ObservedObject var viewModel: FireAppViewModel
+    @EnvironmentObject private var homeFeedStore: FireHomeFeedStore
+    let viewModel: FireAppViewModel
     @Environment(\.dismiss) private var dismiss
 
     private var parentCategories: [FireTopicCategoryPresentation] {
-        viewModel.allCategories().filter { $0.parentCategoryId == nil }
+        homeFeedStore.allCategories.filter { $0.parentCategoryId == nil }
     }
 
     private var topTags: [String] {
-        viewModel.topTags()
+        homeFeedStore.topTags
     }
 
     private func subcategories(of parentID: UInt64) -> [FireTopicCategoryPresentation] {
-        viewModel.allCategories().filter { $0.parentCategoryId == parentID }
+        homeFeedStore.allCategories.filter { $0.parentCategoryId == parentID }
     }
 
     var body: some View {
@@ -88,10 +89,10 @@ struct FireCategoryBrowserSheet: View {
     }
 
     private func categoryGridItem(label: String, color: Color, categoryId: UInt64?) -> some View {
-        let isSelected = viewModel.selectedHomeCategoryId == categoryId
+        let isSelected = homeFeedStore.selectedHomeCategoryId == categoryId
         return Button {
             withAnimation(.easeInOut(duration: 0.2)) {
-                viewModel.selectHomeCategory(categoryId)
+                homeFeedStore.selectHomeCategory(categoryId)
             }
             dismiss()
         } label: {
@@ -130,7 +131,7 @@ struct FireCategoryBrowserSheet: View {
     ) -> some View {
         Menu {
             Button {
-                viewModel.selectHomeCategory(parent.id)
+                homeFeedStore.selectHomeCategory(parent.id)
                 dismiss()
             } label: {
                 Label(parent.displayName, systemImage: "folder")
@@ -140,15 +141,15 @@ struct FireCategoryBrowserSheet: View {
 
             ForEach(children, id: \.id) { child in
                 Button {
-                    viewModel.selectHomeCategory(child.id)
+                    homeFeedStore.selectHomeCategory(child.id)
                     dismiss()
                 } label: {
                     Text(child.displayName)
                 }
             }
         } label: {
-            let isSelected = viewModel.selectedHomeCategoryId == parent.id
-                || children.contains { viewModel.selectedHomeCategoryId == $0.id }
+            let isSelected = homeFeedStore.selectedHomeCategoryId == parent.id
+                || children.contains { homeFeedStore.selectedHomeCategoryId == $0.id }
             HStack(spacing: 8) {
                 RoundedRectangle(cornerRadius: 3, style: .continuous)
                     .fill(color)
@@ -184,13 +185,13 @@ struct FireCategoryBrowserSheet: View {
 
             FlowLayout(spacing: 8) {
                 ForEach(topTags, id: \.self) { tag in
-                    let isSelected = viewModel.selectedHomeTags.contains(tag)
+                    let isSelected = homeFeedStore.selectedHomeTags.contains(tag)
                     Button {
                         withAnimation(.easeInOut(duration: 0.2)) {
                             if isSelected {
-                                viewModel.removeHomeTag(tag)
+                                homeFeedStore.removeHomeTag(tag)
                             } else {
-                                viewModel.addHomeTag(tag)
+                                homeFeedStore.addHomeTag(tag)
                             }
                         }
                     } label: {
@@ -236,14 +237,15 @@ struct FireCategoryBrowserSheet: View {
 // MARK: - Legacy Categories View (pushed from topic detail navigation)
 
 struct FireCategoriesView: View {
-    @ObservedObject var viewModel: FireAppViewModel
+    @EnvironmentObject private var homeFeedStore: FireHomeFeedStore
+    let viewModel: FireAppViewModel
 
     private var parentCategories: [FireTopicCategoryPresentation] {
-        viewModel.allCategories().filter { $0.parentCategoryId == nil }
+        homeFeedStore.allCategories.filter { $0.parentCategoryId == nil }
     }
 
     private var topTags: [String] {
-        viewModel.topTags()
+        homeFeedStore.topTags
     }
 
     private var hasContent: Bool {
@@ -251,7 +253,7 @@ struct FireCategoriesView: View {
     }
 
     private func subcategories(of parentID: UInt64) -> [FireTopicCategoryPresentation] {
-        viewModel.allCategories().filter { $0.parentCategoryId == parentID }
+        homeFeedStore.allCategories.filter { $0.parentCategoryId == parentID }
     }
 
     var body: some View {

--- a/native/ios-app/App/FireHomeView.swift
+++ b/native/ios-app/App/FireHomeView.swift
@@ -1,32 +1,68 @@
 import SwiftUI
 
 struct FireHomeView: View {
+    private struct SelectedTopicDestination: Hashable, Identifiable {
+        let topicID: UInt64
+
+        var id: UInt64 { topicID }
+    }
+
     @EnvironmentObject private var navigationState: FireNavigationState
-    @ObservedObject var viewModel: FireAppViewModel
+    @EnvironmentObject private var homeFeedStore: FireHomeFeedStore
+    let viewModel: FireAppViewModel
     let searchStore: FireSearchStore
-    @Namespace private var feedSelectionNamespace
     @State private var showCategoryBrowser = false
     @State private var showTagPicker = false
     @State private var showCreateTopicComposer = false
     @State private var didPrefetchToFillViewport = false
     @State private var selectedRoute: FireAppRoute?
+    @State private var selectedTopicDestination: SelectedTopicDestination?
+    @State private var lastTopicListScrollMetrics: FireCollectionScrollMetrics?
 
-    private struct TopicListScrollMetrics: Equatable {
-        let remainingDistanceToBottom: CGFloat
-        let contentHeight: CGFloat
-        let visibleHeight: CGFloat
-    }
-
-    private var parentCategories: [FireTopicCategoryPresentation] {
-        viewModel.allCategories().filter { $0.parentCategoryId == nil }
-    }
+    private static let paginationPrefetchDistance: CGFloat = 480
 
     var body: some View {
         NavigationStack {
-            homeList
-                .navigationDestination(item: $selectedRoute) { route in
-                    FireAppRouteDestinationView(viewModel: viewModel, route: route)
+            FireHomeCollectionView(
+                onShowCategoryBrowser: {
+                    showCategoryBrowser = true
+                },
+                onShowTagPicker: {
+                    showTagPicker = true
+                },
+                onSelectTopic: selectTopic(_:),
+                onRefresh: refreshTopics,
+                onScrollMetricsChanged: handleTopicListScrollMetricsChange(_: )
+            )
+            .navigationTitle("首页")
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    HStack(spacing: 14) {
+                        Button {
+                            showCreateTopicComposer = true
+                        } label: {
+                            Image(systemName: "square.and.pencil")
+                        }
+
+                        NavigationLink {
+                            FireSearchView(appViewModel: viewModel, searchStore: searchStore)
+                        } label: {
+                            Image(systemName: "magnifyingglass")
+                        }
+                    }
                 }
+            }
+            .navigationDestination(item: $selectedRoute) { route in
+                FireAppRouteDestinationView(viewModel: viewModel, route: route)
+            }
+            .navigationDestination(item: $selectedTopicDestination) { destination in
+                if let row = homeFeedStore.topicRow(for: destination.topicID) {
+                    FireTopicDetailView(viewModel: viewModel, row: row)
+                } else {
+                    ProgressView()
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
         }
         .onAppear {
             consumePendingRouteIfVisible(navigationState.pendingRoute)
@@ -34,68 +70,14 @@ struct FireHomeView: View {
         .onChange(of: navigationState.pendingRoute) { _, route in
             consumePendingRouteIfVisible(route)
         }
-    }
-
-    @ViewBuilder
-    private var homeList: some View {
-        if #available(iOS 18.0, *) {
-            baseList
-                .onScrollGeometryChange(
-                    for: TopicListScrollMetrics.self,
-                    of: topicListScrollMetrics(from:)
-                ) { oldValue, newValue in
-                    handleTopicListScrollMetricsChange(oldValue: oldValue, newValue: newValue)
-                }
-        } else {
-            baseList
+        .onChange(of: homeFeedStore.selectedTopicKind) { _, _ in
+            resetPaginationTracking()
         }
-    }
-
-    private var baseList: some View {
-        List {
-            categoryTabSection
-            feedSelectorSection
-            tagChipsSection
-
-            if viewModel.isLoadingTopics && viewModel.topicRows.isEmpty {
-                loadingSection
-            } else if viewModel.topicRows.isEmpty {
-                emptySection
-            } else {
-                topicListSection
-            }
+        .onChange(of: homeFeedStore.selectedHomeCategoryId) { _, _ in
+            resetPaginationTracking()
         }
-        .listStyle(.plain)
-        .navigationTitle("首页")
-        .toolbar {
-            ToolbarItem(placement: .topBarTrailing) {
-                HStack(spacing: 14) {
-                    Button {
-                        showCreateTopicComposer = true
-                    } label: {
-                        Image(systemName: "square.and.pencil")
-                    }
-
-                    NavigationLink {
-                        FireSearchView(appViewModel: viewModel, searchStore: searchStore)
-                    } label: {
-                        Image(systemName: "magnifyingglass")
-                    }
-                }
-            }
-        }
-        .refreshable {
-            didPrefetchToFillViewport = false
-            await refreshTopics()
-        }
-        .onChange(of: viewModel.selectedTopicKind) { _, _ in
-            didPrefetchToFillViewport = false
-        }
-        .onChange(of: viewModel.selectedHomeCategoryId) { _, _ in
-            didPrefetchToFillViewport = false
-        }
-        .onChange(of: viewModel.selectedHomeTags) { _, _ in
-            didPrefetchToFillViewport = false
+        .onChange(of: homeFeedStore.selectedHomeTags) { _, _ in
+            resetPaginationTracking()
         }
         .sheet(isPresented: $showCategoryBrowser) {
             FireCategoryBrowserSheet(viewModel: viewModel)
@@ -108,8 +90,8 @@ struct FireHomeView: View {
                 FireComposerView(
                     viewModel: viewModel,
                     route: FireComposerRoute(kind: .createTopic),
-                    initialCategoryID: viewModel.selectedHomeCategoryId,
-                    initialTags: viewModel.selectedHomeTags,
+                    initialCategoryID: homeFeedStore.selectedHomeCategoryId,
+                    initialTags: homeFeedStore.selectedHomeTags,
                     onTopicCreated: { _ in
                         showCreateTopicComposer = false
                     }
@@ -118,293 +100,38 @@ struct FireHomeView: View {
         }
     }
 
-    // MARK: - Category Tabs
-
-    private var categoryTabSection: some View {
-        Section {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 6) {
-                    categoryTab(label: "全部", categoryId: nil, color: FireTheme.accent)
-
-                    ForEach(parentCategories, id: \.id) { category in
-                        categoryTab(
-                            label: category.displayName,
-                            categoryId: category.id,
-                            color: Color(fireHex: category.colorHex) ?? FireTheme.accent
-                        )
-                    }
-
-                    Button {
-                        showCategoryBrowser = true
-                    } label: {
-                        Image(systemName: "square.grid.2x2")
-                            .font(.subheadline.weight(.medium))
-                            .foregroundStyle(FireTheme.subtleInk)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 7)
-                            .background(
-                                Capsule().fill(Color(.tertiarySystemFill))
-                            )
-                    }
-                    .buttonStyle(.plain)
-                }
-                .padding(.vertical, 2)
-            }
-        }
-        .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 4, trailing: 16))
-        .listRowSeparator(.hidden)
-        .listRowBackground(Color.clear)
+    private func resetPaginationTracking() {
+        didPrefetchToFillViewport = false
+        lastTopicListScrollMetrics = nil
     }
 
-    private func categoryTab(label: String, categoryId: UInt64?, color: Color) -> some View {
-        let isSelected = viewModel.selectedHomeCategoryId == categoryId
-        return Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                viewModel.selectHomeCategory(categoryId)
-            }
-        } label: {
-            Text(label)
-                .font(.subheadline.weight(.medium))
-                .foregroundStyle(isSelected ? Color.white : Color(.label))
-                .padding(.horizontal, 14)
-                .padding(.vertical, 7)
-                .background(
-                    Capsule().fill(isSelected ? color : Color(.tertiarySystemFill))
-                )
-                .lineLimit(1)
-        }
-        .buttonStyle(.plain)
-    }
-
-    // MARK: - Feed Selector
-
-    private var feedSelectorSection: some View {
-        Section {
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 4) {
-                    ForEach(TopicListKindState.orderedCases, id: \.self) { kind in
-                        Button {
-                            withAnimation(.easeInOut(duration: 0.2)) {
-                                viewModel.selectTopicKind(kind)
-                            }
-                        } label: {
-                            Text(kind.title)
-                                .font(.caption.weight(.medium))
-                                .foregroundStyle(
-                                    viewModel.selectedTopicKind == kind
-                                        ? Color.white
-                                        : Color(.secondaryLabel)
-                                )
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 6)
-                                .background(
-                                    Capsule()
-                                        .fill(
-                                            viewModel.selectedTopicKind == kind
-                                                ? FireTheme.accent
-                                                : Color(.tertiarySystemFill)
-                                        )
-                                )
-                        }
-                        .buttonStyle(.plain)
-                    }
-                }
-                .padding(.vertical, 2)
-            }
-        }
-        .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 4, trailing: 16))
-        .listRowSeparator(.hidden)
-        .listRowBackground(Color.clear)
-    }
-
-    // MARK: - Tag Chips
-
-    @ViewBuilder
-    private var tagChipsSection: some View {
-        if !viewModel.selectedHomeTags.isEmpty || !viewModel.topTags().isEmpty {
-            Section {
-                ScrollView(.horizontal, showsIndicators: false) {
-                    HStack(spacing: 6) {
-                        ForEach(viewModel.selectedHomeTags, id: \.self) { tag in
-                            selectedTagChip(tag)
-                        }
-
-                        Button {
-                            showTagPicker = true
-                        } label: {
-                            HStack(spacing: 4) {
-                                Image(systemName: "plus")
-                                    .font(.caption2.weight(.bold))
-                                Text("标签")
-                                    .font(.caption.weight(.medium))
-                            }
-                            .foregroundStyle(FireTheme.accent)
-                            .padding(.horizontal, 10)
-                            .padding(.vertical, 5)
-                            .background(
-                                Capsule()
-                                    .strokeBorder(FireTheme.accent.opacity(0.3), lineWidth: 1)
-                            )
-                        }
-                        .buttonStyle(.plain)
-                    }
-                    .padding(.vertical, 2)
-                }
-            }
-            .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 6, trailing: 16))
-            .listRowSeparator(.hidden)
-            .listRowBackground(Color.clear)
-        }
-    }
-
-    private func selectedTagChip(_ tag: String) -> some View {
-        Button {
-            withAnimation(.easeInOut(duration: 0.2)) {
-                viewModel.removeHomeTag(tag)
-            }
-        } label: {
-            HStack(spacing: 4) {
-                Text("#\(tag)")
-                    .font(.caption.weight(.medium))
-                Image(systemName: "xmark")
-                    .font(.system(size: 8, weight: .bold))
-            }
-            .foregroundStyle(FireTheme.accent)
-            .padding(.horizontal, 10)
-            .padding(.vertical, 5)
-            .background(
-                Capsule().fill(FireTheme.accent.opacity(0.12))
-            )
-        }
-        .buttonStyle(.plain)
-    }
-
-    // MARK: - Topic List
-
-    private static let paginationPrefetchDistance: CGFloat = 480
-    private static let legacyPaginationPrefetchThreshold = 5
-
-    private var topicListSection: some View {
-        Section {
-            ForEach(Array(viewModel.topicRows.enumerated()), id: \.element.topic.id) { index, topicRow in
-                NavigationLink {
-                    FireTopicDetailView(viewModel: viewModel, row: topicRow)
-                } label: {
-                    FireTopicRow(
-                        row: topicRow,
-                        category: viewModel.categoryPresentation(for: topicRow.topic.categoryId)
-                    )
-                }
-                .onAppear {
-                    if #unavailable(iOS 18.0) {
-                        prefetchLegacyTopicsPageIfNeeded(currentIndex: index)
-                    }
-                }
-            }
-
-            if viewModel.nextTopicsPage != nil && viewModel.isAppendingTopics {
-                HStack {
-                    Spacer()
-                    ProgressView()
-                        .controlSize(.small)
-                    Spacer()
-                }
-                .padding(.vertical, 8)
-                .listRowSeparator(.hidden)
-            }
-        }
-    }
-
-    // MARK: - Loading & Empty
-
-    private var loadingSection: some View {
-        Section {
-            ForEach(0..<6, id: \.self) { _ in
-                HStack(spacing: 12) {
-                    Circle()
-                        .fill(Color(.tertiarySystemFill))
-                        .frame(width: 38, height: 38)
-
-                    VStack(alignment: .leading, spacing: 6) {
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(Color(.tertiarySystemFill))
-                            .frame(height: 14)
-
-                        RoundedRectangle(cornerRadius: 4)
-                            .fill(Color(.quaternarySystemFill))
-                            .frame(width: 100, height: 10)
-                    }
-                }
-                .padding(.vertical, 6)
-                .redacted(reason: .placeholder)
-            }
-        }
-    }
-
-    private var emptySection: some View {
-        Section {
-            VStack(spacing: 12) {
-                Image(systemName: "tray")
-                    .font(.title)
-                    .foregroundStyle(.secondary)
-
-                Text("当前 feed 暂无话题")
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-
-                Button("刷新") {
-                    viewModel.refreshTopics()
-                }
-                .buttonStyle(.bordered)
-                .tint(FireTheme.accent)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 40)
-        }
-        .listRowSeparator(.hidden)
-    }
-
-    // MARK: - Helpers
-
-    @Sendable
     private func refreshTopics() async {
-        await viewModel.refreshTopicsAsync()
+        await homeFeedStore.refreshTopicsAsync()
     }
 
-    @available(iOS 18.0, *)
-    private func topicListScrollMetrics(from geometry: ScrollGeometry) -> TopicListScrollMetrics {
-        TopicListScrollMetrics(
-            remainingDistanceToBottom: max(0, geometry.contentSize.height - geometry.visibleRect.maxY),
-            contentHeight: geometry.contentSize.height,
-            visibleHeight: geometry.visibleRect.height
-        )
+    private func selectTopic(_ topicID: UInt64) {
+        selectedTopicDestination = SelectedTopicDestination(topicID: topicID)
     }
 
-    private func handleTopicListScrollMetricsChange(
-        oldValue: TopicListScrollMetrics,
-        newValue: TopicListScrollMetrics
-    ) {
-        guard viewModel.nextTopicsPage != nil else { return }
-        guard !viewModel.isLoadingTopics else { return }
+    private func handleTopicListScrollMetricsChange(_ newMetrics: FireCollectionScrollMetrics) {
+        defer {
+            lastTopicListScrollMetrics = newMetrics
+        }
 
-        let contentFitsViewport = newValue.contentHeight <= newValue.visibleHeight + 1
+        guard homeFeedStore.nextTopicsPage != nil else { return }
+        guard !homeFeedStore.isLoadingTopics else { return }
+
+        let contentFitsViewport = newMetrics.contentHeight <= newMetrics.visibleHeight + 1
         if contentFitsViewport && !didPrefetchToFillViewport {
             didPrefetchToFillViewport = true
-            viewModel.loadMoreTopics()
+            homeFeedStore.loadMoreTopics()
             return
         }
 
-        guard oldValue.remainingDistanceToBottom > Self.paginationPrefetchDistance else { return }
-        guard newValue.remainingDistanceToBottom <= Self.paginationPrefetchDistance else { return }
-        viewModel.loadMoreTopics()
-    }
-
-    private func prefetchLegacyTopicsPageIfNeeded(currentIndex: Int) {
-        guard viewModel.nextTopicsPage != nil else { return }
-        guard !viewModel.isLoadingTopics else { return }
-        let triggerIndex = max(0, viewModel.topicRows.count - Self.legacyPaginationPrefetchThreshold)
-        guard currentIndex >= triggerIndex else { return }
-        viewModel.loadMoreTopics()
+        guard let oldMetrics = lastTopicListScrollMetrics else { return }
+        guard oldMetrics.remainingDistanceToBottom > Self.paginationPrefetchDistance else { return }
+        guard newMetrics.remainingDistanceToBottom <= Self.paginationPrefetchDistance else { return }
+        homeFeedStore.loadMoreTopics()
     }
 
     private func consumePendingRouteIfVisible(_ route: FireAppRoute?) {

--- a/native/ios-app/App/FireHomeView.swift
+++ b/native/ios-app/App/FireHomeView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 struct FireHomeView: View {
     @EnvironmentObject private var navigationState: FireNavigationState
     @ObservedObject var viewModel: FireAppViewModel
+    let searchStore: FireSearchStore
     @Namespace private var feedSelectionNamespace
     @State private var showCategoryBrowser = false
     @State private var showTagPicker = false
@@ -76,7 +77,7 @@ struct FireHomeView: View {
                     }
 
                     NavigationLink {
-                        FireSearchView(viewModel: viewModel)
+                        FireSearchView(appViewModel: viewModel, searchStore: searchStore)
                     } label: {
                         Image(systemName: "magnifyingglass")
                     }

--- a/native/ios-app/App/FireNotificationHistoryView.swift
+++ b/native/ios-app/App/FireNotificationHistoryView.swift
@@ -1,20 +1,21 @@
 import SwiftUI
 
 struct FireNotificationHistoryView: View {
-    @ObservedObject var viewModel: FireAppViewModel
+    let appViewModel: FireAppViewModel
+    @ObservedObject var notificationStore: FireNotificationStore
     @State private var selectedRoute: FireAppRoute?
 
     private var baseURLString: String {
-        let trimmed = viewModel.session.bootstrap.baseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = appViewModel.session.bootstrap.baseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "https://linux.do" : trimmed
     }
 
     var body: some View {
         Group {
-            if viewModel.isLoadingNotificationFullPage && viewModel.notificationFullList.isEmpty {
+            if notificationStore.isLoadingFullPage && notificationStore.fullNotifications.isEmpty {
                 ProgressView()
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if viewModel.notificationFullList.isEmpty {
+            } else if notificationStore.fullNotifications.isEmpty {
                 emptyState
             } else {
                 notificationList
@@ -24,10 +25,10 @@ struct FireNotificationHistoryView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar(.hidden, for: .tabBar)
         .toolbar {
-            if viewModel.notificationUnreadCount > 0 {
+            if notificationStore.unreadCount > 0 {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button("全部已读") {
-                        viewModel.markAllNotificationsRead()
+                        notificationStore.markAllRead()
                     }
                     .font(.subheadline.weight(.medium))
                     .foregroundStyle(FireTheme.accent)
@@ -35,19 +36,19 @@ struct FireNotificationHistoryView: View {
             }
         }
         .refreshable {
-            await viewModel.loadNotificationFullPage(offset: nil)
+            await notificationStore.loadFullPage(offset: nil)
         }
         .navigationDestination(item: $selectedRoute) { route in
-            FireAppRouteDestinationView(viewModel: viewModel, route: route)
+            FireAppRouteDestinationView(viewModel: appViewModel, route: route)
         }
         .task {
-            await viewModel.loadNotificationFullPage(offset: nil)
+            await notificationStore.loadFullPage(offset: nil)
         }
     }
 
     private var notificationList: some View {
         List {
-            ForEach(viewModel.notificationFullList, id: \.id) { item in
+            ForEach(notificationStore.fullNotifications, id: \.id) { item in
                 Button {
                     handleNotificationTap(item)
                 } label: {
@@ -62,7 +63,7 @@ struct FireNotificationHistoryView: View {
                 .listRowBackground(Color.clear)
             }
 
-            if viewModel.hasMoreNotificationFull {
+            if notificationStore.hasMoreFull {
                 HStack {
                     Spacer()
                     ProgressView()
@@ -72,8 +73,8 @@ struct FireNotificationHistoryView: View {
                 .listRowSeparator(.hidden)
                 .listRowBackground(Color.clear)
                 .task {
-                    await viewModel.loadNotificationFullPage(
-                        offset: viewModel.notificationFullNextOffset
+                    await notificationStore.loadFullPage(
+                        offset: notificationStore.fullNextOffset
                     )
                 }
             }
@@ -93,7 +94,7 @@ struct FireNotificationHistoryView: View {
 
             Button("刷新") {
                 Task {
-                    await viewModel.loadNotificationFullPage(offset: nil)
+                    await notificationStore.loadFullPage(offset: nil)
                 }
             }
             .buttonStyle(FireSecondaryButtonStyle())
@@ -104,7 +105,7 @@ struct FireNotificationHistoryView: View {
 
     private func handleNotificationTap(_ item: NotificationItemState) {
         if !item.read {
-            viewModel.markNotificationRead(id: item.id)
+            notificationStore.markRead(id: item.id)
         }
 
         selectedRoute = item.appRoute

--- a/native/ios-app/App/FireNotificationsView.swift
+++ b/native/ios-app/App/FireNotificationsView.swift
@@ -189,20 +189,21 @@ extension NotificationItemState {
 // MARK: - View
 
 struct FireNotificationsView: View {
-    @ObservedObject var viewModel: FireAppViewModel
+    let appViewModel: FireAppViewModel
+    @ObservedObject var notificationStore: FireNotificationStore
     @State private var selectedRoute: FireAppRoute?
 
     private var baseURLString: String {
-        let trimmed = viewModel.session.bootstrap.baseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = appViewModel.session.bootstrap.baseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "https://linux.do" : trimmed
     }
 
     var body: some View {
         NavigationStack {
             Group {
-                if viewModel.isLoadingNotifications && viewModel.recentNotifications.isEmpty {
+                if notificationStore.isLoadingRecent && notificationStore.recentNotifications.isEmpty {
                     loadingSkeleton
-                } else if viewModel.recentNotifications.isEmpty {
+                } else if notificationStore.recentNotifications.isEmpty {
                     emptyState
                 } else {
                     notificationList
@@ -210,10 +211,10 @@ struct FireNotificationsView: View {
             }
             .navigationTitle("通知")
             .toolbar {
-                if viewModel.notificationUnreadCount > 0 {
+                if notificationStore.unreadCount > 0 {
                     ToolbarItem(placement: .topBarTrailing) {
                         Button("全部已读") {
-                            viewModel.markAllNotificationsRead()
+                            notificationStore.markAllRead()
                         }
                         .font(.subheadline.weight(.medium))
                         .foregroundStyle(FireTheme.accent)
@@ -221,14 +222,14 @@ struct FireNotificationsView: View {
                 }
             }
             .refreshable {
-                await viewModel.loadRecentNotifications(force: true)
+                await notificationStore.loadRecent(force: true)
             }
             .navigationDestination(item: $selectedRoute) { route in
-                FireAppRouteDestinationView(viewModel: viewModel, route: route)
+                FireAppRouteDestinationView(viewModel: appViewModel, route: route)
             }
         }
         .task {
-            await viewModel.loadRecentNotifications(force: false)
+            await notificationStore.loadRecent(force: false)
         }
     }
 
@@ -236,7 +237,7 @@ struct FireNotificationsView: View {
 
     private var notificationList: some View {
         List {
-            ForEach(viewModel.recentNotifications, id: \.id) { item in
+            ForEach(notificationStore.recentNotifications, id: \.id) { item in
                 notificationRow(item)
                     .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
                     .listRowSeparator(.hidden)
@@ -244,7 +245,10 @@ struct FireNotificationsView: View {
             }
 
             NavigationLink {
-                FireNotificationHistoryView(viewModel: viewModel)
+                FireNotificationHistoryView(
+                    appViewModel: appViewModel,
+                    notificationStore: notificationStore
+                )
             } label: {
                 HStack {
                     Spacer()
@@ -277,7 +281,7 @@ struct FireNotificationsView: View {
 
     private func handleNotificationTap(_ item: NotificationItemState) {
         if !item.read {
-            viewModel.markNotificationRead(id: item.id)
+            notificationStore.markRead(id: item.id)
         }
 
         selectedRoute = item.appRoute
@@ -342,7 +346,7 @@ struct FireNotificationsView: View {
 
             Button("刷新") {
                 Task {
-                    await viewModel.loadRecentNotifications(force: true)
+                    await notificationStore.loadRecent(force: true)
                 }
             }
             .buttonStyle(FireSecondaryButtonStyle())

--- a/native/ios-app/App/FireSearchView.swift
+++ b/native/ios-app/App/FireSearchView.swift
@@ -1,19 +1,16 @@
 import SwiftUI
 
 struct FireSearchView: View {
-    @ObservedObject var viewModel: FireAppViewModel
+    let appViewModel: FireAppViewModel
+    @ObservedObject var searchStore: FireSearchStore
     @FocusState private var isSearchFieldFocused: Bool
     @State private var hasAppeared = false
     @State private var selectedRoute: FireAppRoute?
 
-    private var trimmedQuery: String {
-        viewModel.searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
     private var scopeBinding: Binding<FireSearchScope> {
         Binding(
-            get: { viewModel.searchScope },
-            set: { viewModel.setSearchScope($0) }
+            get: { searchStore.scope },
+            set: { searchStore.setScope($0) }
         )
     }
 
@@ -26,12 +23,12 @@ struct FireSearchView: View {
         .navigationTitle("搜索")
         .navigationBarTitleDisplayMode(.inline)
         .navigationDestination(item: $selectedRoute) { route in
-            FireAppRouteDestinationView(viewModel: viewModel, route: route)
+            FireAppRouteDestinationView(viewModel: appViewModel, route: route)
         }
         .onAppear {
             guard !hasAppeared else { return }
             hasAppeared = true
-            viewModel.resetSearch()
+            searchStore.reset()
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {
                 isSearchFieldFocused = true
             }
@@ -46,19 +43,19 @@ struct FireSearchView: View {
                 Image(systemName: "magnifyingglass")
                     .foregroundStyle(FireTheme.tertiaryInk)
 
-                TextField("搜索话题、帖子、用户…", text: $viewModel.searchQuery)
+                TextField("搜索话题、帖子、用户…", text: $searchStore.query)
                     .focused($isSearchFieldFocused)
                     .textFieldStyle(.plain)
                     .submitLabel(.search)
                     .autocorrectionDisabled()
                     .textInputAutocapitalization(.never)
                     .onSubmit {
-                        viewModel.submitSearch(reset: true)
+                        searchStore.submit(reset: true)
                     }
 
-                if !viewModel.searchQuery.isEmpty {
+                if !searchStore.query.isEmpty {
                     Button {
-                        viewModel.resetSearch()
+                        searchStore.reset()
                         isSearchFieldFocused = true
                     } label: {
                         Image(systemName: "xmark.circle.fill")
@@ -92,7 +89,7 @@ struct FireSearchView: View {
 
     @ViewBuilder
     private var contentArea: some View {
-        if viewModel.isSearching && viewModel.searchResult == nil {
+        if searchStore.isSearching && searchStore.result == nil {
             VStack(spacing: 8) {
                 Spacer()
                 ProgressView()
@@ -103,9 +100,9 @@ struct FireSearchView: View {
                 Spacer()
             }
             .frame(maxWidth: .infinity)
-        } else if let result = viewModel.searchResult {
+        } else if let result = searchStore.result {
             resultList(result)
-        } else if let errorMessage = viewModel.searchErrorMessage {
+        } else if let errorMessage = searchStore.errorMessage {
             VStack(spacing: 12) {
                 Spacer()
                 Image(systemName: "exclamationmark.triangle")
@@ -117,7 +114,7 @@ struct FireSearchView: View {
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 32)
                 Button("重试") {
-                    viewModel.submitSearch(reset: true)
+                    searchStore.submit(reset: true)
                 }
                 .buttonStyle(.bordered)
                 .tint(FireTheme.accent)
@@ -138,7 +135,7 @@ struct FireSearchView: View {
         )
 
         return List {
-            if let errorMessage = viewModel.searchErrorMessage {
+            if let errorMessage = searchStore.errorMessage {
                 Section {
                     Label(errorMessage, systemImage: "exclamationmark.triangle")
                         .font(.footnote)
@@ -159,7 +156,7 @@ struct FireSearchView: View {
                         } label: {
                             FireTopicRow(
                                 row: row,
-                                category: viewModel.categoryPresentation(for: topic.categoryId)
+                                category: appViewModel.categoryPresentation(for: topic.categoryId)
                             )
                         }
                         .buttonStyle(.plain)
@@ -201,14 +198,14 @@ struct FireSearchView: View {
                 }
             }
 
-            if viewModel.canLoadMoreSearchResults {
+            if searchStore.canLoadMoreResults {
                 Section {
                     Button {
-                        viewModel.submitSearch(reset: false)
+                        searchStore.submit(reset: false)
                     } label: {
                         HStack {
                             Spacer()
-                            if viewModel.isAppendingSearch {
+                            if searchStore.isAppending {
                                 ProgressView()
                                     .controlSize(.small)
                             } else {
@@ -220,7 +217,7 @@ struct FireSearchView: View {
                         }
                         .padding(.vertical, 4)
                     }
-                    .disabled(viewModel.isSearching || viewModel.isAppendingSearch)
+                    .disabled(searchStore.isSearching || searchStore.isAppending)
                 }
             }
 

--- a/native/ios-app/App/FireTabRoot.swift
+++ b/native/ios-app/App/FireTabRoot.swift
@@ -5,12 +5,16 @@ struct FireTabRoot: View {
     @EnvironmentObject private var navigationState: FireNavigationState
     @StateObject private var viewModel = FireAppViewModel()
     @StateObject private var searchStore: FireSearchStore
+    @StateObject private var notificationStore: FireNotificationStore
     @StateObject private var profileViewModel: FireProfileViewModel
 
     init() {
         let vm = FireAppViewModel()
+        let notifications = FireNotificationStore(appViewModel: vm)
+        vm.bindNotificationStore(notifications)
         _viewModel = StateObject(wrappedValue: vm)
         _searchStore = StateObject(wrappedValue: FireSearchStore(appViewModel: vm))
+        _notificationStore = StateObject(wrappedValue: notifications)
         _profileViewModel = StateObject(wrappedValue: FireProfileViewModel(appViewModel: vm))
     }
 
@@ -28,12 +32,15 @@ struct FireTabRoot: View {
                         }
                         .tag(0)
 
-                    FireNotificationsView(viewModel: viewModel)
-                        .tabItem {
-                            Label("通知", systemImage: "bell")
-                        }
-                        .badge(viewModel.notificationUnreadCount)
-                        .tag(1)
+                    FireNotificationsView(
+                        appViewModel: viewModel,
+                        notificationStore: notificationStore
+                    )
+                    .tabItem {
+                        Label("通知", systemImage: "bell")
+                    }
+                    .badge(notificationStore.unreadCount)
+                    .tag(1)
 
                     FireProfileView(viewModel: viewModel, profileViewModel: profileViewModel)
                         .tabItem {
@@ -112,6 +119,7 @@ struct FireTabRoot: View {
         .onChange(of: isAuthenticated) { _, authenticated in
             if !authenticated {
                 searchStore.reset()
+                notificationStore.reset()
             }
             viewModel.updateTopLevelAPMRoute(
                 selectedTab: navigationState.selectedTab,

--- a/native/ios-app/App/FireTabRoot.swift
+++ b/native/ios-app/App/FireTabRoot.swift
@@ -4,11 +4,13 @@ struct FireTabRoot: View {
     @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject private var navigationState: FireNavigationState
     @StateObject private var viewModel = FireAppViewModel()
+    @StateObject private var searchStore: FireSearchStore
     @StateObject private var profileViewModel: FireProfileViewModel
 
     init() {
         let vm = FireAppViewModel()
         _viewModel = StateObject(wrappedValue: vm)
+        _searchStore = StateObject(wrappedValue: FireSearchStore(appViewModel: vm))
         _profileViewModel = StateObject(wrappedValue: FireProfileViewModel(appViewModel: vm))
     }
 
@@ -20,7 +22,7 @@ struct FireTabRoot: View {
         Group {
             if isAuthenticated {
                 TabView(selection: $navigationState.selectedTab) {
-                    FireHomeView(viewModel: viewModel)
+                    FireHomeView(viewModel: viewModel, searchStore: searchStore)
                         .tabItem {
                             Label("首页", systemImage: "house")
                         }
@@ -108,6 +110,9 @@ struct FireTabRoot: View {
             )
         }
         .onChange(of: isAuthenticated) { _, authenticated in
+            if !authenticated {
+                searchStore.reset()
+            }
             viewModel.updateTopLevelAPMRoute(
                 selectedTab: navigationState.selectedTab,
                 isAuthenticated: authenticated

--- a/native/ios-app/App/FireTabRoot.swift
+++ b/native/ios-app/App/FireTabRoot.swift
@@ -4,17 +4,25 @@ struct FireTabRoot: View {
     @Environment(\.scenePhase) private var scenePhase
     @EnvironmentObject private var navigationState: FireNavigationState
     @StateObject private var viewModel = FireAppViewModel()
+    @StateObject private var homeFeedStore: FireHomeFeedStore
     @StateObject private var searchStore: FireSearchStore
     @StateObject private var notificationStore: FireNotificationStore
+    @StateObject private var topicDetailStore: FireTopicDetailStore
     @StateObject private var profileViewModel: FireProfileViewModel
 
     init() {
         let vm = FireAppViewModel()
+        let homeFeed = FireHomeFeedStore(appViewModel: vm)
         let notifications = FireNotificationStore(appViewModel: vm)
+        let topicDetails = FireTopicDetailStore(appViewModel: vm)
+        vm.bindHomeFeedStore(homeFeed)
         vm.bindNotificationStore(notifications)
+        vm.bindTopicDetailStore(topicDetails)
         _viewModel = StateObject(wrappedValue: vm)
+        _homeFeedStore = StateObject(wrappedValue: homeFeed)
         _searchStore = StateObject(wrappedValue: FireSearchStore(appViewModel: vm))
         _notificationStore = StateObject(wrappedValue: notifications)
+        _topicDetailStore = StateObject(wrappedValue: topicDetails)
         _profileViewModel = StateObject(wrappedValue: FireProfileViewModel(appViewModel: vm))
     }
 
@@ -49,6 +57,8 @@ struct FireTabRoot: View {
                         .tag(2)
                 }
                 .tint(FireTheme.accent)
+                .environmentObject(homeFeedStore)
+                .environmentObject(topicDetailStore)
             } else {
                 FireOnboardingView(
                     viewModel: viewModel,
@@ -118,8 +128,10 @@ struct FireTabRoot: View {
         }
         .onChange(of: isAuthenticated) { _, authenticated in
             if !authenticated {
+                homeFeedStore.reset()
                 searchStore.reset()
                 notificationStore.reset()
+                topicDetailStore.reset()
             }
             viewModel.updateTopLevelAPMRoute(
                 selectedTab: navigationState.selectedTab,

--- a/native/ios-app/App/FireTagPickerSheet.swift
+++ b/native/ios-app/App/FireTagPickerSheet.swift
@@ -1,7 +1,8 @@
 import SwiftUI
 
 struct FireTagPickerSheet: View {
-    @ObservedObject var viewModel: FireAppViewModel
+    @EnvironmentObject private var homeFeedStore: FireHomeFeedStore
+    let viewModel: FireAppViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var searchText = ""
     @State private var searchResults: [TagSearchItemState] = []
@@ -9,7 +10,7 @@ struct FireTagPickerSheet: View {
     @State private var searchTask: Task<Void, Never>?
 
     private var topTags: [String] {
-        viewModel.topTags()
+        homeFeedStore.topTags
     }
 
     private var displayedTags: [String] {
@@ -65,13 +66,13 @@ struct FireTagPickerSheet: View {
 
     @ViewBuilder
     private var selectedTagsBar: some View {
-        if !viewModel.selectedHomeTags.isEmpty {
+        if !homeFeedStore.selectedHomeTags.isEmpty {
             ScrollView(.horizontal, showsIndicators: false) {
                 HStack(spacing: 6) {
-                    ForEach(viewModel.selectedHomeTags, id: \.self) { tag in
+                    ForEach(homeFeedStore.selectedHomeTags, id: \.self) { tag in
                         Button {
                             withAnimation(.easeInOut(duration: 0.2)) {
-                                viewModel.removeHomeTag(tag)
+                                homeFeedStore.removeHomeTag(tag)
                             }
                         } label: {
                             HStack(spacing: 4) {
@@ -100,13 +101,13 @@ struct FireTagPickerSheet: View {
     // MARK: - Tag Row
 
     private func tagRow(_ tag: String) -> some View {
-        let isSelected = viewModel.selectedHomeTags.contains(tag)
+        let isSelected = homeFeedStore.selectedHomeTags.contains(tag)
         return Button {
             withAnimation(.easeInOut(duration: 0.2)) {
                 if isSelected {
-                    viewModel.removeHomeTag(tag)
+                    homeFeedStore.removeHomeTag(tag)
                 } else {
-                    viewModel.addHomeTag(tag)
+                    homeFeedStore.addHomeTag(tag)
                 }
             }
         } label: {
@@ -171,8 +172,8 @@ struct FireTagPickerSheet: View {
                     query: trimmed,
                     filterForInput: true,
                     limit: 20,
-                    categoryID: viewModel.selectedHomeCategoryId,
-                    selectedTags: viewModel.selectedHomeTags
+                    categoryID: homeFeedStore.selectedHomeCategoryId,
+                    selectedTags: homeFeedStore.selectedHomeTags
                 )
                 guard !Task.isCancelled else { return }
 

--- a/native/ios-app/App/FireTopicDetailView.swift
+++ b/native/ios-app/App/FireTopicDetailView.swift
@@ -64,7 +64,8 @@ struct FireTopicDetailView: View {
         "\(topicId)-\(canOpenMessageBus)-\(hasLoadedDetail)"
     }
 
-    @ObservedObject var viewModel: FireAppViewModel
+    @EnvironmentObject private var topicDetailStore: FireTopicDetailStore
+    let viewModel: FireAppViewModel
     let row: FireTopicRowPresentation
     let scrollToPostNumber: UInt32?
 
@@ -100,11 +101,11 @@ struct FireTopicDetailView: View {
     }
 
     private var detail: TopicDetailState? {
-        viewModel.topicDetail(for: topic.id)
+        topicDetailStore.topicDetail(for: topic.id)
     }
 
     private var detailError: String? {
-        viewModel.errorMessage
+        topicDetailStore.errorMessage
     }
 
     private var displayedTopicTitle: String {
@@ -186,7 +187,7 @@ struct FireTopicDetailView: View {
     }
 
     private var typingUsers: [TopicPresenceUserState] {
-        viewModel.topicPresenceUsers(for: topic.id)
+        topicDetailStore.topicPresenceUsers(for: topic.id)
     }
 
     private var nonHeartReactionOptions: [FireReactionOption] {
@@ -299,7 +300,7 @@ struct FireTopicDetailView: View {
     }
 
     private var isSubmittingReply: Bool {
-        viewModel.isSubmittingReply(topicId: topic.id)
+        topicDetailStore.isSubmittingReply(topicId: topic.id)
     }
 
     private var composerTargetPost: TopicPostState? {
@@ -315,7 +316,7 @@ struct FireTopicDetailView: View {
 
     private func canChangeReaction(for post: TopicPostState) -> Bool {
         canWriteInteractions
-            && !viewModel.isMutatingPost(postId: post.id)
+            && !topicDetailStore.isMutatingPost(postId: post.id)
             && (post.currentUserReaction?.canUndo ?? true)
     }
 
@@ -419,12 +420,12 @@ struct FireTopicDetailView: View {
                             reminderAt: reminderAt
                         )
                     }
-                    await viewModel.loadTopicDetail(topicId: topic.id, force: true)
+                    await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
                 },
                 onDelete: context.bookmarkID.map { bookmarkID in
                     {
                         try await viewModel.deleteBookmark(bookmarkID: bookmarkID)
-                        await viewModel.loadTopicDetail(topicId: topic.id, force: true)
+                        await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
                     }
                 }
             )
@@ -438,7 +439,7 @@ struct FireTopicDetailView: View {
                     postNumber: context.postNumber,
                     onSaved: {
                         Task {
-                            await viewModel.loadTopicDetail(topicId: topic.id, force: true)
+                            await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
                         }
                     }
                 )
@@ -454,7 +455,7 @@ struct FireTopicDetailView: View {
                     initialTags: detail?.tags.map(\.name) ?? row.tagNames,
                     onSaved: {
                         Task {
-                            await viewModel.loadTopicDetail(topicId: topic.id, force: true)
+                            await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
                         }
                     }
                 )
@@ -488,7 +489,7 @@ struct FireTopicDetailView: View {
                         composerContext = nil
                         quickReplyError = nil
                         Task {
-                            await viewModel.loadTopicDetail(topicId: topic.id, force: true)
+                            await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
                         }
                     }
                 )
@@ -512,11 +513,11 @@ struct FireTopicDetailView: View {
         }
         .refreshable {
             timingTracker.recordInteraction()
-            viewModel.clearTopicDetailAnchor(topicId: topic.id)
-            await viewModel.loadTopicDetail(topicId: topic.id, force: true)
+            topicDetailStore.clearTopicDetailAnchor(topicId: topic.id)
+            await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
         }
         .onAppear {
-            viewModel.beginTopicDetailLifecycle(topicId: topic.id, ownerToken: detailOwnerToken)
+            topicDetailStore.beginTopicDetailLifecycle(topicId: topic.id, ownerToken: detailOwnerToken)
             viewModel.setAPMRoute("topic.detail.\(topic.id)")
         }
         .task(id: topic.id) {
@@ -528,10 +529,13 @@ struct FireTopicDetailView: View {
                 )
             }
             await timingTracker.setSceneActive(scenePhase == .active)
-            await viewModel.loadTopicDetail(topicId: topic.id, targetPostNumber: scrollToPostNumber)
+            await topicDetailStore.loadTopicDetail(
+                topicId: topic.id,
+                targetPostNumber: scrollToPostNumber
+            )
         }
         .task(id: messageBusSubscriptionTaskID) {
-            await viewModel.maintainTopicDetailSubscription(
+            await topicDetailStore.maintainTopicDetailSubscription(
                 topicId: topic.id,
                 ownerToken: detailOwnerToken
             )
@@ -543,19 +547,23 @@ struct FireTopicDetailView: View {
         }
         .onChange(of: isReplyFieldFocused) { _, isFocused in
             if isFocused {
-                viewModel.beginTopicReplyPresence(topicId: topic.id)
+                topicDetailStore.beginTopicReplyPresence(topicId: topic.id)
             } else {
                 Task {
-                    await viewModel.endTopicReplyPresence(topicId: topic.id)
+                    await topicDetailStore.endTopicReplyPresence(topicId: topic.id)
                 }
             }
         }
         .onDisappear {
-            viewModel.endTopicDetailLifecycle(topicId: topic.id, ownerToken: detailOwnerToken)
+            topicDetailStore.endTopicDetailLifecycle(
+                topicId: topic.id,
+                ownerToken: detailOwnerToken,
+                visibleTopicIDs: viewModel.currentVisibleTopicIDs()
+            )
             viewModel.restoreTopLevelAPMRoute()
             Task {
                 await timingTracker.stop()
-                await viewModel.endTopicReplyPresence(topicId: topic.id)
+                await topicDetailStore.endTopicReplyPresence(topicId: topic.id)
             }
         }
         .onChange(of: replyDraft) { _, _ in
@@ -669,7 +677,7 @@ struct FireTopicDetailView: View {
                         showsThreadLine: false,
                         baseURLString: baseURLString,
                         canWriteInteractions: canWriteInteractions,
-                        isMutating: viewModel.isMutatingPost(postId: originalPost.id),
+                        isMutating: topicDetailStore.isMutatingPost(postId: originalPost.id),
                         onOpenImage: { selectedImage = $0 },
                         onToggleLike: { toggleLike(for: $0) },
                         onSelectReaction: { post, reactionId in
@@ -750,11 +758,11 @@ struct FireTopicDetailView: View {
             let displayPosts = replyPosts
 
             if displayPosts.isEmpty {
-                if viewModel.hasMoreTopicPosts(topicId: topic.id) {
+                if topicDetailStore.hasMoreTopicPosts(topicId: topic.id) {
                     FireTopicPostsLoadingFooter()
                         .padding(.vertical, 16)
                         .task(id: topic.id) {
-                            viewModel.preloadTopicPostsIfNeeded(
+                            topicDetailStore.preloadTopicPostsIfNeeded(
                                 topicId: topic.id,
                                 visibleReplyIndex: 0,
                                 totalReplyCount: 1
@@ -770,12 +778,12 @@ struct FireTopicDetailView: View {
             } else {
                 replyPostRows(displayPosts)
 
-                if viewModel.isLoadingMoreTopicPosts(topicId: topic.id) {
+                if topicDetailStore.isLoadingMoreTopicPosts(topicId: topic.id) {
                     FireTopicPostsLoadingFooter()
                         .padding(.top, 12)
                 }
             }
-        } else if viewModel.isLoadingTopic(topicId: topic.id) {
+        } else if topicDetailStore.isLoadingTopic(topicId: topic.id) {
             HStack {
                 Spacer()
                 VStack(spacing: 8) {
@@ -796,7 +804,7 @@ struct FireTopicDetailView: View {
 
                 Button("重试") {
                     Task {
-                        await viewModel.loadTopicDetail(topicId: topic.id, force: true)
+                        await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
                     }
                 }
                 .buttonStyle(.bordered)
@@ -807,7 +815,7 @@ struct FireTopicDetailView: View {
         } else {
             Button("加载帖子") {
                 Task {
-                    await viewModel.loadTopicDetail(topicId: topic.id, force: true)
+                    await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
                 }
             }
             .frame(maxWidth: .infinity)
@@ -828,7 +836,7 @@ struct FireTopicDetailView: View {
                     showsThreadLine: flatPost.showsThreadLine,
                     baseURLString: baseURLString,
                     canWriteInteractions: canWriteInteractions,
-                    isMutating: viewModel.isMutatingPost(postId: flatPost.post.id),
+                    isMutating: topicDetailStore.isMutatingPost(postId: flatPost.post.id),
                     onOpenImage: { selectedImage = $0 },
                     onToggleLike: { toggleLike(for: $0) },
                     onSelectReaction: { post, reactionId in
@@ -920,7 +928,7 @@ struct FireTopicDetailView: View {
             return
         }
 
-        viewModel.preloadTopicPostsIfNeeded(
+        topicDetailStore.preloadTopicPostsIfNeeded(
             topicId: topic.id,
             visibleReplyIndex: visibleReplyIndex,
             totalReplyCount: replyPosts.count
@@ -1102,7 +1110,7 @@ struct FireTopicDetailView: View {
 
         Task { @MainActor in
             do {
-                try await viewModel.submitReply(
+                try await topicDetailStore.submitReply(
                     topicId: topicId,
                     raw: trimmed,
                     replyToPostNumber: replyToPostNumber
@@ -1185,19 +1193,19 @@ struct FireTopicDetailView: View {
     ) async throws {
         switch (currentReactionID, desiredReactionID) {
         case (nil, "heart"):
-            try await viewModel.setPostLiked(
+            try await topicDetailStore.setPostLiked(
                 topicId: topic.id,
                 postId: postId,
                 liked: true
             )
         case ("heart", nil):
-            try await viewModel.setPostLiked(
+            try await topicDetailStore.setPostLiked(
                 topicId: topic.id,
                 postId: postId,
                 liked: false
             )
         default:
-            try await viewModel.togglePostReaction(
+            try await topicDetailStore.togglePostReaction(
                 topicId: topic.id,
                 postId: postId,
                 reactionId: toggledReactionId
@@ -1211,7 +1219,7 @@ struct FireTopicDetailView: View {
                 topicID: topic.id,
                 notificationLevel: option.rawValue
             )
-            await viewModel.loadTopicDetail(topicId: topic.id, force: true)
+            await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
         } catch {
             composerNotice = error.localizedDescription
         }

--- a/native/ios-app/App/ListKit/FireCollectionHost.swift
+++ b/native/ios-app/App/ListKit/FireCollectionHost.swift
@@ -1,0 +1,77 @@
+import SwiftUI
+import UIKit
+
+struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: View>:
+    UIViewControllerRepresentable
+{
+    let sections: [FireListSectionModel<SectionID, ItemID>]
+    let makeLayout: () -> UICollectionViewLayout
+    let showsVerticalScrollIndicator: Bool
+    let backgroundColor: UIColor
+    let animatingDifferences: Bool
+    let onSelectItem: ((ItemID) -> Void)?
+    let canSelectItem: ((ItemID) -> Bool)?
+    let onVisibleItemsChanged: (([ItemID]) -> Void)?
+    let onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)?
+    let onRefresh: (() async -> Void)?
+    let rowContent: (ItemID) -> RowContent
+
+    init(
+        sections: [FireListSectionModel<SectionID, ItemID>],
+        showsVerticalScrollIndicator: Bool = true,
+        backgroundColor: UIColor = .clear,
+        animatingDifferences: Bool = true,
+        onSelectItem: ((ItemID) -> Void)? = nil,
+        canSelectItem: ((ItemID) -> Bool)? = nil,
+        onVisibleItemsChanged: (([ItemID]) -> Void)? = nil,
+        onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)? = nil,
+        onRefresh: (() async -> Void)? = nil,
+        makeLayout: @escaping () -> UICollectionViewLayout,
+        rowContent: @escaping (ItemID) -> RowContent
+    ) {
+        self.sections = sections
+        self.showsVerticalScrollIndicator = showsVerticalScrollIndicator
+        self.backgroundColor = backgroundColor
+        self.animatingDifferences = animatingDifferences
+        self.onSelectItem = onSelectItem
+        self.canSelectItem = canSelectItem
+        self.onVisibleItemsChanged = onVisibleItemsChanged
+        self.onScrollMetricsChanged = onScrollMetricsChanged
+        self.onRefresh = onRefresh
+        self.makeLayout = makeLayout
+        self.rowContent = rowContent
+    }
+
+    func makeUIViewController(context: Context)
+        -> FireDiffableListController<SectionID, ItemID, RowContent>
+    {
+        let controller: FireDiffableListController<SectionID, ItemID, RowContent> =
+            FireDiffableListController(
+                layout: makeLayout(),
+                showsVerticalScrollIndicator: showsVerticalScrollIndicator,
+                backgroundColor: backgroundColor,
+                onSelectItem: onSelectItem,
+                canSelectItem: canSelectItem,
+                onVisibleItemsChanged: onVisibleItemsChanged,
+                onScrollMetricsChanged: onScrollMetricsChanged,
+                onRefresh: onRefresh,
+                rowContent: rowContent
+            )
+        return controller
+    }
+
+    func updateUIViewController(
+        _ uiViewController: FireDiffableListController<SectionID, ItemID, RowContent>,
+        context: Context
+    ) {
+        uiViewController.updateLayout(makeLayout())
+        uiViewController.updateAppearance(
+            showsVerticalScrollIndicator: showsVerticalScrollIndicator,
+            backgroundColor: backgroundColor
+        )
+        uiViewController.setSections(
+            sections,
+            animatingDifferences: animatingDifferences
+        )
+    }
+}

--- a/native/ios-app/App/ListKit/FireDiffableListController.swift
+++ b/native/ios-app/App/ListKit/FireDiffableListController.swift
@@ -1,0 +1,292 @@
+import SwiftUI
+import UIKit
+
+struct FireCollectionScrollMetrics: Equatable {
+    let remainingDistanceToBottom: CGFloat
+    let contentHeight: CGFloat
+    let visibleHeight: CGFloat
+}
+
+struct FireCollectionScrollAnchor<ItemID: Hashable>: Equatable {
+    let itemID: ItemID
+    let offsetFromTop: CGFloat
+}
+
+@MainActor
+final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, RowContent: View>: UIViewController,
+    UICollectionViewDelegate
+{
+    private let rowContent: (ItemID) -> RowContent
+    private let onSelectItem: ((ItemID) -> Void)?
+    private let canSelectItem: ((ItemID) -> Bool)?
+    private let onVisibleItemsChanged: (([ItemID]) -> Void)?
+    private let onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)?
+    private let onRefresh: (() async -> Void)?
+    private var listLayout: UICollectionViewLayout
+    private var showsVerticalScrollIndicator: Bool
+    private var backgroundColor: UIColor
+
+    private var collectionView: UICollectionView?
+    private var dataSource: UICollectionViewDiffableDataSource<SectionID, ItemID>?
+    private var lastVisibleItemIDs: [ItemID] = []
+    private var lastScrollMetrics: FireCollectionScrollMetrics?
+    private var isRefreshing = false
+
+    init(
+        layout: UICollectionViewLayout,
+        showsVerticalScrollIndicator: Bool = true,
+        backgroundColor: UIColor = .clear,
+        onSelectItem: ((ItemID) -> Void)? = nil,
+        canSelectItem: ((ItemID) -> Bool)? = nil,
+        onVisibleItemsChanged: (([ItemID]) -> Void)? = nil,
+        onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)? = nil,
+        onRefresh: (() async -> Void)? = nil,
+        rowContent: @escaping (ItemID) -> RowContent
+    ) {
+        self.listLayout = layout
+        self.showsVerticalScrollIndicator = showsVerticalScrollIndicator
+        self.backgroundColor = backgroundColor
+        self.onSelectItem = onSelectItem
+        self.canSelectItem = canSelectItem
+        self.onVisibleItemsChanged = onVisibleItemsChanged
+        self.onScrollMetricsChanged = onScrollMetricsChanged
+        self.onRefresh = onRefresh
+        self.rowContent = rowContent
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func loadView() {
+        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: listLayout)
+        collectionView.backgroundColor = backgroundColor
+        collectionView.alwaysBounceVertical = true
+        collectionView.keyboardDismissMode = .interactive
+        collectionView.showsVerticalScrollIndicator = showsVerticalScrollIndicator
+        collectionView.allowsSelection = onSelectItem != nil
+        collectionView.delegate = self
+        self.collectionView = collectionView
+        view = collectionView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        guard let collectionView else { return }
+
+        if onRefresh != nil {
+            let refreshControl = UIRefreshControl()
+            refreshControl.addAction(
+                UIAction { [weak self] _ in
+                    self?.triggerRefresh()
+                },
+                for: .valueChanged
+            )
+            collectionView.refreshControl = refreshControl
+        }
+
+        let registration = UICollectionView.CellRegistration<UICollectionViewListCell, ItemID> {
+            [weak self] cell, _, itemID in
+            guard let self else { return }
+            cell.backgroundConfiguration = UIBackgroundConfiguration.clear()
+            cell.contentConfiguration = UIHostingConfiguration {
+                self.rowContent(itemID)
+            }
+            .margins(.all, 0)
+        }
+
+        dataSource = UICollectionViewDiffableDataSource<SectionID, ItemID>(
+            collectionView: collectionView
+        ) { collectionView, indexPath, itemID in
+            collectionView.dequeueConfiguredReusableCell(
+                using: registration,
+                for: indexPath,
+                item: itemID
+            )
+        }
+    }
+
+    func updateLayout(_ layout: UICollectionViewLayout) {
+        listLayout = layout
+        collectionView?.setCollectionViewLayout(layout, animated: false)
+    }
+
+    func updateAppearance(
+        showsVerticalScrollIndicator: Bool,
+        backgroundColor: UIColor
+    ) {
+        self.showsVerticalScrollIndicator = showsVerticalScrollIndicator
+        self.backgroundColor = backgroundColor
+        collectionView?.showsVerticalScrollIndicator = showsVerticalScrollIndicator
+        collectionView?.backgroundColor = backgroundColor
+    }
+
+    func setSections(
+        _ sections: [FireListSectionModel<SectionID, ItemID>],
+        animatingDifferences: Bool
+    ) {
+        guard let dataSource else { return }
+
+        let scrollAnchor = currentScrollAnchor()
+        var snapshot = NSDiffableDataSourceSnapshot<SectionID, ItemID>()
+        for section in sections {
+            snapshot.appendSections([section.id])
+            snapshot.appendItems(section.items, toSection: section.id)
+        }
+
+        dataSource.apply(snapshot, animatingDifferences: animatingDifferences) { [weak self] in
+            guard let self else { return }
+            self.restoreScrollAnchor(scrollAnchor)
+            self.publishVisibleItems()
+            self.publishScrollMetrics()
+        }
+    }
+
+    func collectionView(_ collectionView: UICollectionView, shouldSelectItemAt indexPath: IndexPath)
+        -> Bool
+    {
+        guard let itemID = dataSource?.itemIdentifier(for: indexPath) else { return false }
+        return canSelectItem?(itemID) ?? true
+    }
+
+    func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
+        guard let itemID = dataSource?.itemIdentifier(for: indexPath) else { return }
+        onSelectItem?(itemID)
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        publishVisibleItems()
+        publishScrollMetrics()
+    }
+
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        if !decelerate {
+            publishVisibleItems()
+            publishScrollMetrics()
+        }
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        publishVisibleItems()
+        publishScrollMetrics()
+    }
+
+    private func publishVisibleItems() {
+        guard let collectionView, let dataSource else { return }
+
+        let visibleItemIDs = collectionView.indexPathsForVisibleItems
+            .sorted()
+            .compactMap { dataSource.itemIdentifier(for: $0) }
+
+        guard visibleItemIDs != lastVisibleItemIDs else { return }
+        lastVisibleItemIDs = visibleItemIDs
+        onVisibleItemsChanged?(visibleItemIDs)
+    }
+
+    private func publishScrollMetrics() {
+        guard let collectionView else { return }
+
+        let visibleHeight = max(
+            collectionView.bounds.height
+                - collectionView.adjustedContentInset.top
+                - collectionView.adjustedContentInset.bottom,
+            0
+        )
+        let visibleTop = collectionView.contentOffset.y + collectionView.adjustedContentInset.top
+        let visibleBottom = visibleTop + visibleHeight
+        let metrics = FireCollectionScrollMetrics(
+            remainingDistanceToBottom: max(0, collectionView.contentSize.height - visibleBottom),
+            contentHeight: collectionView.contentSize.height,
+            visibleHeight: visibleHeight
+        )
+
+        guard metrics != lastScrollMetrics else { return }
+        lastScrollMetrics = metrics
+        onScrollMetricsChanged?(metrics)
+    }
+
+    private func triggerRefresh() {
+        guard !isRefreshing else { return }
+        guard let onRefresh else { return }
+        isRefreshing = true
+
+        Task { [weak self] in
+            await onRefresh()
+            await MainActor.run {
+                guard let self else { return }
+                self.collectionView?.refreshControl?.endRefreshing()
+                self.isRefreshing = false
+                self.publishScrollMetrics()
+            }
+        }
+    }
+
+    private func currentScrollAnchor() -> FireCollectionScrollAnchor<ItemID>? {
+        guard let collectionView, let dataSource else { return nil }
+
+        let topIndexPath = collectionView.indexPathsForVisibleItems
+            .sorted {
+                if $0.section == $1.section {
+                    return $0.item < $1.item
+                }
+                return $0.section < $1.section
+            }
+            .first
+
+        guard
+            let topIndexPath,
+            let itemID = dataSource.itemIdentifier(for: topIndexPath),
+            let attributes = collectionView.layoutAttributesForItem(at: topIndexPath)
+        else {
+            return nil
+        }
+
+        let offsetFromTop =
+            collectionView.contentOffset.y
+            + collectionView.adjustedContentInset.top
+            - attributes.frame.minY
+
+        return FireCollectionScrollAnchor(
+            itemID: itemID,
+            offsetFromTop: offsetFromTop
+        )
+    }
+
+    private func restoreScrollAnchor(_ scrollAnchor: FireCollectionScrollAnchor<ItemID>?) {
+        guard
+            let collectionView,
+            let dataSource,
+            let scrollAnchor,
+            let indexPath = dataSource.indexPath(for: scrollAnchor.itemID)
+        else {
+            return
+        }
+
+        collectionView.layoutIfNeeded()
+
+        guard let attributes = collectionView.layoutAttributesForItem(at: indexPath) else {
+            return
+        }
+
+        let adjustedTop = collectionView.adjustedContentInset.top
+        let minOffsetY = -adjustedTop
+        let maxOffsetY = max(
+            minOffsetY,
+            collectionView.contentSize.height
+                - collectionView.bounds.height
+                + collectionView.adjustedContentInset.bottom
+        )
+        let targetOffsetY = attributes.frame.minY - adjustedTop + scrollAnchor.offsetFromTop
+
+        collectionView.setContentOffset(
+            CGPoint(
+                x: collectionView.contentOffset.x,
+                y: min(max(targetOffsetY, minOffsetY), maxOffsetY)
+            ),
+            animated: false
+        )
+    }
+}

--- a/native/ios-app/App/ListKit/FireListSectionModel.swift
+++ b/native/ios-app/App/ListKit/FireListSectionModel.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+struct FireListSectionModel<SectionID: Hashable, ItemID: Hashable>: Hashable {
+    let id: SectionID
+    let items: [ItemID]
+
+    init(
+        id: SectionID,
+        items: [ItemID]
+    ) {
+        self.id = id
+        self.items = items
+    }
+}

--- a/native/ios-app/App/ListKit/Home/FireHomeCollectionView.swift
+++ b/native/ios-app/App/ListKit/Home/FireHomeCollectionView.swift
@@ -1,0 +1,317 @@
+import SwiftUI
+import UIKit
+
+private enum FireHomeCollectionSection: Int, Hashable {
+    case categoryTabs
+    case feedSelector
+    case tagChips
+    case content
+}
+
+private enum FireHomeCollectionItem: Hashable {
+    case categoryTabs
+    case feedSelector
+    case tagChips
+    case topic(UInt64)
+    case loadingSkeleton(Int)
+    case emptyState
+    case appendingFooter
+}
+
+struct FireHomeCollectionView: View {
+    @EnvironmentObject private var homeFeedStore: FireHomeFeedStore
+
+    let onShowCategoryBrowser: () -> Void
+    let onShowTagPicker: () -> Void
+    let onSelectTopic: (UInt64) -> Void
+    let onRefresh: () async -> Void
+    let onScrollMetricsChanged: (FireCollectionScrollMetrics) -> Void
+
+    private var parentCategories: [FireTopicCategoryPresentation] {
+        homeFeedStore.allCategories.filter { $0.parentCategoryId == nil }
+    }
+
+    private var sections: [FireListSectionModel<FireHomeCollectionSection, FireHomeCollectionItem>] {
+        var sections: [FireListSectionModel<FireHomeCollectionSection, FireHomeCollectionItem>] = [
+            .init(id: .categoryTabs, items: [.categoryTabs]),
+            .init(id: .feedSelector, items: [.feedSelector]),
+        ]
+
+        if !homeFeedStore.selectedHomeTags.isEmpty || !homeFeedStore.topTags.isEmpty {
+            sections.append(.init(id: .tagChips, items: [.tagChips]))
+        }
+
+        let contentItems: [FireHomeCollectionItem]
+        if homeFeedStore.isLoadingTopics && homeFeedStore.topicRows.isEmpty {
+            contentItems = (0..<6).map(FireHomeCollectionItem.loadingSkeleton)
+        } else if homeFeedStore.topicRows.isEmpty {
+            contentItems = [.emptyState]
+        } else {
+            contentItems =
+                homeFeedStore.topicRows.map { .topic($0.topic.id) }
+                + (homeFeedStore.nextTopicsPage != nil && homeFeedStore.isAppendingTopics
+                    ? [.appendingFooter]
+                    : [])
+        }
+
+        sections.append(.init(id: .content, items: contentItems))
+        return sections
+    }
+
+    var body: some View {
+        FireCollectionHost(
+            sections: sections,
+            backgroundColor: .systemBackground,
+            animatingDifferences: true,
+            onSelectItem: handleSelection(_:),
+            canSelectItem: canSelect(_:),
+            onScrollMetricsChanged: onScrollMetricsChanged,
+            onRefresh: onRefresh,
+            makeLayout: Self.makeLayout,
+            rowContent: rowView(for:)
+        )
+    }
+
+    private static func makeLayout() -> UICollectionViewLayout {
+        var configuration = UICollectionLayoutListConfiguration(appearance: .plain)
+        configuration.backgroundColor = .clear
+        configuration.showsSeparators = false
+        return UICollectionViewCompositionalLayout.list(using: configuration)
+    }
+
+    private func canSelect(_ item: FireHomeCollectionItem) -> Bool {
+        if case .topic = item {
+            return true
+        }
+        return false
+    }
+
+    private func handleSelection(_ item: FireHomeCollectionItem) {
+        guard case let .topic(topicID) = item else { return }
+        onSelectTopic(topicID)
+    }
+
+    @ViewBuilder
+    private func rowView(for item: FireHomeCollectionItem) -> some View {
+        switch item {
+        case .categoryTabs:
+            categoryTabsRow
+        case .feedSelector:
+            feedSelectorRow
+        case .tagChips:
+            tagChipsRow
+        case let .topic(topicID):
+            if let row = homeFeedStore.topicRow(for: topicID) {
+                FireTopicRow(
+                    row: row,
+                    category: homeFeedStore.categoryPresentation(for: row.topic.categoryId)
+                )
+                .padding(.horizontal, 16)
+            } else {
+                Color.clear
+                    .frame(height: 0)
+            }
+        case .loadingSkeleton:
+            loadingRow
+        case .emptyState:
+            emptyStateRow
+        case .appendingFooter:
+            appendingFooterRow
+        }
+    }
+
+    private var categoryTabsRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                categoryTab(label: "全部", categoryId: nil, color: FireTheme.accent)
+
+                ForEach(parentCategories, id: \.id) { category in
+                    categoryTab(
+                        label: category.displayName,
+                        categoryId: category.id,
+                        color: Color(fireHex: category.colorHex) ?? FireTheme.accent
+                    )
+                }
+
+                Button(action: onShowCategoryBrowser) {
+                    Image(systemName: "square.grid.2x2")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(FireTheme.subtleInk)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 7)
+                        .background(
+                            Capsule().fill(Color(.tertiarySystemFill))
+                        )
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.vertical, 2)
+        }
+        .padding(.top, 8)
+        .padding(.bottom, 4)
+        .padding(.horizontal, 16)
+    }
+
+    private func categoryTab(label: String, categoryId: UInt64?, color: Color) -> some View {
+        let isSelected = homeFeedStore.selectedHomeCategoryId == categoryId
+        return Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                homeFeedStore.selectHomeCategory(categoryId)
+            }
+        } label: {
+            Text(label)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(isSelected ? Color.white : Color(.label))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .background(
+                    Capsule().fill(isSelected ? color : Color(.tertiarySystemFill))
+                )
+                .lineLimit(1)
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var feedSelectorRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 4) {
+                ForEach(TopicListKindState.orderedCases, id: \.self) { kind in
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.2)) {
+                            homeFeedStore.selectTopicKind(kind)
+                        }
+                    } label: {
+                        Text(kind.title)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(
+                                homeFeedStore.selectedTopicKind == kind
+                                    ? Color.white
+                                    : Color(.secondaryLabel)
+                            )
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 6)
+                            .background(
+                                Capsule()
+                                    .fill(
+                                        homeFeedStore.selectedTopicKind == kind
+                                            ? FireTheme.accent
+                                            : Color(.tertiarySystemFill)
+                                    )
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+        .padding(.top, 2)
+        .padding(.bottom, 4)
+        .padding(.horizontal, 16)
+    }
+
+    @ViewBuilder
+    private var tagChipsRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                ForEach(homeFeedStore.selectedHomeTags, id: \.self) { tag in
+                    selectedTagChip(tag)
+                }
+
+                Button(action: onShowTagPicker) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "plus")
+                            .font(.caption2.weight(.bold))
+                        Text("标签")
+                            .font(.caption.weight(.medium))
+                    }
+                    .foregroundStyle(FireTheme.accent)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(
+                        Capsule()
+                            .strokeBorder(FireTheme.accent.opacity(0.3), lineWidth: 1)
+                    )
+                }
+                .buttonStyle(.plain)
+            }
+            .padding(.vertical, 2)
+        }
+        .padding(.top, 2)
+        .padding(.bottom, 6)
+        .padding(.horizontal, 16)
+    }
+
+    private func selectedTagChip(_ tag: String) -> some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                homeFeedStore.removeHomeTag(tag)
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text("#\(tag)")
+                    .font(.caption.weight(.medium))
+                Image(systemName: "xmark")
+                    .font(.system(size: 8, weight: .bold))
+            }
+            .foregroundStyle(FireTheme.accent)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(
+                Capsule().fill(FireTheme.accent.opacity(0.12))
+            )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var loadingRow: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(Color(.tertiarySystemFill))
+                .frame(width: 38, height: 38)
+
+            VStack(alignment: .leading, spacing: 6) {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color(.tertiarySystemFill))
+                    .frame(height: 14)
+
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color(.quaternarySystemFill))
+                    .frame(width: 100, height: 10)
+            }
+        }
+        .padding(.vertical, 6)
+        .padding(.horizontal, 16)
+        .redacted(reason: .placeholder)
+    }
+
+    private var emptyStateRow: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "tray")
+                .font(.title)
+                .foregroundStyle(.secondary)
+
+            Text("当前 feed 暂无话题")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+
+            Button("刷新") {
+                homeFeedStore.refreshTopics()
+            }
+            .buttonStyle(.bordered)
+            .tint(FireTheme.accent)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 40)
+    }
+
+    private var appendingFooterRow: some View {
+        HStack {
+            Spacer()
+            ProgressView()
+                .controlSize(.small)
+            Spacer()
+        }
+        .padding(.vertical, 8)
+    }
+}

--- a/native/ios-app/App/Stores/FireHomeFeedStore.swift
+++ b/native/ios-app/App/Stores/FireHomeFeedStore.swift
@@ -1,0 +1,383 @@
+import Foundation
+
+@MainActor
+final class FireHomeFeedStore: ObservableObject {
+    private static let topicListRefreshLoadingPollInterval: Duration = .milliseconds(250)
+
+    @Published private(set) var selectedTopicKind: TopicListKindState = .latest
+    @Published private(set) var selectedHomeCategoryId: UInt64?
+    @Published private(set) var selectedHomeTags: [String] = []
+    @Published private(set) var topicRows: [FireTopicRowPresentation] = []
+    @Published private(set) var moreTopicsUrl: String?
+    @Published private(set) var nextTopicsPage: UInt32?
+    @Published private(set) var allCategories: [FireTopicCategoryPresentation] = []
+    @Published private(set) var topicCategories: [UInt64: FireTopicCategoryPresentation] = [:]
+    @Published private(set) var topTags: [String] = []
+    @Published private(set) var canTagTopics = false
+    @Published private(set) var isLoadingTopics = false
+    @Published private(set) var isAppendingTopics = false
+
+    private let appViewModel: FireAppViewModel
+    private let topicListRefreshClock = ContinuousClock()
+    private var pendingTopicListRefreshTask: Task<Void, Never>?
+    private var filterChangeRefreshTask: Task<Void, Never>?
+    private var topicListMessageBusRefreshController = FireTopicListMessageBusRefreshController()
+    private var topicEntities = FireEntityIndex<UInt64, FireTopicRowPresentation>()
+    private var topicOrder = FireOrderedIDList<UInt64>()
+
+    init(appViewModel: FireAppViewModel) {
+        self.appViewModel = appViewModel
+        applySession(appViewModel.session)
+    }
+
+    var selectedHomeCategoryPresentation: FireTopicCategoryPresentation? {
+        guard let id = selectedHomeCategoryId else { return nil }
+        return categoryPresentation(for: id)
+    }
+
+    var visibleTopicIDs: Set<UInt64> {
+        Set(topicRows.map(\.topic.id))
+    }
+
+    func applySession(_ session: SessionState) {
+        allCategories = session.bootstrap.categories
+        topicCategories = Dictionary(
+            uniqueKeysWithValues: session.bootstrap.categories.map { ($0.id, $0) }
+        )
+        topTags = session.bootstrap.topTags
+        canTagTopics = session.bootstrap.canTagTopics
+
+        guard session.readiness.canReadAuthenticatedApi else {
+            reset(resetTopicKind: true)
+            return
+        }
+    }
+
+    func categoryPresentation(for categoryID: UInt64?) -> FireTopicCategoryPresentation? {
+        guard let categoryID else {
+            return nil
+        }
+        return topicCategories[categoryID]
+    }
+
+    func topicRow(for topicID: UInt64) -> FireTopicRowPresentation? {
+        topicEntities.entity(for: topicID)
+    }
+
+    func selectTopicKind(_ kind: TopicListKindState) {
+        guard selectedTopicKind != kind else {
+            return
+        }
+        selectedTopicKind = kind
+        scheduleDebouncedRefresh()
+    }
+
+    func selectHomeCategory(_ categoryId: UInt64?) {
+        guard selectedHomeCategoryId != categoryId else { return }
+        selectedHomeCategoryId = categoryId
+        selectedHomeTags = []
+        scheduleDebouncedRefresh()
+    }
+
+    func addHomeTag(_ tag: String) {
+        guard !selectedHomeTags.contains(tag) else { return }
+        selectedHomeTags.append(tag)
+        scheduleDebouncedRefresh()
+    }
+
+    func removeHomeTag(_ tag: String) {
+        guard selectedHomeTags.contains(tag) else { return }
+        selectedHomeTags.removeAll { $0 == tag }
+        scheduleDebouncedRefresh()
+    }
+
+    func clearHomeTags() {
+        guard !selectedHomeTags.isEmpty else { return }
+        selectedHomeTags = []
+        scheduleDebouncedRefresh()
+    }
+
+    func refreshTopics() {
+        Task {
+            await refreshTopicsAsync()
+        }
+    }
+
+    func refreshTopicsAsync() async {
+        await refreshTopicsIfPossible(force: true)
+    }
+
+    func refreshTopicsIfPossible(force: Bool) async {
+        cancelPendingTopicListRefresh()
+        await loadTopics(page: nil, reset: true, force: force, refreshMode: .full)
+    }
+
+    func loadMoreTopics() {
+        guard let nextTopicsPage else {
+            return
+        }
+
+        Task {
+            await loadTopics(page: nextTopicsPage, reset: false, force: true)
+        }
+    }
+
+    func handleTopicListMessageBusEvent(_ event: MessageBusEventState) {
+        guard let busKind = event.topicListKind else { return }
+        let scope = currentTopicListRefreshScope
+        guard busKind == scope.kind else { return }
+
+        let allowIncremental = scope.supportsIncrementalMessageBusRefresh && !topicRows.isEmpty
+        guard let delay = topicListMessageBusRefreshController.register(
+            event: event,
+            for: scope,
+            now: topicListRefreshClock.now,
+            allowIncremental: allowIncremental
+        ) else {
+            return
+        }
+
+        pendingTopicListRefreshTask?.cancel()
+        pendingTopicListRefreshTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: delay)
+            } catch {
+                return
+            }
+
+            guard let self else { return }
+
+            while self.isLoadingTopics {
+                do {
+                    try await Task.sleep(for: Self.topicListRefreshLoadingPollInterval)
+                } catch {
+                    return
+                }
+            }
+
+            let scope = self.currentTopicListRefreshScope
+            let refreshMode = self.topicListMessageBusRefreshController.takePendingRefresh(for: scope)
+            self.pendingTopicListRefreshTask = nil
+
+            guard let refreshMode else { return }
+            await self.refreshTopicsFromMessageBus(refreshMode)
+        }
+    }
+
+    func handleMessageBusStopped() {
+        cancelPendingTopicListRefresh()
+    }
+
+    func reset(resetTopicKind: Bool = true) {
+        cancelPendingTopicListRefresh()
+        filterChangeRefreshTask?.cancel()
+        filterChangeRefreshTask = nil
+        topicEntities.removeAll()
+        topicOrder.removeAll()
+        topicRows = []
+        moreTopicsUrl = nil
+        nextTopicsPage = nil
+        isLoadingTopics = false
+        isAppendingTopics = false
+        selectedHomeCategoryId = nil
+        selectedHomeTags = []
+        if resetTopicKind {
+            selectedTopicKind = .latest
+        }
+    }
+
+    private var currentTopicListRefreshScope: FireTopicListRefreshScope {
+        FireTopicListRefreshScope(
+            kind: selectedTopicKind,
+            categoryId: selectedHomeCategoryId,
+            tags: selectedHomeTags
+        )
+    }
+
+    private func scheduleDebouncedRefresh() {
+        cancelPendingTopicListRefresh()
+        filterChangeRefreshTask?.cancel()
+        filterChangeRefreshTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(300))
+            guard !Task.isCancelled else { return }
+            guard let self else { return }
+            await self.refreshTopicsIfPossible(force: true)
+        }
+    }
+
+    private func refreshTopicsFromMessageBus(_ refreshMode: FireTopicListMessageBusRefreshMode) async {
+        await loadTopics(page: nil, reset: true, force: true, refreshMode: refreshMode)
+    }
+
+    @discardableResult
+    private func loadTopics(
+        page: UInt32?,
+        reset: Bool,
+        force: Bool,
+        refreshMode: FireTopicListMessageBusRefreshMode = .full
+    ) async -> Bool {
+        if !appViewModel.session.readiness.canReadAuthenticatedApi {
+            self.reset(resetTopicKind: true)
+            return false
+        }
+        if isLoadingTopics {
+            return false
+        }
+        if reset && !force && !topicRows.isEmpty {
+            return false
+        }
+
+        isLoadingTopics = true
+        isAppendingTopics = !reset
+        defer {
+            isLoadingTopics = false
+            isAppendingTopics = false
+        }
+
+        do {
+            let sessionStore = try await appViewModel.sessionStoreValue()
+            appViewModel.errorMessage = nil
+            let requestedKind = selectedTopicKind
+            let categoryId = selectedHomeCategoryId
+            let requestedTags = selectedHomeTags
+            let requestedScope = FireTopicListRefreshScope(
+                kind: requestedKind,
+                categoryId: categoryId,
+                tags: requestedTags
+            )
+            let categorySlug = categoryId.flatMap { categoryPresentation(for: $0)?.slug }
+            let parentSlug: String? = categoryId.flatMap { id in
+                guard let category = categoryPresentation(for: id),
+                      let parentId = category.parentCategoryId else {
+                    return nil
+                }
+                return categoryPresentation(for: parentId)?.slug
+            }
+            let primaryTag = requestedTags.first
+            let additionalTags = requestedTags.count > 1
+                ? Array(requestedTags.dropFirst())
+                : []
+            let incrementalTopicIDs: [UInt64]
+            switch refreshMode {
+            case .full:
+                incrementalTopicIDs = []
+            case .incremental(let topicIDs):
+                incrementalTopicIDs = topicIDs
+            }
+            let usesIncrementalRefresh = page == nil
+                && reset
+                && !incrementalTopicIDs.isEmpty
+                && requestedScope.supportsIncrementalMessageBusRefresh
+                && !topicRows.isEmpty
+            let fetch: () async throws -> TopicListState = {
+                try await sessionStore.fetchTopicList(
+                    query: TopicListQueryState(
+                        kind: requestedKind,
+                        page: page,
+                        topicIds: usesIncrementalRefresh ? incrementalTopicIDs : [],
+                        order: nil,
+                        ascending: nil,
+                        categorySlug: categorySlug,
+                        categoryId: categoryId,
+                        parentCategorySlug: parentSlug,
+                        tag: primaryTag,
+                        additionalTags: additionalTags,
+                        matchAllTags: !additionalTags.isEmpty
+                    )
+                )
+            }
+
+            let response: TopicListState
+            if reset && page == nil && requestedKind == .latest {
+                response = try await FireAPMManager.shared.withSpan(
+                    .feedLatestInitialLoad,
+                    metadata: [
+                        "category_id": categoryId.map(String.init) ?? "none",
+                        "tag": primaryTag ?? "none",
+                        "incremental": usesIncrementalRefresh ? "true" : "false"
+                    ],
+                    operation: fetch
+                )
+            } else {
+                response = try await fetch()
+            }
+
+            guard requestedScope == currentTopicListRefreshScope else {
+                return false
+            }
+
+            let mergedTopicRows = mergeTopicRows(
+                incoming: response.rows,
+                reset: reset,
+                usesIncrementalRefresh: usesIncrementalRefresh
+            )
+            setTopicRows(mergedTopicRows)
+
+            if !usesIncrementalRefresh {
+                moreTopicsUrl = response.moreTopicsUrl
+                nextTopicsPage = response.nextPage
+            }
+
+            appViewModel.pruneTopicDetailState(retainingVisibleTopicIDs: visibleTopicIDs)
+
+            if reset && page == nil {
+                topicListMessageBusRefreshController.markRefreshCompleted(
+                    for: requestedScope,
+                    at: topicListRefreshClock.now
+                )
+            }
+            return true
+        } catch {
+            if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
+                return false
+            }
+            if reset, case .full = refreshMode {
+                clearTopicRows()
+            }
+            appViewModel.errorMessage = error.localizedDescription
+            return false
+        }
+    }
+
+    private func cancelPendingTopicListRefresh() {
+        pendingTopicListRefreshTask?.cancel()
+        pendingTopicListRefreshTask = nil
+
+        let scope = currentTopicListRefreshScope
+        topicListMessageBusRefreshController.clearPending(for: scope)
+    }
+
+    private func setTopicRows(_ rows: [FireTopicRowPresentation]) {
+        topicEntities.replaceAll(rows, id: \.topic.id)
+        topicOrder.replace(with: rows.map(\.topic.id))
+        topicRows = rows
+    }
+
+    private func clearTopicRows() {
+        topicEntities.removeAll()
+        topicOrder.removeAll()
+        topicRows = []
+        moreTopicsUrl = nil
+        nextTopicsPage = nil
+    }
+
+    private func mergeTopicRows(
+        incoming: [FireTopicRowPresentation],
+        reset: Bool,
+        usesIncrementalRefresh: Bool
+    ) -> [FireTopicRowPresentation] {
+        if reset {
+            if usesIncrementalRefresh {
+                return FireTopicListMessageBusRefreshMerger.merge(
+                    existing: topicRows,
+                    incoming: incoming
+                )
+            }
+            return incoming
+        }
+
+        topicEntities.upsert(incoming, id: \.topic.id)
+        topicOrder.append(incoming.map(\.topic.id))
+        return topicEntities.orderedValues(for: topicOrder)
+    }
+}

--- a/native/ios-app/App/Stores/FireNotificationStore.swift
+++ b/native/ios-app/App/Stores/FireNotificationStore.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+@MainActor
+final class FireNotificationStore: ObservableObject {
+    @Published private(set) var unreadCount: Int = 0
+    @Published private(set) var recentNotifications: [NotificationItemState] = []
+    @Published private(set) var isLoadingRecent = false
+    @Published private(set) var fullNotifications: [NotificationItemState] = []
+    @Published private(set) var fullNextOffset: UInt32?
+    @Published private(set) var isLoadingFullPage = false
+    @Published private(set) var hasMoreFull = false
+
+    private let appViewModel: FireAppViewModel
+    private var pendingStateRefreshTask: Task<Void, Never>?
+
+    init(appViewModel: FireAppViewModel) {
+        self.appViewModel = appViewModel
+    }
+
+    func reset() {
+        pendingStateRefreshTask?.cancel()
+        pendingStateRefreshTask = nil
+        unreadCount = 0
+        recentNotifications = []
+        isLoadingRecent = false
+        fullNotifications = []
+        fullNextOffset = nil
+        isLoadingFullPage = false
+        hasMoreFull = false
+    }
+
+    func cancelScheduledRefresh() {
+        pendingStateRefreshTask?.cancel()
+        pendingStateRefreshTask = nil
+    }
+
+    func syncStateFromRuntimeIfAvailable() async {
+        guard appViewModel.session.readiness.canReadAuthenticatedApi else {
+            reset()
+            return
+        }
+
+        do {
+            let state = try await appViewModel.notificationCenterState()
+            apply(centerState: state, updateRecent: state.hasLoadedRecent, updateFull: state.hasLoadedFull)
+        } catch {
+            _ = await appViewModel.handleRecoverableSessionErrorIfNeeded(error)
+        }
+    }
+
+    func loadRecent(force: Bool = true) async {
+        guard appViewModel.session.readiness.canReadAuthenticatedApi else { return }
+        guard !isLoadingRecent || force else { return }
+
+        isLoadingRecent = true
+        defer { isLoadingRecent = false }
+
+        do {
+            try await FireAPMManager.shared.withSpan(.notificationsRefresh) {
+                let list = try await appViewModel.fetchRecentNotificationsData()
+                recentNotifications = list.notifications
+                if let state = try? await appViewModel.notificationCenterState() {
+                    apply(centerState: state, updateRecent: true, updateFull: state.hasLoadedFull)
+                }
+            }
+        } catch {
+            _ = await appViewModel.handleRecoverableSessionErrorIfNeeded(error)
+        }
+    }
+
+    func markRead(id: UInt64) {
+        Task {
+            do {
+                let state = try await appViewModel.markNotificationReadState(id: id)
+                apply(centerState: state, updateRecent: true, updateFull: state.hasLoadedFull)
+            } catch {
+                _ = await appViewModel.handleRecoverableSessionErrorIfNeeded(error)
+            }
+        }
+    }
+
+    func markAllRead() {
+        Task {
+            do {
+                let state = try await appViewModel.markAllNotificationsReadState()
+                apply(centerState: state, updateRecent: true, updateFull: state.hasLoadedFull)
+            } catch {
+                _ = await appViewModel.handleRecoverableSessionErrorIfNeeded(error)
+            }
+        }
+    }
+
+    func loadFullPage(offset: UInt32?) async {
+        guard appViewModel.session.readiness.canReadAuthenticatedApi else { return }
+        guard !isLoadingFullPage else { return }
+
+        isLoadingFullPage = true
+        defer { isLoadingFullPage = false }
+
+        do {
+            _ = try await appViewModel.fetchNotificationsData(offset: offset)
+            let state = try await appViewModel.notificationCenterState()
+            apply(centerState: state, updateRecent: state.hasLoadedRecent, updateFull: true)
+        } catch {
+            _ = await appViewModel.handleRecoverableSessionErrorIfNeeded(error)
+        }
+    }
+
+    func scheduleStateRefresh() {
+        pendingStateRefreshTask?.cancel()
+        pendingStateRefreshTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(150))
+            guard !Task.isCancelled else { return }
+            guard let self else { return }
+
+            do {
+                let state = try await self.appViewModel.notificationCenterState()
+                self.apply(
+                    centerState: state,
+                    updateRecent: true,
+                    updateFull: state.hasLoadedFull
+                )
+            } catch {
+                _ = await self.appViewModel.handleRecoverableSessionErrorIfNeeded(error)
+            }
+
+            self.pendingStateRefreshTask = nil
+        }
+    }
+
+    func apply(
+        centerState: NotificationCenterState,
+        updateRecent: Bool,
+        updateFull: Bool
+    ) {
+        unreadCount = Int(centerState.counters.allUnread)
+        if updateRecent {
+            recentNotifications = centerState.recent
+        }
+        if updateFull {
+            fullNotifications = centerState.full
+            fullNextOffset = centerState.fullNextOffset
+            hasMoreFull = centerState.fullNextOffset != nil
+        }
+    }
+}

--- a/native/ios-app/App/Stores/FireSearchStore.swift
+++ b/native/ios-app/App/Stores/FireSearchStore.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+@MainActor
+final class FireSearchStore: ObservableObject {
+    @Published var query = ""
+    @Published private(set) var scope: FireSearchScope = .all
+    @Published private(set) var result: SearchResultState?
+    @Published private(set) var currentPage: UInt32 = 1
+    @Published private(set) var isSearching = false
+    @Published private(set) var isAppending = false
+    @Published private(set) var errorMessage: String?
+
+    private let appViewModel: FireAppViewModel
+    private var searchTask: Task<Void, Never>?
+    private var latestSearchRequestID: UInt64 = 0
+
+    init(appViewModel: FireAppViewModel) {
+        self.appViewModel = appViewModel
+    }
+
+    var canLoadMoreResults: Bool {
+        guard let result else { return false }
+        switch scope {
+        case .all:
+            return result.groupedResult.moreFullPageResults
+                || result.groupedResult.morePosts
+                || result.groupedResult.moreUsers
+        case .topic, .post:
+            return result.groupedResult.moreFullPageResults
+                || result.groupedResult.morePosts
+        case .user:
+            return result.groupedResult.moreUsers
+        }
+    }
+
+    func reset(resetQuery: Bool = true) {
+        clear(resetQuery: resetQuery)
+    }
+
+    func setScope(_ newScope: FireSearchScope) {
+        guard scope != newScope else {
+            return
+        }
+        scope = newScope
+        guard result != nil else {
+            return
+        }
+        submit(reset: true)
+    }
+
+    func submit(reset: Bool) {
+        let trimmedQuery = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedQuery.isEmpty else {
+            clear(resetQuery: false)
+            return
+        }
+        if !reset && (isSearching || isAppending) {
+            return
+        }
+
+        searchTask?.cancel()
+        let nextPage = reset ? UInt32(1) : currentPage + 1
+        let requestID = latestSearchRequestID &+ 1
+        latestSearchRequestID = requestID
+        let currentScope = scope
+
+        if reset {
+            isSearching = true
+            isAppending = false
+        } else {
+            isAppending = true
+        }
+
+        searchTask = Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let response = try await self.appViewModel.search(
+                    query: trimmedQuery,
+                    typeFilter: currentScope.typeFilter,
+                    page: nextPage
+                )
+                guard !Task.isCancelled, requestID == self.latestSearchRequestID else {
+                    return
+                }
+
+                self.errorMessage = nil
+                self.currentPage = nextPage
+                self.result = reset
+                    ? response
+                    : Self.merge(existing: self.result, incoming: response)
+            } catch is CancellationError {
+                return
+            } catch {
+                guard !Task.isCancelled, requestID == self.latestSearchRequestID else {
+                    return
+                }
+                if await self.appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
+                    self.errorMessage = nil
+                } else {
+                    self.errorMessage = error.localizedDescription
+                }
+            }
+
+            guard requestID == self.latestSearchRequestID else {
+                return
+            }
+            self.isSearching = false
+            self.isAppending = false
+            self.searchTask = nil
+        }
+    }
+
+    nonisolated static func merge(
+        existing: SearchResultState?,
+        incoming: SearchResultState
+    ) -> SearchResultState {
+        guard let existing else {
+            return incoming
+        }
+
+        return SearchResultState(
+            posts: mergeItemsByID(existing.posts, incoming.posts, keyPath: \.id),
+            topics: mergeItemsByID(existing.topics, incoming.topics, keyPath: \.id),
+            users: mergeItemsByID(existing.users, incoming.users, keyPath: \.id),
+            groupedResult: incoming.groupedResult
+        )
+    }
+
+    private nonisolated static func mergeItemsByID<Item>(
+        _ existing: [Item],
+        _ incoming: [Item],
+        keyPath: KeyPath<Item, UInt64>
+    ) -> [Item] {
+        var merged = Dictionary(uniqueKeysWithValues: existing.map { ($0[keyPath: keyPath], $0) })
+        var orderedIDs = existing.map { $0[keyPath: keyPath] }
+
+        for item in incoming {
+            let id = item[keyPath: keyPath]
+            if merged[id] == nil {
+                orderedIDs.append(id)
+            }
+            merged[id] = item
+        }
+
+        return orderedIDs.compactMap { merged[$0] }
+    }
+
+    private func clear(resetQuery: Bool) {
+        searchTask?.cancel()
+        searchTask = nil
+        latestSearchRequestID = latestSearchRequestID &+ 1
+        if resetQuery {
+            query = ""
+        }
+        result = nil
+        currentPage = 1
+        isSearching = false
+        isAppending = false
+        errorMessage = nil
+        scope = .all
+    }
+}

--- a/native/ios-app/App/Stores/FireTopicDetailStore.swift
+++ b/native/ios-app/App/Stores/FireTopicDetailStore.swift
@@ -1,0 +1,881 @@
+import Foundation
+
+@MainActor
+final class FireTopicDetailStore: ObservableObject {
+    private static let topicPostPageSize = 30
+    private static let topicPostPrefetchThreshold = 6
+
+    @Published private(set) var topicDetails: [UInt64: TopicDetailState] = [:]
+    @Published private(set) var topicPresenceUsersByTopic: [UInt64: [TopicPresenceUserState]] = [:]
+    @Published private(set) var loadingMoreTopicPostIDs: Set<UInt64> = []
+    @Published private(set) var loadingTopicIDs: Set<UInt64> = []
+    @Published private(set) var submittingReplyTopicIDs: Set<UInt64> = []
+    @Published private(set) var mutatingPostIDs: Set<UInt64> = []
+    @Published var errorMessage: String?
+
+    private let appViewModel: FireAppViewModel
+    private var pendingTopicDetailRefreshTasks: [UInt64: Task<Void, Never>] = [:]
+    private var topicPresenceHeartbeatTasks: [UInt64: Task<Void, Never>] = [:]
+    private var topicPostPreloadTasks: [UInt64: Task<Void, Never>] = [:]
+    private var topicPostPaginationStates: [UInt64: FireTopicPostPaginationState] = [:]
+    private var topicDetailTargetPostNumbers: [UInt64: UInt32] = [:]
+    private var activeTopicDetailOwnerTokens: [UInt64: Set<String>] = [:]
+
+    init(appViewModel: FireAppViewModel) {
+        self.appViewModel = appViewModel
+    }
+
+    func applySession(_ session: SessionState) {
+        guard session.readiness.canReadAuthenticatedApi else {
+            reset()
+            return
+        }
+    }
+
+    func handleMessageBusStopped() {
+        pendingTopicDetailRefreshTasks.values.forEach { $0.cancel() }
+        pendingTopicDetailRefreshTasks = [:]
+        topicPresenceHeartbeatTasks.values.forEach { $0.cancel() }
+        topicPresenceHeartbeatTasks = [:]
+        topicPresenceUsersByTopic = [:]
+    }
+
+    func reset() {
+        pendingTopicDetailRefreshTasks.values.forEach { $0.cancel() }
+        pendingTopicDetailRefreshTasks = [:]
+        topicPresenceHeartbeatTasks.values.forEach { $0.cancel() }
+        topicPresenceHeartbeatTasks = [:]
+        topicPostPreloadTasks.values.forEach { $0.cancel() }
+        topicPostPreloadTasks = [:]
+        activeTopicDetailOwnerTokens = [:]
+        topicDetailTargetPostNumbers = [:]
+        topicPostPaginationStates = [:]
+        topicDetails = [:]
+        topicPresenceUsersByTopic = [:]
+        loadingMoreTopicPostIDs = []
+        loadingTopicIDs = []
+        submittingReplyTopicIDs = []
+        mutatingPostIDs = []
+        errorMessage = nil
+    }
+
+    func loadTopicDetail(
+        topicId: UInt64,
+        targetPostNumber: UInt32? = nil,
+        force: Bool = false
+    ) async {
+        if loadingTopicIDs.contains(topicId) {
+            return
+        }
+        if topicDetails[topicId] != nil && !force {
+            return
+        }
+        if !appViewModel.session.readiness.canReadAuthenticatedApi {
+            reset()
+            return
+        }
+
+        if let targetPostNumber {
+            topicDetailTargetPostNumbers[topicId] = targetPostNumber
+        }
+
+        let hadCachedDetail = topicDetails[topicId] != nil
+        appViewModel.topicDetailLogger()?.debug(
+            "loading topic detail topic_id=\(topicId) force=\(force) had_cache=\(hadCachedDetail) target_post=\(String(describing: targetPostNumber))"
+        )
+        loadingTopicIDs.insert(topicId)
+        defer { loadingTopicIDs.remove(topicId) }
+
+        do {
+            let sessionStore = try await appViewModel.sessionStoreValue()
+            errorMessage = nil
+            let detail = try await FireAPMManager.shared.withSpan(
+                .topicDetailInitialLoad,
+                metadata: ["topic_id": String(topicId)]
+            ) {
+                try await sessionStore.fetchTopicDetailInitial(
+                    query: TopicDetailQueryState(
+                        topicId: topicId,
+                        postNumber: targetPostNumber,
+                        trackVisit: true,
+                        filter: nil,
+                        usernameFilters: nil,
+                        filterTopLevelReplies: false
+                    )
+                )
+            }
+            applyTopicDetail(detail, topicId: topicId)
+            appViewModel.topicDetailLogger()?.debug(
+                "loaded topic detail topic_id=\(topicId) loaded_posts=\(detail.postStream.posts.count) stream_posts=\(detail.postStream.stream.count)"
+            )
+        } catch {
+            appViewModel.topicDetailLogger()?.error(
+                "topic detail load failed topic_id=\(topicId) error=\(error.localizedDescription)"
+            )
+            if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
+                return
+            }
+            errorMessage = error.localizedDescription
+        }
+    }
+
+    func clearTopicDetailAnchor(topicId: UInt64) {
+        topicDetailTargetPostNumbers.removeValue(forKey: topicId)
+    }
+
+    func topicDetail(for topicId: UInt64) -> TopicDetailState? {
+        topicDetails[topicId]
+    }
+
+    func topicPresenceUsers(for topicId: UInt64) -> [TopicPresenceUserState] {
+        topicPresenceUsersByTopic[topicId] ?? []
+    }
+
+    func isLoadingTopic(topicId: UInt64) -> Bool {
+        loadingTopicIDs.contains(topicId)
+    }
+
+    func isLoadingMoreTopicPosts(topicId: UInt64) -> Bool {
+        loadingMoreTopicPostIDs.contains(topicId)
+    }
+
+    func hasMoreTopicPosts(topicId: UInt64) -> Bool {
+        guard let detail = topicDetails[topicId] else {
+            return false
+        }
+        let loadedWindowCount = FireTopicPresentation.loadedWindowCount(detail: detail)
+        let pagination = topicPostPaginationStates[topicId]
+        let targetLoadedCount = max(pagination?.targetLoadedCount ?? loadedWindowCount, loadedWindowCount)
+        let unresolvedPostIDs = FireTopicPresentation.missingPostIDs(
+            in: detail,
+            upTo: targetLoadedCount,
+            excluding: pagination?.exhaustedPostIDs ?? Set<UInt64>()
+        )
+        return !unresolvedPostIDs.isEmpty || targetLoadedCount < detail.postStream.stream.count
+    }
+
+    func preloadTopicPostsIfNeeded(
+        topicId: UInt64,
+        visibleReplyIndex: Int,
+        totalReplyCount: Int
+    ) {
+        guard totalReplyCount > 0 else { return }
+        let triggerIndex = max(totalReplyCount - Self.topicPostPrefetchThreshold, 0)
+        guard visibleReplyIndex >= triggerIndex else { return }
+        guard hasMoreTopicPosts(topicId: topicId) else { return }
+        guard !loadingMoreTopicPostIDs.contains(topicId) else { return }
+        guard topicPostPreloadTasks[topicId] == nil else { return }
+
+        topicPostPreloadTasks[topicId] = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.topicPostPreloadTasks[topicId] = nil }
+            await self.loadMoreTopicPostsIfNeeded(topicId: topicId)
+        }
+    }
+
+    func beginTopicDetailLifecycle(topicId: UInt64, ownerToken: String) {
+        var owners = activeTopicDetailOwnerTokens[topicId] ?? []
+        let inserted = owners.insert(ownerToken).inserted
+        activeTopicDetailOwnerTokens[topicId] = owners
+        guard inserted else { return }
+
+        appViewModel.topicDetailLogger()?.debug(
+            "registered topic detail lifecycle topic_id=\(topicId) owner_token=\(ownerToken) owner_count=\(owners.count)"
+        )
+    }
+
+    func endTopicDetailLifecycle(
+        topicId: UInt64,
+        ownerToken: String,
+        visibleTopicIDs: Set<UInt64>
+    ) {
+        guard var owners = activeTopicDetailOwnerTokens[topicId] else { return }
+        guard owners.remove(ownerToken) != nil else { return }
+
+        if owners.isEmpty {
+            activeTopicDetailOwnerTokens.removeValue(forKey: topicId)
+        } else {
+            activeTopicDetailOwnerTokens[topicId] = owners
+        }
+
+        appViewModel.topicDetailLogger()?.debug(
+            "released topic detail lifecycle topic_id=\(topicId) owner_token=\(ownerToken) owner_count=\(owners.count)"
+        )
+
+        guard owners.isEmpty else { return }
+        topicDetailTargetPostNumbers.removeValue(forKey: topicId)
+        guard !visibleTopicIDs.contains(topicId) else { return }
+        evictTopicDetailState(topicId: topicId, reason: "detail view disappeared")
+    }
+
+    func pruneInactiveTopicDetailState(retainingVisibleTopicIDs visibleTopicIDs: Set<UInt64>) {
+        let retainedTopicIDs = retainedTopicDetailIDs(visibleTopicIDs: visibleTopicIDs)
+        pruneInactiveTopicDetailState(retaining: retainedTopicIDs, visibleTopicIDs: visibleTopicIDs)
+    }
+
+    func maintainTopicDetailSubscription(topicId: UInt64, ownerToken: String) async {
+        guard appViewModel.session.readiness.canOpenMessageBus else { return }
+        guard topicDetails[topicId] != nil else {
+            appViewModel.topicDetailLogger()?.debug(
+                "skipping topic detail subscription bootstrap topic_id=\(topicId) reason=detail not loaded"
+            )
+            return
+        }
+
+        guard let store = appViewModel.currentSessionStore() else { return }
+
+        do {
+            try await store.subscribeTopicDetailChannel(topicId: topicId, ownerToken: ownerToken)
+            try await store.subscribeTopicReactionChannel(topicId: topicId, ownerToken: ownerToken)
+        } catch {
+            try? await store.unsubscribeTopicReactionChannel(topicId: topicId, ownerToken: ownerToken)
+            try? await store.unsubscribeTopicDetailChannel(topicId: topicId, ownerToken: ownerToken)
+            return
+        }
+
+        do {
+            let presence = try await store.bootstrapTopicReplyPresence(
+                topicId: topicId,
+                ownerToken: ownerToken
+            )
+            applyTopicPresenceState(presence)
+        } catch {
+            topicPresenceUsersByTopic[topicId] = []
+        }
+
+        defer {
+            Task {
+                await self.endTopicReplyPresence(topicId: topicId)
+                self.topicPresenceUsersByTopic[topicId] = []
+                try? await store.unsubscribeTopicReplyPresenceChannel(topicId: topicId, ownerToken: ownerToken)
+                try? await store.unsubscribeTopicReactionChannel(topicId: topicId, ownerToken: ownerToken)
+                try? await store.unsubscribeTopicDetailChannel(topicId: topicId, ownerToken: ownerToken)
+            }
+        }
+
+        await appViewModel.ensureMessageBusActiveIfPossible()
+
+        while !Task.isCancelled {
+            do {
+                try await Task.sleep(for: .seconds(3600))
+            } catch {
+                break
+            }
+        }
+    }
+
+    func handleMessageBusEvent(_ event: MessageBusEventState) {
+        switch event.kind {
+        case .topicDetail, .topicReaction:
+            guard let topicId = event.topicId else { return }
+            guard topicDetails[topicId] != nil else { return }
+            scheduleTopicDetailRefresh(topicId: topicId)
+        case .presence:
+            guard let topicId = event.topicId else { return }
+            refreshTopicPresenceState(topicId: topicId)
+        default:
+            break
+        }
+    }
+
+    func beginTopicReplyPresence(topicId: UInt64) {
+        guard appViewModel.session.readiness.canOpenMessageBus else { return }
+        guard appViewModel.session.readiness.canWriteAuthenticatedApi else { return }
+        guard topicPresenceHeartbeatTasks[topicId] == nil else { return }
+        guard let store = appViewModel.currentSessionStore() else { return }
+
+        topicPresenceHeartbeatTasks[topicId] = Task { [weak self] in
+            while !Task.isCancelled {
+                do {
+                    try await store.updateTopicReplyPresence(topicId: topicId, active: true)
+                } catch {
+                    return
+                }
+
+                guard let self else { return }
+                guard self.topicPresenceHeartbeatTasks[topicId] != nil else { return }
+
+                do {
+                    try await Task.sleep(for: .seconds(30))
+                } catch {
+                    return
+                }
+            }
+        }
+    }
+
+    func endTopicReplyPresence(topicId: UInt64) async {
+        let task = topicPresenceHeartbeatTasks.removeValue(forKey: topicId)
+        task?.cancel()
+        guard let store = appViewModel.currentSessionStore() else { return }
+        try? await store.updateTopicReplyPresence(topicId: topicId, active: false)
+    }
+
+    func isSubmittingReply(topicId: UInt64) -> Bool {
+        submittingReplyTopicIDs.contains(topicId)
+    }
+
+    func isMutatingPost(postId: UInt64) -> Bool {
+        mutatingPostIDs.contains(postId)
+    }
+
+    func submitReply(
+        topicId: UInt64,
+        raw: String,
+        replyToPostNumber: UInt32?
+    ) async throws {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw FireTopicInteractionError.emptyReply
+        }
+
+        let sessionStore = try await appViewModel.sessionStoreValue()
+        guard appViewModel.session.readiness.canWriteAuthenticatedApi else {
+            throw FireTopicInteractionError.requiresAuthenticatedWrite
+        }
+        guard !submittingReplyTopicIDs.contains(topicId) else {
+            return
+        }
+
+        submittingReplyTopicIDs.insert(topicId)
+        defer { submittingReplyTopicIDs.remove(topicId) }
+
+        do {
+            errorMessage = nil
+            let createdReply = try await FireAPMManager.shared.withSpan(
+                .topicReplySubmit,
+                metadata: [
+                    "topic_id": String(topicId),
+                    "reply_to_post_number": replyToPostNumber.map(String.init) ?? "root"
+                ]
+            ) {
+                try await appViewModel.performWriteWithCloudflareRetry {
+                    try await sessionStore.createReply(
+                        topicID: topicId,
+                        raw: trimmed,
+                        replyToPostNumber: replyToPostNumber
+                    )
+                }
+            }
+            await appViewModel.syncSessionSnapshotIfAvailable(from: sessionStore)
+            applyCreatedReply(createdReply, topicId: topicId)
+            try? await refreshTopicDetailAfterMutation(topicId: topicId, sessionStore: sessionStore)
+        } catch {
+            if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
+                throw error
+            }
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+
+    func updatePost(
+        topicID: UInt64,
+        postID: UInt64,
+        raw: String,
+        editReason: String? = nil
+    ) async throws -> TopicPostState {
+        let trimmedRaw = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedRaw.isEmpty else {
+            throw FireTopicInteractionError.emptyReply
+        }
+
+        let sessionStore = try await appViewModel.sessionStoreValue()
+        guard appViewModel.session.readiness.canWriteAuthenticatedApi else {
+            throw FireTopicInteractionError.requiresAuthenticatedWrite
+        }
+        guard !mutatingPostIDs.contains(postID) else {
+            return try await sessionStore.fetchPost(postID: postID)
+        }
+
+        mutatingPostIDs.insert(postID)
+        defer { mutatingPostIDs.remove(postID) }
+
+        do {
+            errorMessage = nil
+            let updatedPost = try await appViewModel.performWriteWithCloudflareRetry {
+                try await sessionStore.updatePost(
+                    postID: postID,
+                    raw: trimmedRaw,
+                    editReason: editReason
+                )
+            }
+            await appViewModel.syncSessionSnapshotIfAvailable(from: sessionStore)
+            try? await refreshTopicDetailAfterMutation(topicId: topicID, sessionStore: sessionStore)
+            await appViewModel.refreshHomeFeedIfPossible(force: false)
+            return updatedPost
+        } catch {
+            if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
+                throw error
+            }
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+
+    func setPostLiked(
+        topicId: UInt64,
+        postId: UInt64,
+        liked: Bool
+    ) async throws {
+        let sessionStore = try await appViewModel.sessionStoreValue()
+        guard appViewModel.session.readiness.canWriteAuthenticatedApi else {
+            throw FireTopicInteractionError.requiresAuthenticatedWrite
+        }
+        guard !mutatingPostIDs.contains(postId) else {
+            return
+        }
+
+        mutatingPostIDs.insert(postId)
+        defer { mutatingPostIDs.remove(postId) }
+
+        do {
+            errorMessage = nil
+            let update = try await appViewModel.performWriteWithCloudflareRetry {
+                if liked {
+                    try await sessionStore.likePost(postID: postId)
+                } else {
+                    try await sessionStore.unlikePost(postID: postId)
+                }
+            }
+            await appViewModel.syncSessionSnapshotIfAvailable(from: sessionStore)
+            if let update {
+                applyPostReactionUpdate(topicId: topicId, postId: postId, update: update)
+            } else {
+                try? await refreshTopicDetailAfterMutation(topicId: topicId, sessionStore: sessionStore)
+            }
+        } catch {
+            if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
+                throw error
+            }
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+
+    func togglePostReaction(
+        topicId: UInt64,
+        postId: UInt64,
+        reactionId: String
+    ) async throws {
+        let trimmedReactionID = reactionId.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedReactionID.isEmpty else {
+            return
+        }
+
+        let sessionStore = try await appViewModel.sessionStoreValue()
+        guard appViewModel.session.readiness.canWriteAuthenticatedApi else {
+            throw FireTopicInteractionError.requiresAuthenticatedWrite
+        }
+        guard !mutatingPostIDs.contains(postId) else {
+            return
+        }
+
+        mutatingPostIDs.insert(postId)
+        defer { mutatingPostIDs.remove(postId) }
+
+        do {
+            errorMessage = nil
+            let update = try await appViewModel.performWriteWithCloudflareRetry {
+                try await sessionStore.togglePostReaction(
+                    postID: postId,
+                    reactionID: trimmedReactionID
+                )
+            }
+            applyPostReactionUpdate(topicId: topicId, postId: postId, update: update)
+        } catch {
+            if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
+                throw error
+            }
+            errorMessage = error.localizedDescription
+            throw error
+        }
+    }
+
+    func refreshTopicDetailAfterMutation(topicId: UInt64) async {
+        guard let sessionStore = try? await appViewModel.sessionStoreValue() else {
+            return
+        }
+        try? await refreshTopicDetailAfterMutation(topicId: topicId, sessionStore: sessionStore)
+    }
+
+    private func refreshTopicDetailAfterMutation(
+        topicId: UInt64,
+        sessionStore: FireSessionStore
+    ) async throws {
+        let detail = try await sessionStore.fetchTopicDetailInitial(
+            query: TopicDetailQueryState(
+                topicId: topicId,
+                postNumber: nil,
+                trackVisit: false,
+                filter: nil,
+                usernameFilters: nil,
+                filterTopLevelReplies: false
+            )
+        )
+        applyTopicDetail(detail, topicId: topicId)
+    }
+
+    private func scheduleTopicDetailRefresh(topicId: UInt64) {
+        pendingTopicDetailRefreshTasks[topicId]?.cancel()
+        pendingTopicDetailRefreshTasks[topicId] = Task { [weak self] in
+            try? await Task.sleep(for: .seconds(1.5))
+            guard !Task.isCancelled else { return }
+            guard let self, let store = self.appViewModel.currentSessionStore() else { return }
+            guard self.topicDetails[topicId] != nil else { return }
+            let anchorPostNumber = self.topicDetailTargetPostNumbers[topicId]
+            do {
+                let detail = try await store.fetchTopicDetailInitial(
+                    query: TopicDetailQueryState(
+                        topicId: topicId,
+                        postNumber: anchorPostNumber,
+                        trackVisit: false,
+                        filter: nil,
+                        usernameFilters: nil,
+                        filterTopLevelReplies: false
+                    )
+                )
+                self.applyTopicDetail(detail, topicId: topicId)
+            } catch {
+                _ = await self.appViewModel.handleRecoverableSessionErrorIfNeeded(error)
+            }
+        }
+    }
+
+    private func refreshTopicPresenceState(topicId: UInt64) {
+        guard let store = appViewModel.currentSessionStore() else { return }
+        Task { [weak self] in
+            guard let self else { return }
+            guard let presence = try? await store.topicReplyPresenceState(topicId: topicId) else {
+                return
+            }
+            self.applyTopicPresenceState(presence)
+        }
+    }
+
+    private func applyTopicPresenceState(_ state: TopicPresenceState) {
+        let currentUserID = appViewModel.session.bootstrap.currentUserId
+        let filteredUsers = state.users.filter { user in
+            guard let currentUserID else { return true }
+            return user.id != currentUserID
+        }
+
+        if filteredUsers.isEmpty {
+            topicPresenceUsersByTopic.removeValue(forKey: state.topicId)
+        } else {
+            topicPresenceUsersByTopic[state.topicId] = filteredUsers
+        }
+    }
+
+    func retainedTopicDetailIDs(visibleTopicIDs: Set<UInt64>) -> Set<UInt64> {
+        let activeTopicIDs = activeTopicDetailOwnerTokens.compactMap { topicId, owners in
+            owners.isEmpty ? nil : topicId
+        }
+        return visibleTopicIDs.union(activeTopicIDs)
+    }
+
+    private func pruneInactiveTopicDetailState(
+        retaining retainedTopicIDs: Set<UInt64>,
+        visibleTopicIDs: Set<UInt64>
+    ) {
+        let trackedTopicIDs = Set(topicDetails.keys)
+            .union(topicPostPaginationStates.keys)
+            .union(topicPresenceUsersByTopic.keys)
+            .union(loadingTopicIDs)
+            .union(loadingMoreTopicPostIDs)
+            .union(topicPostPreloadTasks.keys)
+            .union(pendingTopicDetailRefreshTasks.keys)
+            .union(topicPresenceHeartbeatTasks.keys)
+        let inactiveTopicIDs = trackedTopicIDs.subtracting(retainedTopicIDs)
+        guard !inactiveTopicIDs.isEmpty else {
+            return
+        }
+
+        let activeTopicIDs = retainedTopicIDs.subtracting(visibleTopicIDs)
+        appViewModel.topicDetailLogger()?.notice(
+            "pruning inactive topic detail state retained_active_topic_ids=\(Self.formattedTopicIDs(activeTopicIDs)) pruned_topic_ids=\(Self.formattedTopicIDs(inactiveTopicIDs))"
+        )
+
+        for topicId in inactiveTopicIDs.sorted() {
+            evictTopicDetailState(topicId: topicId, reason: "topic list refresh pruned inactive detail")
+        }
+    }
+
+    private static func formattedTopicIDs(_ topicIDs: Set<UInt64>) -> String {
+        topicIDs.sorted().map(String.init).joined(separator: ",")
+    }
+
+    private func evictTopicDetailState(topicId: UInt64, reason: String) {
+        let removedDetail = topicDetails.removeValue(forKey: topicId) != nil
+        let removedPagination = topicPostPaginationStates.removeValue(forKey: topicId) != nil
+        let removedPresence = topicPresenceUsersByTopic.removeValue(forKey: topicId) != nil
+        let removedLoadingTopic = loadingTopicIDs.remove(topicId) != nil
+        let removedLoadingMore = loadingMoreTopicPostIDs.remove(topicId) != nil
+        let refreshTask = pendingTopicDetailRefreshTasks.removeValue(forKey: topicId)
+        let presenceTask = topicPresenceHeartbeatTasks.removeValue(forKey: topicId)
+        let preloadTask = topicPostPreloadTasks.removeValue(forKey: topicId)
+        refreshTask?.cancel()
+        presenceTask?.cancel()
+        preloadTask?.cancel()
+
+        guard removedDetail
+            || removedPagination
+            || removedPresence
+            || removedLoadingTopic
+            || removedLoadingMore
+            || refreshTask != nil
+            || presenceTask != nil
+            || preloadTask != nil
+        else {
+            return
+        }
+
+        appViewModel.topicDetailLogger()?.notice(
+            "evicted topic detail state topic_id=\(topicId) reason=\(reason)"
+        )
+    }
+
+    private func applyTopicDetail(_ incomingDetail: TopicDetailState, topicId: UInt64) {
+        let previousDetail = topicDetails[topicId]
+        let previousTargetLoadedCount = topicPostPaginationStates[topicId]?.targetLoadedCount
+            ?? previousDetail.map { FireTopicPresentation.loadedWindowCount(detail: $0) }
+            ?? 0
+        let previousWasFullyLoaded = previousDetail.map {
+            previousTargetLoadedCount >= $0.postStream.stream.count
+        } ?? false
+
+        var detail = incomingDetail
+        if let previousDetail {
+            detail.postStream.posts = FireTopicPresentation.mergeTopicPosts(
+                existing: previousDetail.postStream.posts,
+                incoming: detail.postStream.posts,
+                orderedPostIDs: detail.postStream.stream
+            )
+        }
+        detail = FireTopicPresentation.recomposedDetail(detail)
+
+        let loadedWindowCount = FireTopicPresentation.loadedWindowCount(detail: detail)
+        let targetLoadedCount = min(
+            max(
+                previousWasFullyLoaded ? detail.postStream.stream.count : previousTargetLoadedCount,
+                loadedWindowCount
+            ),
+            detail.postStream.stream.count
+        )
+        topicDetails[topicId] = detail
+        topicPostPaginationStates[topicId] = FireTopicPostPaginationState(
+            targetLoadedCount: targetLoadedCount
+        )
+
+        let missingPostIDs = FireTopicPresentation.missingPostIDs(
+            in: detail,
+            upTo: targetLoadedCount
+        )
+        if !missingPostIDs.isEmpty {
+            Task {
+                await hydrateTopicPostsToTargetIfNeeded(topicId: topicId)
+            }
+        }
+    }
+
+    private func applyCreatedReply(_ reply: TopicPostState, topicId: UInt64) {
+        guard var detail = topicDetails[topicId] else {
+            return
+        }
+
+        let isNewPost = !detail.postStream.stream.contains(reply.id)
+        if isNewPost {
+            detail.postStream.stream.append(reply.id)
+        }
+
+        if let postIndex = detail.postStream.posts.firstIndex(where: { $0.id == reply.id }) {
+            detail.postStream.posts[postIndex] = reply
+        } else {
+            detail.postStream.posts.append(reply)
+        }
+
+        if isNewPost {
+            detail.postsCount = max(
+                detail.postsCount + 1,
+                UInt32(detail.postStream.stream.count)
+            )
+        }
+
+        detail = FireTopicPresentation.recomposedDetail(detail)
+        topicDetails[topicId] = detail
+
+        var pagination = topicPostPaginationStates[topicId]
+            ?? FireTopicPostPaginationState(
+                targetLoadedCount: FireTopicPresentation.loadedWindowCount(detail: detail)
+            )
+        pagination.targetLoadedCount = max(pagination.targetLoadedCount, detail.postStream.stream.count)
+        pagination.exhaustedPostIDs.remove(reply.id)
+        topicPostPaginationStates[topicId] = pagination
+    }
+
+    private func loadMoreTopicPostsIfNeeded(topicId: UInt64) async {
+        guard var pagination = topicPostPaginationStates[topicId],
+              let detail = topicDetails[topicId] else {
+            return
+        }
+        guard !Task.isCancelled else {
+            return
+        }
+        guard !loadingMoreTopicPostIDs.contains(topicId) else {
+            return
+        }
+
+        let loadedWindowCount = FireTopicPresentation.loadedWindowCount(detail: detail)
+        let currentTargetLoadedCount = min(
+            max(pagination.targetLoadedCount, loadedWindowCount),
+            detail.postStream.stream.count
+        )
+        let missingPostIDs = FireTopicPresentation.missingPostIDs(
+            in: detail,
+            upTo: currentTargetLoadedCount,
+            excluding: pagination.exhaustedPostIDs
+        )
+        guard !missingPostIDs.isEmpty || currentTargetLoadedCount < detail.postStream.stream.count else {
+            return
+        }
+
+        if currentTargetLoadedCount < detail.postStream.stream.count {
+            pagination.targetLoadedCount = min(
+                currentTargetLoadedCount + Self.topicPostPageSize,
+                detail.postStream.stream.count
+            )
+            topicPostPaginationStates[topicId] = pagination
+        }
+        await hydrateTopicPostsToTargetIfNeeded(topicId: topicId)
+    }
+
+    private func hydrateTopicPostsToTargetIfNeeded(topicId: UInt64) async {
+        guard let sessionStore = appViewModel.currentSessionStore() else {
+            return
+        }
+        guard !Task.isCancelled else {
+            return
+        }
+        guard !loadingMoreTopicPostIDs.contains(topicId) else {
+            return
+        }
+
+        loadingMoreTopicPostIDs.insert(topicId)
+        defer { loadingMoreTopicPostIDs.remove(topicId) }
+
+        var hydratedPosts: [TopicPostState] = []
+        var hydratedPostIDs: Set<UInt64> = []
+        var exhaustedPostIDs: Set<UInt64> = []
+
+        while !Task.isCancelled {
+            guard let detail = topicDetails[topicId],
+                  let pagination = topicPostPaginationStates[topicId] else {
+                return
+            }
+
+            let missingPostIDs = FireTopicPresentation.missingPostIDs(
+                orderedPostIDs: detail.postStream.stream,
+                loadedPostIDs: Set(detail.postStream.posts.map(\.id)).union(hydratedPostIDs),
+                upTo: pagination.targetLoadedCount,
+                excluding: pagination.exhaustedPostIDs.union(exhaustedPostIDs)
+            )
+            guard !missingPostIDs.isEmpty else {
+                applyHydratedTopicPostsIfNeeded(
+                    topicId: topicId,
+                    posts: hydratedPosts,
+                    exhaustedPostIDs: exhaustedPostIDs
+                )
+                return
+            }
+
+            let batchPostIDs = Array(missingPostIDs.prefix(Self.topicPostPageSize))
+
+            do {
+                let fetchedPosts = try await sessionStore.fetchTopicPosts(
+                    topicID: topicId,
+                    postIDs: batchPostIDs
+                )
+                let returnedPostIDs = Set(fetchedPosts.map(\.id))
+                exhaustedPostIDs.formUnion(
+                    batchPostIDs.filter { !returnedPostIDs.contains($0) }
+                )
+                hydratedPosts.append(contentsOf: fetchedPosts)
+                hydratedPostIDs.formUnion(returnedPostIDs)
+            } catch {
+                applyHydratedTopicPostsIfNeeded(
+                    topicId: topicId,
+                    posts: hydratedPosts,
+                    exhaustedPostIDs: exhaustedPostIDs
+                )
+                if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
+                    return
+                }
+                errorMessage = error.localizedDescription
+                return
+            }
+        }
+
+        applyHydratedTopicPostsIfNeeded(
+            topicId: topicId,
+            posts: hydratedPosts,
+            exhaustedPostIDs: exhaustedPostIDs
+        )
+    }
+
+    private func applyHydratedTopicPostsIfNeeded(
+        topicId: UInt64,
+        posts: [TopicPostState],
+        exhaustedPostIDs: Set<UInt64>
+    ) {
+        guard !posts.isEmpty || !exhaustedPostIDs.isEmpty else {
+            return
+        }
+        guard var currentDetail = topicDetails[topicId],
+              var currentPagination = topicPostPaginationStates[topicId] else {
+            return
+        }
+
+        currentPagination.exhaustedPostIDs.formUnion(exhaustedPostIDs)
+        topicPostPaginationStates[topicId] = currentPagination
+
+        guard !posts.isEmpty else {
+            return
+        }
+
+        currentDetail.postStream.posts = FireTopicPresentation.mergeTopicPosts(
+            existing: currentDetail.postStream.posts,
+            incoming: posts,
+            orderedPostIDs: currentDetail.postStream.stream
+        )
+        topicDetails[topicId] = FireTopicPresentation.recomposedDetail(currentDetail)
+    }
+
+    private func applyPostReactionUpdate(
+        topicId: UInt64,
+        postId: UInt64,
+        update: PostReactionUpdateState
+    ) {
+        guard var detail = topicDetails[topicId] else {
+            return
+        }
+        guard let postIndex = detail.postStream.posts.firstIndex(where: { $0.id == postId }) else {
+            return
+        }
+
+        var post = detail.postStream.posts[postIndex]
+        let previousHeartCount = post.reactions.first(where: { $0.id == "heart" })?.count
+        let updatedHeartCount = update.reactions.first(where: { $0.id == "heart" })?.count
+
+        post.reactions = update.reactions
+        post.currentUserReaction = update.currentUserReaction
+
+        if let updatedHeartCount {
+            post.likeCount = updatedHeartCount
+        } else if previousHeartCount != nil || post.currentUserReaction?.id == "heart" {
+            post.likeCount = 0
+        }
+
+        detail.postStream.posts[postIndex] = post
+        topicDetails[topicId] = FireTopicPresentation.recomposedDetail(detail)
+    }
+}

--- a/native/ios-app/App/Stores/Shared/FireEntityIndex.swift
+++ b/native/ios-app/App/Stores/Shared/FireEntityIndex.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+struct FireEntityIndex<ID: Hashable, Entity> {
+    private(set) var entitiesByID: [ID: Entity] = [:]
+
+    var isEmpty: Bool {
+        entitiesByID.isEmpty
+    }
+
+    mutating func replaceAll(
+        _ entities: [Entity],
+        id: KeyPath<Entity, ID>
+    ) {
+        entitiesByID = Dictionary(
+            uniqueKeysWithValues: entities.map { ($0[keyPath: id], $0) }
+        )
+    }
+
+    mutating func upsert(
+        _ entities: [Entity],
+        id: KeyPath<Entity, ID>
+    ) {
+        for entity in entities {
+            entitiesByID[entity[keyPath: id]] = entity
+        }
+    }
+
+    mutating func removeAll() {
+        entitiesByID.removeAll()
+    }
+
+    func entity(for id: ID) -> Entity? {
+        entitiesByID[id]
+    }
+
+    func orderedValues(
+        for orderedIDs: FireOrderedIDList<ID>
+    ) -> [Entity] {
+        orderedIDs.ids.compactMap { entitiesByID[$0] }
+    }
+}

--- a/native/ios-app/App/Stores/Shared/FireOrderedIDList.swift
+++ b/native/ios-app/App/Stores/Shared/FireOrderedIDList.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+struct FireOrderedIDList<ID: Hashable> {
+    private(set) var ids: [ID] = []
+    private var idSet: Set<ID> = []
+
+    init(ids: [ID] = []) {
+        replace(with: ids)
+    }
+
+    var isEmpty: Bool {
+        ids.isEmpty
+    }
+
+    mutating func replace(with newIDs: [ID]) {
+        ids = []
+        idSet = []
+        append(newIDs)
+    }
+
+    mutating func append(_ newIDs: [ID]) {
+        for id in newIDs {
+            guard idSet.insert(id).inserted else { continue }
+            ids.append(id)
+        }
+    }
+
+    mutating func removeAll() {
+        ids.removeAll()
+        idSet.removeAll()
+    }
+}

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		7FC4730D00066ED2E1605539 /* FireComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F174773C4A2B3D0A4D29DD /* FireComponents.swift */; };
 		82D925C1A3A758CB7309295E /* FirePostEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BDAC8FBC21B254D1B0BE8A /* FirePostEditorView.swift */; };
 		852C8492BAACCFDD0529DE22 /* FireProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419222F55DFE2BC290CD5335 /* FireProfileViewModel.swift */; };
+		8823DAD708691783D2AB85A4 /* FireNotificationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E8287F8F1E148177E1A223 /* FireNotificationStoreTests.swift */; };
 		8B8629DE49FD3256333B0CF4 /* FireFollowListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA34E2414014BD28A7AF803 /* FireFollowListView.swift */; };
 		8D3E53867C1B21D940FB765A /* FireProfileActivityRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292A9A11D19C39A02BC00B38 /* FireProfileActivityRow.swift */; };
 		8D77430DC1266A1EDEF3A6E4 /* FireAppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA66CA083BF4889AE258926 /* FireAppViewModel.swift */; };
@@ -65,6 +66,7 @@
 		A7657EA99808CEBE3F038176 /* CrashReporter in Frameworks */ = {isa = PBXBuildFile; productRef = 601B450FB4E87A5243FAE5F9 /* CrashReporter */; };
 		AFA0A6BA1AC5282B233D218F /* FireRecipientTokenField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73775E8E299DC2577C64DC6E /* FireRecipientTokenField.swift */; };
 		B21E0A6B519EA414B836E4BE /* FireProfileTrustLevelPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F02D3C136EFF0589DC131FB9 /* FireProfileTrustLevelPill.swift */; };
+		B4AA77D05D86AB070BE06A93 /* FireNotificationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502CE714A74D91C33212BF57 /* FireNotificationStore.swift */; };
 		BACF637B5B2F0C0C8EDA3048 /* fire_uniffi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588B3F8CFD76DF758BE3A242 /* fire_uniffi.swift */; };
 		C02B0FA4DC635EE4FF05F19F /* SessionState+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F3291447D7DA0AEF9AA413 /* SessionState+Helpers.swift */; };
 		C1300F26689601362E952200 /* FireTopicListMessageBusRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91142A1E76D9831A6B3EC94 /* FireTopicListMessageBusRefresh.swift */; };
@@ -122,6 +124,7 @@
 		46C35F105D036EECAAE7B93D /* FireRouteParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireRouteParserTests.swift; sourceTree = "<group>"; };
 		46CF09F1CBAC6CFAA0E9128A /* FireAppRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppRoute.swift; sourceTree = "<group>"; };
 		48CAB0E38556929FC140E25D /* Fire.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Fire.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		502CE714A74D91C33212BF57 /* FireNotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNotificationStore.swift; sourceTree = "<group>"; };
 		51431D8CC0EBCA6C0E79380C /* FireBackgroundNotificationAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireBackgroundNotificationAlert.swift; sourceTree = "<group>"; };
 		51FDDE688920A8904B16F9A2 /* FireDeveloperToolsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDeveloperToolsView.swift; sourceTree = "<group>"; };
 		52BB1F5B0970DC2504ACD989 /* FirePushRegistrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePushRegistrationCoordinator.swift; sourceTree = "<group>"; };
@@ -158,6 +161,7 @@
 		BF328A93631D56CB94E4FA7A /* FireAppRouteDestinationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppRouteDestinationView.swift; sourceTree = "<group>"; };
 		BFA66CA083BF4889AE258926 /* FireAppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppViewModel.swift; sourceTree = "<group>"; };
 		C20BDF82CCD1BF22BB3C7729 /* FireAPMMainThreadStallMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMMainThreadStallMonitor.swift; sourceTree = "<group>"; };
+		C2E8287F8F1E148177E1A223 /* FireNotificationStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNotificationStoreTests.swift; sourceTree = "<group>"; };
 		C313FFDD8D569FA6D9B1C0E0 /* FireAuthCookieKeychainStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAuthCookieKeychainStore.swift; sourceTree = "<group>"; };
 		C6DEF53357E681E40E482813 /* FireAPMResourceSampler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMResourceSampler.swift; sourceTree = "<group>"; };
 		C810E3D0B2CF415495A3D5C4 /* FireFilteredTopicListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireFilteredTopicListView.swift; sourceTree = "<group>"; };
@@ -302,6 +306,7 @@
 			children = (
 				2EFBB6F3B1D7E3DD79D98C17 /* FireAPMEventStoreTests.swift */,
 				299683BEDEC559B03C136C34 /* FireAppRouteTests.swift */,
+				C2E8287F8F1E148177E1A223 /* FireNotificationStoreTests.swift */,
 				EC77525391DD1C7EA7329451 /* FirePushRegistrationCoordinatorTests.swift */,
 				46C35F105D036EECAAE7B93D /* FireRouteParserTests.swift */,
 				B17BF0CB4137B71949AACC0C /* FireSearchStoreTests.swift */,
@@ -350,6 +355,7 @@
 		CEB7A4EE131ABA30059C2518 /* Stores */ = {
 			isa = PBXGroup;
 			children = (
+				502CE714A74D91C33212BF57 /* FireNotificationStore.swift */,
 				25FD219C2BFB0727FD0D3DD2 /* FireSearchStore.swift */,
 			);
 			path = Stores;
@@ -495,6 +501,7 @@
 			files = (
 				180BEE1FEF5E76FF92403C34 /* FireAPMEventStoreTests.swift in Sources */,
 				3330A9C7E4C8BA80778F79EB /* FireAppRouteTests.swift in Sources */,
+				8823DAD708691783D2AB85A4 /* FireNotificationStoreTests.swift in Sources */,
 				3F8B5F1239E17802675A013B /* FirePushRegistrationCoordinatorTests.swift in Sources */,
 				4F0305B9162423D8D821A304 /* FireRouteParserTests.swift in Sources */,
 				2264C8107D1350906282A04E /* FireSearchStoreTests.swift in Sources */,
@@ -538,6 +545,7 @@
 				A1991999F769CF1B701DEFA4 /* FireMyBadgesView.swift in Sources */,
 				75AFEF785571E34FC9CAFC8B /* FireNavigationState.swift in Sources */,
 				D7055404526257A9C288B052 /* FireNotificationHistoryView.swift in Sources */,
+				B4AA77D05D86AB070BE06A93 /* FireNotificationStore.swift in Sources */,
 				9D5F82625F6960B6A6ED10B9 /* FireNotificationsView.swift in Sources */,
 				792980AB2D2B5BF56221DF47 /* FireOnboardingView.swift in Sources */,
 				82D925C1A3A758CB7309295E /* FirePostEditorView.swift in Sources */,

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -22,7 +22,6 @@
 		3330A9C7E4C8BA80778F79EB /* FireAppRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299683BEDEC559B03C136C34 /* FireAppRouteTests.swift */; };
 		34DC539E6C32931D4743C75F /* FireBadgeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467E95A2109D81DB456F64A9 /* FireBadgeDetailView.swift */; };
 		390219653B0C0A96C81D8962 /* FireAPMEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373861687BBCD8EB8E350DA4 /* FireAPMEventStore.swift */; };
-		3E86B05D0E10C74BB865A0F9 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = 3F5DB59F34DC2099A84C0F6F /* Nuke */; };
 		3F8B5F1239E17802675A013B /* FirePushRegistrationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC77525391DD1C7EA7329451 /* FirePushRegistrationCoordinatorTests.swift */; };
 		428170833590DCF14AEEA64C /* FireTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFC5F5EA7CD05C23FBEB9A2 /* FireTheme.swift */; };
 		4291E89FC3D5D35AC9A06898 /* FireOrderedIDList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DA04AEF775D5BD01FC23AC /* FireOrderedIDList.swift */; };
@@ -93,7 +92,6 @@
 		E67F86DADDE88559438DE849 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08F96260D49AF4E41AB4739C /* CoreFoundation.framework */; };
 		F171E34C843A4BD06FB50408 /* FireBookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE19EEF18F20BE710E4B7E4 /* FireBookmarksView.swift */; };
 		F31A70760B997F5ADFB7C489 /* FireListSectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6B1F10783D1D78B2D1F63 /* FireListSectionModel.swift */; };
-		F7AF0493553E46BB2FCAB4A5 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = A46FF58D4D7E79645FFA574A /* SnapshotTesting */; };
 		F8963543E87EACAD49C9B131 /* FireCollectionHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CF84F1E6774BE411D4D2C2E /* FireCollectionHost.swift */; };
 		FA462FF0334E77051F227943 /* FirePublicProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F67B40FC02230AFEC2A562 /* FirePublicProfileView.swift */; };
 		FFCC342F97F349220632A787 /* FireTopicPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9189433D7C9260885742A5BA /* FireTopicPresentationTests.swift */; };
@@ -225,15 +223,6 @@
 				E67F86DADDE88559438DE849 /* CoreFoundation.framework in Frameworks */,
 				9726B24BBA832290EA063E8F /* libiconv.tbd in Frameworks */,
 				A7657EA99808CEBE3F038176 /* CrashReporter in Frameworks */,
-				3E86B05D0E10C74BB865A0F9 /* Nuke in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		55C19647F463E787E7CD4750 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				F7AF0493553E46BB2FCAB4A5 /* SnapshotTesting in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -473,7 +462,6 @@
 			buildConfigurationList = 45130E50B606D6C48CB508C5 /* Build configuration list for PBXNativeTarget "FireTests" */;
 			buildPhases = (
 				2FCCC820ECEB057462CC26A9 /* Sources */,
-				55C19647F463E787E7CD4750 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -482,7 +470,6 @@
 			);
 			name = FireTests;
 			packageProductDependencies = (
-				A46FF58D4D7E79645FFA574A /* SnapshotTesting */,
 			);
 			productName = FireTests;
 			productReference = 0C933069DE6C026030AAB6EF /* FireTests.xctest */;
@@ -521,7 +508,6 @@
 			name = Fire;
 			packageProductDependencies = (
 				601B450FB4E87A5243FAE5F9 /* CrashReporter */,
-				3F5DB59F34DC2099A84C0F6F /* Nuke */,
 			);
 			productName = Fire;
 			productReference = 48CAB0E38556929FC140E25D /* Fire.app */;
@@ -556,8 +542,6 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				9F8D6D7CFB3643BCA8C9F545 /* XCRemoteSwiftPackageReference "plcrashreporter" */,
-				0B33AAACF1C3CFC774277ECB /* XCRemoteSwiftPackageReference "Nuke" */,
-				B82195B66E414BF6398F0197 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1D88C155B3075FF19641DF3E /* Products */;
@@ -1056,14 +1040,6 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		0B33AAACF1C3CFC774277ECB /* XCRemoteSwiftPackageReference "Nuke" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/kean/Nuke.git";
-			requirement = {
-				kind = exactVersion;
-				version = 13.0.1;
-			};
-		};
 		9F8D6D7CFB3643BCA8C9F545 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/microsoft/plcrashreporter.git";
@@ -1072,31 +1048,13 @@
 				version = 1.12.2;
 			};
 		};
-		B82195B66E414BF6398F0197 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing.git";
-			requirement = {
-				kind = exactVersion;
-				version = 1.19.2;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		3F5DB59F34DC2099A84C0F6F /* Nuke */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = 0B33AAACF1C3CFC774277ECB /* XCRemoteSwiftPackageReference "Nuke" */;
-			productName = Nuke;
-		};
 		601B450FB4E87A5243FAE5F9 /* CrashReporter */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9F8D6D7CFB3643BCA8C9F545 /* XCRemoteSwiftPackageReference "plcrashreporter" */;
 			productName = CrashReporter;
-		};
-		A46FF58D4D7E79645FFA574A /* SnapshotTesting */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = B82195B66E414BF6398F0197 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
-			productName = SnapshotTesting;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		180BEE1FEF5E76FF92403C34 /* FireAPMEventStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EFBB6F3B1D7E3DD79D98C17 /* FireAPMEventStoreTests.swift */; };
 		1F1EEDCE0B4FEAE2880DC061 /* FireWebViewLoginCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E5271F93B7DF18859B101F /* FireWebViewLoginCoordinator.swift */; };
 		217BC99CE792BDFA88ED89FC /* FireTabRoot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05507C09C3878752BCC013E3 /* FireTabRoot.swift */; };
+		2264C8107D1350906282A04E /* FireSearchStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B17BF0CB4137B71949AACC0C /* FireSearchStoreTests.swift */; };
 		23B6D938A84DB421F8549AD0 /* FireBackgroundNotificationAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51431D8CC0EBCA6C0E79380C /* FireBackgroundNotificationAlert.swift */; };
 		2C5CE663E30B00720A75CD0A /* FireProfileHeaderComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8372AD9A5A2CC34FBD3AEF /* FireProfileHeaderComponents.swift */; };
 		3330A9C7E4C8BA80778F79EB /* FireAppRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299683BEDEC559B03C136C34 /* FireAppRouteTests.swift */; };
@@ -58,6 +59,7 @@
 		9D5F82625F6960B6A6ED10B9 /* FireNotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A86A280EED500EF3126038 /* FireNotificationsView.swift */; };
 		9F734046F02B45409AD5F1C6 /* FireTopicListMessageBusRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859219285EC36B189AF68256 /* FireTopicListMessageBusRefreshTests.swift */; };
 		9FDB03E99AB569E64A17BE3B /* FireSessionSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6840B06FC02F67318B0991 /* FireSessionSecurityTests.swift */; };
+		A04B275253CDF8FAAC9D8C6C /* FireSearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FD219C2BFB0727FD0D3DD2 /* FireSearchStore.swift */; };
 		A1991999F769CF1B701DEFA4 /* FireMyBadgesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33F63CDBE0BC6524D17AB00C /* FireMyBadgesView.swift */; };
 		A29E21413FA011161D518004 /* FireSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8834ADE6E3ADB8A03391560C /* FireSessionStore.swift */; };
 		A7657EA99808CEBE3F038176 /* CrashReporter in Frameworks */ = {isa = PBXBuildFile; productRef = 601B450FB4E87A5243FAE5F9 /* CrashReporter */; };
@@ -103,6 +105,7 @@
 		0F4A54860996435FDDF40EBE /* FireDiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDiagnosticsView.swift; sourceTree = "<group>"; };
 		129694A5F35FF78B3F810049 /* FireAPMManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMManager.swift; sourceTree = "<group>"; };
 		19F67B40FC02230AFEC2A562 /* FirePublicProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePublicProfileView.swift; sourceTree = "<group>"; };
+		25FD219C2BFB0727FD0D3DD2 /* FireSearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSearchStore.swift; sourceTree = "<group>"; };
 		27F174773C4A2B3D0A4D29DD /* FireComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireComponents.swift; sourceTree = "<group>"; };
 		292A9A11D19C39A02BC00B38 /* FireProfileActivityRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileActivityRow.swift; sourceTree = "<group>"; };
 		299683BEDEC559B03C136C34 /* FireAppRouteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppRouteTests.swift; sourceTree = "<group>"; };
@@ -149,6 +152,7 @@
 		A5264103A412DF3C9798D470 /* FireAPMModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMModels.swift; sourceTree = "<group>"; };
 		AA736A1F443337C34A6E33D6 /* Fire.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Fire.entitlements; sourceTree = "<group>"; };
 		AE6087FA4E6DF2034C9E6D77 /* FireReadHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireReadHistoryView.swift; sourceTree = "<group>"; };
+		B17BF0CB4137B71949AACC0C /* FireSearchStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSearchStoreTests.swift; sourceTree = "<group>"; };
 		B5E5271F93B7DF18859B101F /* FireWebViewLoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWebViewLoginCoordinator.swift; sourceTree = "<group>"; };
 		BABD32407FB273553E9394B3 /* FireProfileBadgeChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileBadgeChip.swift; sourceTree = "<group>"; };
 		BF328A93631D56CB94E4FA7A /* FireAppRouteDestinationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppRouteDestinationView.swift; sourceTree = "<group>"; };
@@ -288,6 +292,7 @@
 				F5F3291447D7DA0AEF9AA413 /* SessionState+Helpers.swift */,
 				56BB80A6C2C32FB6128B118C /* Push */,
 				D0D03E8FE66111ECCEC7F2DD /* Routing */,
+				CEB7A4EE131ABA30059C2518 /* Stores */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -299,6 +304,7 @@
 				299683BEDEC559B03C136C34 /* FireAppRouteTests.swift */,
 				EC77525391DD1C7EA7329451 /* FirePushRegistrationCoordinatorTests.swift */,
 				46C35F105D036EECAAE7B93D /* FireRouteParserTests.swift */,
+				B17BF0CB4137B71949AACC0C /* FireSearchStoreTests.swift */,
 				CC6840B06FC02F67318B0991 /* FireSessionSecurityTests.swift */,
 				859219285EC36B189AF68256 /* FireTopicListMessageBusRefreshTests.swift */,
 				9189433D7C9260885742A5BA /* FireTopicPresentationTests.swift */,
@@ -339,6 +345,14 @@
 				FA8E7753E3E1BB8E3CD88E96 /* Fire-Shared.xcconfig */,
 			);
 			path = Configs;
+			sourceTree = "<group>";
+		};
+		CEB7A4EE131ABA30059C2518 /* Stores */ = {
+			isa = PBXGroup;
+			children = (
+				25FD219C2BFB0727FD0D3DD2 /* FireSearchStore.swift */,
+			);
+			path = Stores;
 			sourceTree = "<group>";
 		};
 		D0D03E8FE66111ECCEC7F2DD /* Routing */ = {
@@ -483,6 +497,7 @@
 				3330A9C7E4C8BA80778F79EB /* FireAppRouteTests.swift in Sources */,
 				3F8B5F1239E17802675A013B /* FirePushRegistrationCoordinatorTests.swift in Sources */,
 				4F0305B9162423D8D821A304 /* FireRouteParserTests.swift in Sources */,
+				2264C8107D1350906282A04E /* FireSearchStoreTests.swift in Sources */,
 				9FDB03E99AB569E64A17BE3B /* FireSessionSecurityTests.swift in Sources */,
 				9F734046F02B45409AD5F1C6 /* FireTopicListMessageBusRefreshTests.swift in Sources */,
 				FFCC342F97F349220632A787 /* FireTopicPresentationTests.swift in Sources */,
@@ -541,6 +556,7 @@
 				6E42169DCC199615389AA85B /* FireReadHistoryView.swift in Sources */,
 				AFA0A6BA1AC5282B233D218F /* FireRecipientTokenField.swift in Sources */,
 				DC4203187C3CAF0846C2D8BF /* FireRouteParser.swift in Sources */,
+				A04B275253CDF8FAAC9D8C6C /* FireSearchStore.swift in Sources */,
 				48C404692D8F5FA7471852BF /* FireSearchView.swift in Sources */,
 				A29E21413FA011161D518004 /* FireSessionStore.swift in Sources */,
 				217BC99CE792BDFA88ED89FC /* FireTabRoot.swift in Sources */,

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -22,9 +22,12 @@
 		3330A9C7E4C8BA80778F79EB /* FireAppRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299683BEDEC559B03C136C34 /* FireAppRouteTests.swift */; };
 		34DC539E6C32931D4743C75F /* FireBadgeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467E95A2109D81DB456F64A9 /* FireBadgeDetailView.swift */; };
 		390219653B0C0A96C81D8962 /* FireAPMEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373861687BBCD8EB8E350DA4 /* FireAPMEventStore.swift */; };
+		3E86B05D0E10C74BB865A0F9 /* Nuke in Frameworks */ = {isa = PBXBuildFile; productRef = 3F5DB59F34DC2099A84C0F6F /* Nuke */; };
 		3F8B5F1239E17802675A013B /* FirePushRegistrationCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC77525391DD1C7EA7329451 /* FirePushRegistrationCoordinatorTests.swift */; };
 		428170833590DCF14AEEA64C /* FireTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FFC5F5EA7CD05C23FBEB9A2 /* FireTheme.swift */; };
+		4291E89FC3D5D35AC9A06898 /* FireOrderedIDList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DA04AEF775D5BD01FC23AC /* FireOrderedIDList.swift */; };
 		4397ACCD2A571DB3DA0AC8FC /* FireAppRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CF09F1CBAC6CFAA0E9128A /* FireAppRoute.swift */; };
+		47B89C5984DCCAB601B919EE /* FireTopicDetailStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9267FBC4BA4FD365E6F4E371 /* FireTopicDetailStore.swift */; };
 		48C404692D8F5FA7471852BF /* FireSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A08AB12E53EB29136A0946A /* FireSearchView.swift */; };
 		4F0305B9162423D8D821A304 /* FireRouteParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46C35F105D036EECAAE7B93D /* FireRouteParserTests.swift */; };
 		54170A08D034A622A66D5DBD /* FirePrivateMessagesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FECD6D6E7C9501934DE7EDC9 /* FirePrivateMessagesView.swift */; };
@@ -35,17 +38,20 @@
 		5FA66113E53795C8DC6D0563 /* FireProfileActivityTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35E67F65FB748821001726D /* FireProfileActivityTimelineView.swift */; };
 		6A8BA8AACC4ED45E311894CE /* FireTopicDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67647993BFF688FB02B71DBB /* FireTopicDetailView.swift */; };
 		6A93EC6F3D79F51A9CB66A58 /* FireAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300B5894E4B597FC94E645D3 /* FireAppDelegate.swift */; };
+		6CD842F82A4371F3BCCCF4C5 /* FireEntityIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33FDDDCB91B973C1115A8F6B /* FireEntityIndex.swift */; };
 		6E42169DCC199615389AA85B /* FireReadHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE6087FA4E6DF2034C9E6D77 /* FireReadHistoryView.swift */; };
 		6F88C8AAB2089E7F558EDE67 /* FirePushRegistrationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BB1F5B0970DC2504ACD989 /* FirePushRegistrationCoordinator.swift */; };
 		72EF4FD238A8072A48B7948E /* FireTopicRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D1C4D30FB92D47F801B64D4 /* FireTopicRow.swift */; };
 		73D15598C74EA2ABE6BCC1FA /* FirePresentationIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7218ECE4CE5CE67428ADD4DD /* FirePresentationIdentity.swift */; };
 		75AFEF785571E34FC9CAFC8B /* FireNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBEB262C9A5B9B7348537B8 /* FireNavigationState.swift */; };
+		768DC62B26A1D2EF4F545D35 /* FireHomeFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7384EAE1C43817CAE71D9F /* FireHomeFeedStore.swift */; };
 		790B44E436B0CF137B1FD8A7 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E69013450F80AEC210D5512D /* Security.framework */; };
 		792980AB2D2B5BF56221DF47 /* FireOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9004CEFFCDDBE2E50D71B0 /* FireOnboardingView.swift */; };
 		795E7AB547CA854593A42D91 /* FireHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E60D1F8BA725E4D60AFBA3 /* FireHomeView.swift */; };
 		7C7F1371B83C02B96B266900 /* FireDeveloperToolsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FDDE688920A8904B16F9A2 /* FireDeveloperToolsView.swift */; };
 		7FC4730D00066ED2E1605539 /* FireComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F174773C4A2B3D0A4D29DD /* FireComponents.swift */; };
 		82D925C1A3A758CB7309295E /* FirePostEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BDAC8FBC21B254D1B0BE8A /* FirePostEditorView.swift */; };
+		83E741D10CEEBE061C2B0B30 /* FireHomeCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC115AA696CF29500E0027DD /* FireHomeCollectionView.swift */; };
 		852C8492BAACCFDD0529DE22 /* FireProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419222F55DFE2BC290CD5335 /* FireProfileViewModel.swift */; };
 		8823DAD708691783D2AB85A4 /* FireNotificationStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E8287F8F1E148177E1A223 /* FireNotificationStoreTests.swift */; };
 		8B8629DE49FD3256333B0CF4 /* FireFollowListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA34E2414014BD28A7AF803 /* FireFollowListView.swift */; };
@@ -53,10 +59,12 @@
 		8D77430DC1266A1EDEF3A6E4 /* FireAppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA66CA083BF4889AE258926 /* FireAppViewModel.swift */; };
 		8F10E1B26BE2D5FC5F2D6C1B /* FireProfileStatsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6210541C2E8219CE500CFC04 /* FireProfileStatsRow.swift */; };
 		91BA9CDF0E86830FEB1951B0 /* FireAPMMainThreadStallMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20BDF82CCD1BF22BB3C7729 /* FireAPMMainThreadStallMonitor.swift */; };
+		939404BE03A327D4A29B6E33 /* FireDiffableListController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843289DCC260BF71A9C48DA4 /* FireDiffableListController.swift */; };
 		944A9CD4343088D2E1BABF5A /* FireMessageBusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E5394EEC6957C140D8189FA /* FireMessageBusCoordinator.swift */; };
 		954D2C7BD4B371CA41536C0F /* FireTopicTimingTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AD6D7178B2622B10A5644E2 /* FireTopicTimingTracker.swift */; };
 		9726B24BBA832290EA063E8F /* libiconv.tbd in Frameworks */ = {isa = PBXBuildFile; fileRef = FD5A94769988E39B8BEA7B56 /* libiconv.tbd */; };
 		999638A7F6D5A424815E6F2F /* FireCategoriesView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8675E5DED6CD306553C88CFE /* FireCategoriesView.swift */; };
+		9B0DABDC5BA87A4CAFF3232D /* FireEntityStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADC2ED47CF65AD5BE795908 /* FireEntityStateTests.swift */; };
 		9D5F82625F6960B6A6ED10B9 /* FireNotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A86A280EED500EF3126038 /* FireNotificationsView.swift */; };
 		9F734046F02B45409AD5F1C6 /* FireTopicListMessageBusRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859219285EC36B189AF68256 /* FireTopicListMessageBusRefreshTests.swift */; };
 		9FDB03E99AB569E64A17BE3B /* FireSessionSecurityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC6840B06FC02F67318B0991 /* FireSessionSecurityTests.swift */; };
@@ -69,6 +77,7 @@
 		B4AA77D05D86AB070BE06A93 /* FireNotificationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502CE714A74D91C33212BF57 /* FireNotificationStore.swift */; };
 		BACF637B5B2F0C0C8EDA3048 /* fire_uniffi.swift in Sources */ = {isa = PBXBuildFile; fileRef = 588B3F8CFD76DF758BE3A242 /* fire_uniffi.swift */; };
 		C02B0FA4DC635EE4FF05F19F /* SessionState+Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F3291447D7DA0AEF9AA413 /* SessionState+Helpers.swift */; };
+		C0F81D0F77AD3163B093E18B /* FireSmokeUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CE05C9BDCF4A8B4E7BF4CB0 /* FireSmokeUITests.swift */; };
 		C1300F26689601362E952200 /* FireTopicListMessageBusRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = E91142A1E76D9831A6B3EC94 /* FireTopicListMessageBusRefresh.swift */; };
 		C25654B366748CB1C015E4FA /* FireDraftsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEF79A11C032C071A2F494A0 /* FireDraftsView.swift */; };
 		C393F32FAD3010FF51E3E7F2 /* FireAppRouteDestinationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF328A93631D56CB94E4FA7A /* FireAppRouteDestinationView.swift */; };
@@ -83,11 +92,21 @@
 		E60D57A49519AD07A4834489 /* FireAPMResourceSampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6DEF53357E681E40E482813 /* FireAPMResourceSampler.swift */; };
 		E67F86DADDE88559438DE849 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 08F96260D49AF4E41AB4739C /* CoreFoundation.framework */; };
 		F171E34C843A4BD06FB50408 /* FireBookmarksView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CE19EEF18F20BE710E4B7E4 /* FireBookmarksView.swift */; };
+		F31A70760B997F5ADFB7C489 /* FireListSectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6B1F10783D1D78B2D1F63 /* FireListSectionModel.swift */; };
+		F7AF0493553E46BB2FCAB4A5 /* SnapshotTesting in Frameworks */ = {isa = PBXBuildFile; productRef = A46FF58D4D7E79645FFA574A /* SnapshotTesting */; };
+		F8963543E87EACAD49C9B131 /* FireCollectionHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CF84F1E6774BE411D4D2C2E /* FireCollectionHost.swift */; };
 		FA462FF0334E77051F227943 /* FirePublicProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19F67B40FC02230AFEC2A562 /* FirePublicProfileView.swift */; };
 		FFCC342F97F349220632A787 /* FireTopicPresentationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9189433D7C9260885742A5BA /* FireTopicPresentationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		07329CA8EE49AC256B3F5C5B /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 9AB7FC66AC31A04F54C77B79 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 87BF3D86E2CA36A3D645AA33;
+			remoteInfo = Fire;
+		};
 		DC8D43819C61EEBADFD56ED4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9AB7FC66AC31A04F54C77B79 /* Project object */;
@@ -98,6 +117,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		00DA04AEF775D5BD01FC23AC /* FireOrderedIDList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireOrderedIDList.swift; sourceTree = "<group>"; };
 		05507C09C3878752BCC013E3 /* FireTabRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTabRoot.swift; sourceTree = "<group>"; };
 		08F96260D49AF4E41AB4739C /* CoreFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreFoundation.framework; path = System/Library/Frameworks/CoreFoundation.framework; sourceTree = SDKROOT; };
 		0AA34E2414014BD28A7AF803 /* FireFollowListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireFollowListView.swift; sourceTree = "<group>"; };
@@ -115,6 +135,7 @@
 		2EFBB6F3B1D7E3DD79D98C17 /* FireAPMEventStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMEventStoreTests.swift; sourceTree = "<group>"; };
 		300B5894E4B597FC94E645D3 /* FireAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppDelegate.swift; sourceTree = "<group>"; };
 		33F63CDBE0BC6524D17AB00C /* FireMyBadgesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireMyBadgesView.swift; sourceTree = "<group>"; };
+		33FDDDCB91B973C1115A8F6B /* FireEntityIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireEntityIndex.swift; sourceTree = "<group>"; };
 		373861687BBCD8EB8E350DA4 /* FireAPMEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMEventStore.swift; sourceTree = "<group>"; };
 		3CE19EEF18F20BE710E4B7E4 /* FireBookmarksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireBookmarksView.swift; sourceTree = "<group>"; };
 		3FA800E223882F74B7EB5812 /* FireTopicEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicEditorView.swift; sourceTree = "<group>"; };
@@ -130,6 +151,7 @@
 		52BB1F5B0970DC2504ACD989 /* FirePushRegistrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePushRegistrationCoordinator.swift; sourceTree = "<group>"; };
 		568D9F64260FB53D957BE41C /* FireProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileView.swift; sourceTree = "<group>"; };
 		588B3F8CFD76DF758BE3A242 /* fire_uniffi.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = fire_uniffi.swift; sourceTree = "<group>"; };
+		5CE05C9BDCF4A8B4E7BF4CB0 /* FireSmokeUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSmokeUITests.swift; sourceTree = "<group>"; };
 		6210541C2E8219CE500CFC04 /* FireProfileStatsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileStatsRow.swift; sourceTree = "<group>"; };
 		6725F42C679E922AA3DD1FBF /* FireLoginWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireLoginWebView.swift; sourceTree = "<group>"; };
 		67647993BFF688FB02B71DBB /* FireTopicDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailView.swift; sourceTree = "<group>"; };
@@ -139,12 +161,15 @@
 		73775E8E299DC2577C64DC6E /* FireRecipientTokenField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireRecipientTokenField.swift; sourceTree = "<group>"; };
 		74DDD4D388827A202662DB78 /* FireInviteLinksView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireInviteLinksView.swift; sourceTree = "<group>"; };
 		77FD6C1C577852A9B0EC2532 /* FireComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireComposerView.swift; sourceTree = "<group>"; };
+		7CF84F1E6774BE411D4D2C2E /* FireCollectionHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireCollectionHost.swift; sourceTree = "<group>"; };
+		843289DCC260BF71A9C48DA4 /* FireDiffableListController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDiffableListController.swift; sourceTree = "<group>"; };
 		859219285EC36B189AF68256 /* FireTopicListMessageBusRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicListMessageBusRefreshTests.swift; sourceTree = "<group>"; };
 		8675E5DED6CD306553C88CFE /* FireCategoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireCategoriesView.swift; sourceTree = "<group>"; };
 		8834ADE6E3ADB8A03391560C /* FireSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSessionStore.swift; sourceTree = "<group>"; };
 		8A08AB12E53EB29136A0946A /* FireSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSearchView.swift; sourceTree = "<group>"; };
 		8FFC5F5EA7CD05C23FBEB9A2 /* FireTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTheme.swift; sourceTree = "<group>"; };
 		9189433D7C9260885742A5BA /* FireTopicPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicPresentationTests.swift; sourceTree = "<group>"; };
+		9267FBC4BA4FD365E6F4E371 /* FireTopicDetailStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailStore.swift; sourceTree = "<group>"; };
 		92A16F4854521A901D87D1DD /* FireTagPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTagPickerSheet.swift; sourceTree = "<group>"; };
 		97B0FC401C941BC8F73B959A /* Fire-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Fire-Release.xcconfig"; sourceTree = "<group>"; };
 		996D95DE48DA65385BD587F7 /* FireApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireApp.swift; sourceTree = "<group>"; };
@@ -158,6 +183,8 @@
 		B17BF0CB4137B71949AACC0C /* FireSearchStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSearchStoreTests.swift; sourceTree = "<group>"; };
 		B5E5271F93B7DF18859B101F /* FireWebViewLoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWebViewLoginCoordinator.swift; sourceTree = "<group>"; };
 		BABD32407FB273553E9394B3 /* FireProfileBadgeChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileBadgeChip.swift; sourceTree = "<group>"; };
+		BADC2ED47CF65AD5BE795908 /* FireEntityStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireEntityStateTests.swift; sourceTree = "<group>"; };
+		BC115AA696CF29500E0027DD /* FireHomeCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireHomeCollectionView.swift; sourceTree = "<group>"; };
 		BF328A93631D56CB94E4FA7A /* FireAppRouteDestinationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppRouteDestinationView.swift; sourceTree = "<group>"; };
 		BFA66CA083BF4889AE258926 /* FireAppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppViewModel.swift; sourceTree = "<group>"; };
 		C20BDF82CCD1BF22BB3C7729 /* FireAPMMainThreadStallMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMMainThreadStallMonitor.swift; sourceTree = "<group>"; };
@@ -171,10 +198,12 @@
 		DC90B1231DCA76399CB693E2 /* FireBookmarkEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireBookmarkEditorSheet.swift; sourceTree = "<group>"; };
 		DD9004CEFFCDDBE2E50D71B0 /* FireOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireOnboardingView.swift; sourceTree = "<group>"; };
 		E2A86A280EED500EF3126038 /* FireNotificationsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNotificationsView.swift; sourceTree = "<group>"; };
+		E32651328DFBB06437A350F2 /* FireUITests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = FireUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		E69013450F80AEC210D5512D /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 		E7E60D1F8BA725E4D60AFBA3 /* FireHomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireHomeView.swift; sourceTree = "<group>"; };
 		E91142A1E76D9831A6B3EC94 /* FireTopicListMessageBusRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicListMessageBusRefresh.swift; sourceTree = "<group>"; };
 		EAE00F2C2E4EB9A7A99D327A /* FireRouteParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireRouteParser.swift; sourceTree = "<group>"; };
+		EC7384EAE1C43817CAE71D9F /* FireHomeFeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireHomeFeedStore.swift; sourceTree = "<group>"; };
 		EC77525391DD1C7EA7329451 /* FirePushRegistrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePushRegistrationCoordinatorTests.swift; sourceTree = "<group>"; };
 		F02D3C136EFF0589DC131FB9 /* FireProfileTrustLevelPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileTrustLevelPill.swift; sourceTree = "<group>"; };
 		F5F3291447D7DA0AEF9AA413 /* SessionState+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionState+Helpers.swift"; sourceTree = "<group>"; };
@@ -183,6 +212,7 @@
 		FD5A94769988E39B8BEA7B56 /* libiconv.tbd */ = {isa = PBXFileReference; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libiconv.tbd; path = usr/lib/libiconv.tbd; sourceTree = SDKROOT; };
 		FECD6D6E7C9501934DE7EDC9 /* FirePrivateMessagesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePrivateMessagesView.swift; sourceTree = "<group>"; };
 		FEF79A11C032C071A2F494A0 /* FireDraftsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDraftsView.swift; sourceTree = "<group>"; };
+		FFB6B1F10783D1D78B2D1F63 /* FireListSectionModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireListSectionModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -195,19 +225,47 @@
 				E67F86DADDE88559438DE849 /* CoreFoundation.framework in Frameworks */,
 				9726B24BBA832290EA063E8F /* libiconv.tbd in Frameworks */,
 				A7657EA99808CEBE3F038176 /* CrashReporter in Frameworks */,
+				3E86B05D0E10C74BB865A0F9 /* Nuke in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		55C19647F463E787E7CD4750 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F7AF0493553E46BB2FCAB4A5 /* SnapshotTesting in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		17C4ACC0123F8815EE1A7F9E /* UI */ = {
+			isa = PBXGroup;
+			children = (
+				5CE05C9BDCF4A8B4E7BF4CB0 /* FireSmokeUITests.swift */,
+			);
+			name = UI;
+			path = Tests/UI;
+			sourceTree = "<group>";
+		};
 		1D88C155B3075FF19641DF3E /* Products */ = {
 			isa = PBXGroup;
 			children = (
 				48CAB0E38556929FC140E25D /* Fire.app */,
 				0C933069DE6C026030AAB6EF /* FireTests.xctest */,
+				E32651328DFBB06437A350F2 /* FireUITests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		2662344E7D6ECEF292716835 /* Shared */ = {
+			isa = PBXGroup;
+			children = (
+				33FDDDCB91B973C1115A8F6B /* FireEntityIndex.swift */,
+				00DA04AEF775D5BD01FC23AC /* FireOrderedIDList.swift */,
+			);
+			path = Shared;
 			sourceTree = "<group>";
 		};
 		32338F9E71B0E67C5112C300 /* FireAppSession */ = {
@@ -294,6 +352,7 @@
 				0D1C4D30FB92D47F801B64D4 /* FireTopicRow.swift */,
 				9AD6D7178B2622B10A5644E2 /* FireTopicTimingTracker.swift */,
 				F5F3291447D7DA0AEF9AA413 /* SessionState+Helpers.swift */,
+				D0467DE75C48A41B6DA94023 /* ListKit */,
 				56BB80A6C2C32FB6128B118C /* Push */,
 				D0D03E8FE66111ECCEC7F2DD /* Routing */,
 				CEB7A4EE131ABA30059C2518 /* Stores */,
@@ -301,11 +360,20 @@
 			path = App;
 			sourceTree = "<group>";
 		};
+		84DB66F289AF610198CA72D4 /* Home */ = {
+			isa = PBXGroup;
+			children = (
+				BC115AA696CF29500E0027DD /* FireHomeCollectionView.swift */,
+			);
+			path = Home;
+			sourceTree = "<group>";
+		};
 		8FCD2C1B029D07F4C1B82746 /* Unit */ = {
 			isa = PBXGroup;
 			children = (
 				2EFBB6F3B1D7E3DD79D98C17 /* FireAPMEventStoreTests.swift */,
 				299683BEDEC559B03C136C34 /* FireAppRouteTests.swift */,
+				BADC2ED47CF65AD5BE795908 /* FireEntityStateTests.swift */,
 				C2E8287F8F1E148177E1A223 /* FireNotificationStoreTests.swift */,
 				EC77525391DD1C7EA7329451 /* FirePushRegistrationCoordinatorTests.swift */,
 				46C35F105D036EECAAE7B93D /* FireRouteParserTests.swift */,
@@ -326,6 +394,7 @@
 				BD212BBA5E9DA62F41FF41F4 /* Configs */,
 				32338F9E71B0E67C5112C300 /* FireAppSession */,
 				B6732AD346DE25D47D208DE1 /* Generated */,
+				17C4ACC0123F8815EE1A7F9E /* UI */,
 				8FCD2C1B029D07F4C1B82746 /* Unit */,
 				D5EBFF4F5452417E0754E6D0 /* Frameworks */,
 				1D88C155B3075FF19641DF3E /* Products */,
@@ -355,10 +424,24 @@
 		CEB7A4EE131ABA30059C2518 /* Stores */ = {
 			isa = PBXGroup;
 			children = (
+				EC7384EAE1C43817CAE71D9F /* FireHomeFeedStore.swift */,
 				502CE714A74D91C33212BF57 /* FireNotificationStore.swift */,
 				25FD219C2BFB0727FD0D3DD2 /* FireSearchStore.swift */,
+				9267FBC4BA4FD365E6F4E371 /* FireTopicDetailStore.swift */,
+				2662344E7D6ECEF292716835 /* Shared */,
 			);
 			path = Stores;
+			sourceTree = "<group>";
+		};
+		D0467DE75C48A41B6DA94023 /* ListKit */ = {
+			isa = PBXGroup;
+			children = (
+				7CF84F1E6774BE411D4D2C2E /* FireCollectionHost.swift */,
+				843289DCC260BF71A9C48DA4 /* FireDiffableListController.swift */,
+				FFB6B1F10783D1D78B2D1F63 /* FireListSectionModel.swift */,
+				84DB66F289AF610198CA72D4 /* Home */,
+			);
+			path = ListKit;
 			sourceTree = "<group>";
 		};
 		D0D03E8FE66111ECCEC7F2DD /* Routing */ = {
@@ -390,6 +473,7 @@
 			buildConfigurationList = 45130E50B606D6C48CB508C5 /* Build configuration list for PBXNativeTarget "FireTests" */;
 			buildPhases = (
 				2FCCC820ECEB057462CC26A9 /* Sources */,
+				55C19647F463E787E7CD4750 /* Frameworks */,
 			);
 			buildRules = (
 			);
@@ -398,10 +482,29 @@
 			);
 			name = FireTests;
 			packageProductDependencies = (
+				A46FF58D4D7E79645FFA574A /* SnapshotTesting */,
 			);
 			productName = FireTests;
 			productReference = 0C933069DE6C026030AAB6EF /* FireTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		80B98F4CA63C484FFADEB951 /* FireUITests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 79697F4DF834B9D646F09236 /* Build configuration list for PBXNativeTarget "FireUITests" */;
+			buildPhases = (
+				716BF1E0422BDD56F8AC2402 /* Sources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				3B4B37294E75CD2A91941E75 /* PBXTargetDependency */,
+			);
+			name = FireUITests;
+			packageProductDependencies = (
+			);
+			productName = FireUITests;
+			productReference = E32651328DFBB06437A350F2 /* FireUITests.xctest */;
+			productType = "com.apple.product-type.bundle.ui-testing";
 		};
 		87BF3D86E2CA36A3D645AA33 /* Fire */ = {
 			isa = PBXNativeTarget;
@@ -418,6 +521,7 @@
 			name = Fire;
 			packageProductDependencies = (
 				601B450FB4E87A5243FAE5F9 /* CrashReporter */,
+				3F5DB59F34DC2099A84C0F6F /* Nuke */,
 			);
 			productName = Fire;
 			productReference = 48CAB0E38556929FC140E25D /* Fire.app */;
@@ -432,6 +536,9 @@
 				BuildIndependentTargetsInParallel = YES;
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
+					80B98F4CA63C484FFADEB951 = {
+						TestTargetID = 87BF3D86E2CA36A3D645AA33;
+					};
 					87BF3D86E2CA36A3D645AA33 = {
 						DevelopmentTeam = "$(FIRE_DEVELOPMENT_TEAM)";
 						ProvisioningStyle = "$(FIRE_CODE_SIGN_STYLE)";
@@ -449,6 +556,8 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				9F8D6D7CFB3643BCA8C9F545 /* XCRemoteSwiftPackageReference "plcrashreporter" */,
+				0B33AAACF1C3CFC774277ECB /* XCRemoteSwiftPackageReference "Nuke" */,
+				B82195B66E414BF6398F0197 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1D88C155B3075FF19641DF3E /* Products */;
@@ -457,6 +566,7 @@
 			targets = (
 				87BF3D86E2CA36A3D645AA33 /* Fire */,
 				3ACA300207EBD80A07FC30BD /* FireTests */,
+				80B98F4CA63C484FFADEB951 /* FireUITests */,
 			);
 		};
 /* End PBXProject section */
@@ -501,6 +611,7 @@
 			files = (
 				180BEE1FEF5E76FF92403C34 /* FireAPMEventStoreTests.swift in Sources */,
 				3330A9C7E4C8BA80778F79EB /* FireAppRouteTests.swift in Sources */,
+				9B0DABDC5BA87A4CAFF3232D /* FireEntityStateTests.swift in Sources */,
 				8823DAD708691783D2AB85A4 /* FireNotificationStoreTests.swift in Sources */,
 				3F8B5F1239E17802675A013B /* FirePushRegistrationCoordinatorTests.swift in Sources */,
 				4F0305B9162423D8D821A304 /* FireRouteParserTests.swift in Sources */,
@@ -508,6 +619,14 @@
 				9FDB03E99AB569E64A17BE3B /* FireSessionSecurityTests.swift in Sources */,
 				9F734046F02B45409AD5F1C6 /* FireTopicListMessageBusRefreshTests.swift in Sources */,
 				FFCC342F97F349220632A787 /* FireTopicPresentationTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		716BF1E0422BDD56F8AC2402 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				C0F81D0F77AD3163B093E18B /* FireSmokeUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -531,15 +650,21 @@
 				03AA550F53B37A6C6189FBFB /* FireBookmarkEditorSheet.swift in Sources */,
 				F171E34C843A4BD06FB50408 /* FireBookmarksView.swift in Sources */,
 				999638A7F6D5A424815E6F2F /* FireCategoriesView.swift in Sources */,
+				F8963543E87EACAD49C9B131 /* FireCollectionHost.swift in Sources */,
 				7FC4730D00066ED2E1605539 /* FireComponents.swift in Sources */,
 				5B4072DC893E7612141A8F34 /* FireComposerView.swift in Sources */,
 				7C7F1371B83C02B96B266900 /* FireDeveloperToolsView.swift in Sources */,
 				CBBBFC3F31D03FD92B0C29C5 /* FireDiagnosticsView.swift in Sources */,
+				939404BE03A327D4A29B6E33 /* FireDiffableListController.swift in Sources */,
 				C25654B366748CB1C015E4FA /* FireDraftsView.swift in Sources */,
+				6CD842F82A4371F3BCCCF4C5 /* FireEntityIndex.swift in Sources */,
 				01F9189B11F5E6217DEBB203 /* FireFilteredTopicListView.swift in Sources */,
 				8B8629DE49FD3256333B0CF4 /* FireFollowListView.swift in Sources */,
+				83E741D10CEEBE061C2B0B30 /* FireHomeCollectionView.swift in Sources */,
+				768DC62B26A1D2EF4F545D35 /* FireHomeFeedStore.swift in Sources */,
 				795E7AB547CA854593A42D91 /* FireHomeView.swift in Sources */,
 				55B4C9E127A547A1514C9C16 /* FireInviteLinksView.swift in Sources */,
+				F31A70760B997F5ADFB7C489 /* FireListSectionModel.swift in Sources */,
 				CFF789D0907079D9365F031E /* FireLoginWebView.swift in Sources */,
 				944A9CD4343088D2E1BABF5A /* FireMessageBusCoordinator.swift in Sources */,
 				A1991999F769CF1B701DEFA4 /* FireMyBadgesView.swift in Sources */,
@@ -548,6 +673,7 @@
 				B4AA77D05D86AB070BE06A93 /* FireNotificationStore.swift in Sources */,
 				9D5F82625F6960B6A6ED10B9 /* FireNotificationsView.swift in Sources */,
 				792980AB2D2B5BF56221DF47 /* FireOnboardingView.swift in Sources */,
+				4291E89FC3D5D35AC9A06898 /* FireOrderedIDList.swift in Sources */,
 				82D925C1A3A758CB7309295E /* FirePostEditorView.swift in Sources */,
 				73D15598C74EA2ABE6BCC1FA /* FirePresentationIdentity.swift in Sources */,
 				54170A08D034A622A66D5DBD /* FirePrivateMessagesView.swift in Sources */,
@@ -570,6 +696,7 @@
 				217BC99CE792BDFA88ED89FC /* FireTabRoot.swift in Sources */,
 				CFC36741F088E04A6D55E81B /* FireTagPickerSheet.swift in Sources */,
 				428170833590DCF14AEEA64C /* FireTheme.swift in Sources */,
+				47B89C5984DCCAB601B919EE /* FireTopicDetailStore.swift in Sources */,
 				6A8BA8AACC4ED45E311894CE /* FireTopicDetailView.swift in Sources */,
 				12ED42BB059E1EFA35A00827 /* FireTopicEditorView.swift in Sources */,
 				C1300F26689601362E952200 /* FireTopicListMessageBusRefresh.swift in Sources */,
@@ -585,6 +712,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		3B4B37294E75CD2A91941E75 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 87BF3D86E2CA36A3D645AA33 /* Fire */;
+			targetProxy = 07329CA8EE49AC256B3F5C5B /* PBXContainerItemProxy */;
+		};
 		FAD67CF76E1A43CF274706B3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 87BF3D86E2CA36A3D645AA33 /* Fire */;
@@ -640,6 +772,23 @@
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
+		};
+		0B6567B0DF9F6DE802C0BA13 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Fire;
+			};
+			name = Release;
 		};
 		6E68DB783361D38DCA73F9A4 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -848,6 +997,23 @@
 			};
 			name = Release;
 		};
+		FCD72076FC7437313E8B67F1 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				GENERATE_INFOPLIST_FILE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@loader_path/Frameworks",
+				);
+				SDKROOT = iphoneos;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				TEST_TARGET_NAME = Fire;
+			};
+			name = Debug;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -856,6 +1022,15 @@
 			buildConfigurations = (
 				6E68DB783361D38DCA73F9A4 /* Debug */,
 				8D1DD178D93ACE719AA9A787 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		79697F4DF834B9D646F09236 /* Build configuration list for PBXNativeTarget "FireUITests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				FCD72076FC7437313E8B67F1 /* Debug */,
+				0B6567B0DF9F6DE802C0BA13 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;
@@ -881,6 +1056,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		0B33AAACF1C3CFC774277ECB /* XCRemoteSwiftPackageReference "Nuke" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/kean/Nuke.git";
+			requirement = {
+				kind = exactVersion;
+				version = 13.0.1;
+			};
+		};
 		9F8D6D7CFB3643BCA8C9F545 /* XCRemoteSwiftPackageReference "plcrashreporter" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/microsoft/plcrashreporter.git";
@@ -889,13 +1072,31 @@
 				version = 1.12.2;
 			};
 		};
+		B82195B66E414BF6398F0197 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-snapshot-testing.git";
+			requirement = {
+				kind = exactVersion;
+				version = 1.19.2;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		3F5DB59F34DC2099A84C0F6F /* Nuke */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 0B33AAACF1C3CFC774277ECB /* XCRemoteSwiftPackageReference "Nuke" */;
+			productName = Nuke;
+		};
 		601B450FB4E87A5243FAE5F9 /* CrashReporter */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 9F8D6D7CFB3643BCA8C9F545 /* XCRemoteSwiftPackageReference "plcrashreporter" */;
 			productName = CrashReporter;
+		};
+		A46FF58D4D7E79645FFA574A /* SnapshotTesting */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = B82195B66E414BF6398F0197 /* XCRemoteSwiftPackageReference "swift-snapshot-testing" */;
+			productName = SnapshotTesting;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/native/ios-app/Fire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/native/ios-app/Fire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,15 +1,6 @@
 {
-  "originHash" : "9ec3f8f8464cd26ef2bef3895bb6f0f5a6d2828602c61e77b4dcc8a515f7cfce",
+  "originHash" : "606c3f9d0bc26236a2f60c78aaf8310eddc6e69d6f8a37c89e7f238cf246d3d6",
   "pins" : [
-    {
-      "identity" : "nuke",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/kean/Nuke.git",
-      "state" : {
-        "revision" : "76e780ad7100c224e5127822ff81915dd04880c5",
-        "version" : "13.0.1"
-      }
-    },
     {
       "identity" : "plcrashreporter",
       "kind" : "remoteSourceControl",
@@ -17,42 +8,6 @@
       "state" : {
         "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
         "version" : "1.12.2"
-      }
-    },
-    {
-      "identity" : "swift-custom-dump",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-custom-dump",
-      "state" : {
-        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
-        "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swift-snapshot-testing",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
-      "state" : {
-        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
-        "version" : "1.19.2"
-      }
-    },
-    {
-      "identity" : "swift-syntax",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-syntax",
-      "state" : {
-        "revision" : "2b59c0c741e9184ab057fd22950b491076d42e91",
-        "version" : "603.0.0"
-      }
-    },
-    {
-      "identity" : "xctest-dynamic-overlay",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
-      "state" : {
-        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
-        "version" : "1.9.0"
       }
     }
   ],

--- a/native/ios-app/Fire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/native/ios-app/Fire.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "606c3f9d0bc26236a2f60c78aaf8310eddc6e69d6f8a37c89e7f238cf246d3d6",
+  "originHash" : "9ec3f8f8464cd26ef2bef3895bb6f0f5a6d2828602c61e77b4dcc8a515f7cfce",
   "pins" : [
+    {
+      "identity" : "nuke",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/kean/Nuke.git",
+      "state" : {
+        "revision" : "76e780ad7100c224e5127822ff81915dd04880c5",
+        "version" : "13.0.1"
+      }
+    },
     {
       "identity" : "plcrashreporter",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,42 @@
       "state" : {
         "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
         "version" : "1.12.2"
+      }
+    },
+    {
+      "identity" : "swift-custom-dump",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-custom-dump",
+      "state" : {
+        "revision" : "06c57924455064182d6b217f06ebc05d00cb2990",
+        "version" : "1.5.0"
+      }
+    },
+    {
+      "identity" : "swift-snapshot-testing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/swift-snapshot-testing.git",
+      "state" : {
+        "revision" : "ad5e3190cc63dc288f28546f9c6827efc1e9d495",
+        "version" : "1.19.2"
+      }
+    },
+    {
+      "identity" : "swift-syntax",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-syntax",
+      "state" : {
+        "revision" : "2b59c0c741e9184ab057fd22950b491076d42e91",
+        "version" : "603.0.0"
+      }
+    },
+    {
+      "identity" : "xctest-dynamic-overlay",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/pointfreeco/xctest-dynamic-overlay",
+      "state" : {
+        "revision" : "dfd70507def84cb5fb821278448a262c6ff2bbad",
+        "version" : "1.9.0"
       }
     }
   ],

--- a/native/ios-app/Fire.xcodeproj/xcshareddata/xcschemes/Fire.xcscheme
+++ b/native/ios-app/Fire.xcodeproj/xcshareddata/xcschemes/Fire.xcscheme
@@ -35,6 +35,20 @@
                ReferencedContainer = "container:Fire.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "80B98F4CA63C484FFADEB951"
+               BuildableName = "FireUITests.xctest"
+               BlueprintName = "FireUITests"
+               ReferencedContainer = "container:Fire.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -63,6 +77,17 @@
                BlueprintIdentifier = "3ACA300207EBD80A07FC30BD"
                BuildableName = "FireTests.xctest"
                BlueprintName = "FireTests"
+               ReferencedContainer = "container:Fire.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "80B98F4CA63C484FFADEB951"
+               BuildableName = "FireUITests.xctest"
+               BlueprintName = "FireUITests"
                ReferencedContainer = "container:Fire.xcodeproj">
             </BuildableReference>
          </TestableReference>

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -58,20 +58,26 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - restores the persisted session cache, replays Keychain cookies through Rust on cold start, repairs incomplete authenticated session identity, refreshes CSRF when the restored cache is otherwise ready, and keeps the topic browser in sync with login state
   - holds the onboarding screen in a bootstrap state while cold-start auto-login runs, hiding login actions during restore and only revealing a loading indicator if that bootstrap takes longer than 500ms
   - now builds `FireSessionStore` lazily on a detached task so Rust/logging initialization does not block the first SwiftUI render on the main actor
-  - tracks paginated topic feed state and publishes Rust-backed bootstrap metadata plus Rust-generated topic-row view models into SwiftUI
   - mirrors authenticated LinuxDo cookies into native `HTTPCookieStorage` so inline media/image requests can reuse the restored session
-  - coordinates native reply, like, custom reaction, and topic-timing reporting on top of the shared Rust interaction APIs
   - now also owns native private-message inbox/sent loading plus private-message creation on top of the shared Rust mailbox and `/posts.json` PM surfaces
-  - now acts as a session and interaction facade for feature stores instead of also owning every screen's transient state directly
-  - now owns the foreground MessageBus lifecycle on iOS, including topic-detail reaction/presence subscriptions, shared notification-state sync, and reply-presence heartbeats while the quick composer is focused
+  - now acts as a session/runtime facade for feature stores instead of also owning every screen's transient state directly
+  - now owns the foreground MessageBus transport lifecycle on iOS and forwards runtime refresh work into the bound feature stores instead of publishing home/topic-detail state itself
   - now treats Rust-owned `CloudflareChallenge` errors as the signal to clear the local authenticated snapshot, return the shell to onboarding, and auto-present the login WebView so challenge recovery stays inside the browser flow
   - now also emits host-owned APM spans for cold-start restore, login sync, bootstrap refresh, latest-feed load, topic-detail load, reply submit, notification refresh, and MessageBus start
+- `App/Stores/FireHomeFeedStore.swift`
+  - owns selected feed kind, selected category/tags, paginated home rows, and bootstrap-derived category/tag metadata for the authenticated home shell
+  - applies MessageBus-driven home refreshes with explicit entity patching and stable ordering instead of whole-array replacement
+- `App/Stores/FireTopicDetailStore.swift`
+  - owns topic-detail cache, anchor post numbers, post hydration/pagination, reply presence, and topic-detail mutation flags
+  - keeps topic-detail subscription, presence heartbeat, quick reply, reaction toggles, and post-edit refresh reconciliation out of `FireAppViewModel`
 - `App/Stores/FireSearchStore.swift`
   - owns the search screen's query, scope, result, paging, loading, and error state
   - keeps the actual `/search.json` call path on `FireAppViewModel` so session ownership and recoverable-auth handling stay centralized during the W2 split
 - `App/Stores/FireNotificationStore.swift`
   - owns unread count, recent notifications, full-history paging, and notification-specific loading state
   - keeps MessageBus-triggered runtime refresh and notification read mutations outside `FireAppViewModel`, while still delegating Rust calls and recoverable-auth handling back through the shared app/session facade
+- `App/Stores/Shared/FireEntityIndex.swift` and `App/Stores/Shared/FireOrderedIDList.swift`
+  - provide the minimal entity-by-id and stable-order primitives used by the home feed to support incremental list patching
 - `App/FireSearchView.swift`
   - provides a native search workspace with keyword input, topic/post/user scope switching, paginated result loading, and typed route-based topic/profile navigation
   - now renders from `FireSearchStore`, so search input and pagination no longer invalidate unrelated authenticated tabs through `FireAppViewModel`
@@ -103,13 +109,24 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - exposes host-owned notification permission / APNs registration state and the locally cached device token for production-readiness checks
   - exports both the Rust-owned diagnostics bundle and a host-owned full APM `.firesupportbundle` package containing local crash / MetricKit / route / span artifacts for share-sheet based escalation during beta
 - `App/FireTabRoot.swift`
+  - instantiates the authenticated-shell store graph (`FireHomeFeedStore`, `FireSearchStore`, `FireNotificationStore`, `FireTopicDetailStore`, `FireProfileViewModel`) around one shared `FireAppViewModel`
+  - injects home/topic-detail stores through the SwiftUI environment so those screens observe scoped feature state instead of the app-wide root object
   - forwards scene-phase transitions into shared diagnostics lifecycle logging, re-syncs APNs registration state for authenticated sessions, flushes logs before `inactive` / `background` so exported diagnostics stay durable, and keeps the current top-level route synchronized into the host-owned APM runtime
+- `App/ListKit/`
+  - now contains the W3 collection-host foundation built around `UICollectionView`, diffable data source snapshots, and `UIHostingConfiguration`
+  - `FireCollectionHost.swift` bridges SwiftUI into a reusable collection-backed host while `FireDiffableListController.swift` preserves the top visible item and relative offset across snapshot applies, forwards scroll metrics, and supports native pull-to-refresh
+  - `FireListSectionModel.swift` provides the section/item shape shared by later home/notification/topic-detail migrations
+  - `Home/FireHomeCollectionView.swift` is the first W3 migration slice and now drives the authenticated home feed through diffable collection snapshots instead of SwiftUI `List`
 - `App/FireTopicPresentation.swift`
   - normalizes topic/post timestamps for native presentation
   - extracts inline cooked-image attachments plus enabled reaction options from bootstrap/topic HTML so the native detail view can render media and interaction affordances without a WebView
   - now focuses on host-only presentation helpers after topic-row shaping, shared text helpers, and thread flattening moved into Rust
 - `Tests/Unit/FireTopicPresentationTests.swift`
   - covers the remaining Swift-owned presentation helpers plus the generated Rust-backed text and row/thread models consumed by SwiftUI
+- `Tests/Unit/FireEntityStateTests.swift`
+  - covers `FireEntityIndex` upsert behavior plus `FireOrderedIDList` deduplication and stable ordering for the W2 home-feed list state
+- `Tests/UI/FireSmokeUITests.swift`
+  - backs the new `FireUITests` target with a minimal launch smoke test so the W3 UI-test lane is present before deeper end-to-end coverage lands
 - `Tests/Unit/FireRouteParserTests.swift`
   - covers supported custom URL forms, LinuxDo route parsing, and notification-payload route mapping
 - `App/FireRootView.swift`
@@ -120,6 +137,12 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - now reads the real generated Swift-facing contracts exported from `fire-uniffi`
 - `App/FireHomeView.swift`
   - keeps the top bar title fixed to `首页` so the authenticated home shell does not echo the current profile name in the navigation chrome
+  - now renders its feed/category/tag state from `FireHomeFeedStore`, so home pagination and filter changes no longer flow through the app-wide root observable
+  - now routes the home feed through `FireHomeCollectionView`, keeping toolbar/sheet/navigation ownership in SwiftUI while moving the hot-path list mechanics to the W3 diffable collection host
+- `App/FireCategoriesView.swift` and `App/FireTagPickerSheet.swift`
+  - now read category/tag bootstrap metadata and selected home filters from `FireHomeFeedStore`
+- `App/FireTopicDetailView.swift`
+  - now renders from `FireTopicDetailStore`, keeping detail loading, reply state, post mutation flags, and presence updates scoped to the active topic screen
 
 Expected integration flow:
 
@@ -134,6 +157,10 @@ Expected integration flow:
 Xcode project generation rules:
 
 - `native/ios-app/project.yml` is the source of truth for `Fire.xcodeproj`.
+- `project.yml` now also pins the W3 foundation packages:
+  - `Nuke` for the upcoming production image pipeline
+  - `SnapshotTesting` for later renderer/list snapshot coverage
+  - `FireUITests` as the dedicated UI-test target
 - Signing now flows through `native/ios-app/Configs/Fire-*.xcconfig` so local developer-account overrides do not need to touch the generated project.
 - New Swift files placed under existing source roots such as `App/` or `Sources/FireAppSession/` do not require a `project.yml` edit, but they do require rerunning `xcodegen generate --spec native/ios-app/project.yml` and committing the regenerated `Fire.xcodeproj`.
 - Changes that introduce a new source/resource directory, framework dependency, build script, target, or Xcode build setting must update `project.yml` first, then regenerate `Fire.xcodeproj`.

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -62,11 +62,16 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - mirrors authenticated LinuxDo cookies into native `HTTPCookieStorage` so inline media/image requests can reuse the restored session
   - coordinates native reply, like, custom reaction, and topic-timing reporting on top of the shared Rust interaction APIs
   - now also owns native private-message inbox/sent loading plus private-message creation on top of the shared Rust mailbox and `/posts.json` PM surfaces
+  - now acts as a session and interaction facade for feature stores instead of also owning every screen's transient state directly
   - now owns the foreground MessageBus lifecycle on iOS, including topic-detail reaction/presence subscriptions, shared notification-state sync, and reply-presence heartbeats while the quick composer is focused
   - now treats Rust-owned `CloudflareChallenge` errors as the signal to clear the local authenticated snapshot, return the shell to onboarding, and auto-present the login WebView so challenge recovery stays inside the browser flow
   - now also emits host-owned APM spans for cold-start restore, login sync, bootstrap refresh, latest-feed load, topic-detail load, reply submit, notification refresh, and MessageBus start
+- `App/Stores/FireSearchStore.swift`
+  - owns the search screen's query, scope, result, paging, loading, and error state
+  - keeps the actual `/search.json` call path on `FireAppViewModel` so session ownership and recoverable-auth handling stay centralized during the W2 split
 - `App/FireSearchView.swift`
   - provides a native search workspace with keyword input, topic/post/user scope switching, paginated result loading, and typed route-based topic/profile navigation
+  - now renders from `FireSearchStore`, so search input and pagination no longer invalidate unrelated authenticated tabs through `FireAppViewModel`
 - `App/FireComposerView.swift`
   - now supports native private-message compose alongside create-topic and advanced-reply flows, including recipient token editing, PM-specific draft restore/save, and PM-specific validation lengths from bootstrap
 - `App/FirePrivateMessagesView.swift`

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -69,9 +69,14 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
 - `App/Stores/FireSearchStore.swift`
   - owns the search screen's query, scope, result, paging, loading, and error state
   - keeps the actual `/search.json` call path on `FireAppViewModel` so session ownership and recoverable-auth handling stay centralized during the W2 split
+- `App/Stores/FireNotificationStore.swift`
+  - owns unread count, recent notifications, full-history paging, and notification-specific loading state
+  - keeps MessageBus-triggered runtime refresh and notification read mutations outside `FireAppViewModel`, while still delegating Rust calls and recoverable-auth handling back through the shared app/session facade
 - `App/FireSearchView.swift`
   - provides a native search workspace with keyword input, topic/post/user scope switching, paginated result loading, and typed route-based topic/profile navigation
   - now renders from `FireSearchStore`, so search input and pagination no longer invalidate unrelated authenticated tabs through `FireAppViewModel`
+- `App/FireNotificationsView.swift` and `App/FireNotificationHistoryView.swift`
+  - now render from `FireNotificationStore` instead of reading notification list state directly off `FireAppViewModel`
 - `App/FireComposerView.swift`
   - now supports native private-message compose alongside create-topic and advanced-reply flows, including recipient token editing, PM-specific draft restore/save, and PM-specific validation lengths from bootstrap
 - `App/FirePrivateMessagesView.swift`

--- a/native/ios-app/Tests/UI/FireSmokeUITests.swift
+++ b/native/ios-app/Tests/UI/FireSmokeUITests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+final class FireSmokeUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    @MainActor
+    func testAppLaunches() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 5))
+    }
+}

--- a/native/ios-app/Tests/Unit/FireEntityStateTests.swift
+++ b/native/ios-app/Tests/Unit/FireEntityStateTests.swift
@@ -1,0 +1,57 @@
+import XCTest
+@testable import Fire
+
+final class FireEntityStateTests: XCTestCase {
+    func testOrderedIDListDeduplicatesAndPreservesAppendOrder() {
+        var orderedIDs = FireOrderedIDList(ids: [2, 1, 2])
+        orderedIDs.append([1, 3, 4, 3])
+
+        XCTAssertEqual(orderedIDs.ids, [2, 1, 3, 4])
+    }
+
+    func testEntityIndexUpsertReplacesExistingPayloadAndKeepsOtherEntities() {
+        var index = FireEntityIndex<UInt64, TestEntity>()
+        index.replaceAll(
+            [
+                TestEntity(id: 1, title: "one"),
+                TestEntity(id: 2, title: "two"),
+            ],
+            id: \.id
+        )
+
+        index.upsert(
+            [
+                TestEntity(id: 2, title: "two-updated"),
+                TestEntity(id: 3, title: "three"),
+            ],
+            id: \.id
+        )
+
+        XCTAssertEqual(index.entity(for: 1)?.title, "one")
+        XCTAssertEqual(index.entity(for: 2)?.title, "two-updated")
+        XCTAssertEqual(index.entity(for: 3)?.title, "three")
+    }
+
+    func testOrderedValuesFollowExplicitIDListOrder() {
+        var index = FireEntityIndex<UInt64, TestEntity>()
+        index.replaceAll(
+            [
+                TestEntity(id: 1, title: "one"),
+                TestEntity(id: 2, title: "two"),
+                TestEntity(id: 3, title: "three"),
+            ],
+            id: \.id
+        )
+
+        let orderedValues = index.orderedValues(
+            for: FireOrderedIDList(ids: [3, 1, 2])
+        )
+
+        XCTAssertEqual(orderedValues.map(\.title), ["three", "one", "two"])
+    }
+}
+
+private struct TestEntity: Equatable {
+    let id: UInt64
+    let title: String
+}

--- a/native/ios-app/Tests/Unit/FireNotificationStoreTests.swift
+++ b/native/ios-app/Tests/Unit/FireNotificationStoreTests.swift
@@ -1,0 +1,101 @@
+import XCTest
+@testable import Fire
+
+final class FireNotificationStoreTests: XCTestCase {
+    @MainActor
+    func testApplyCenterStateUpdatesUnreadRecentAndFullLists() {
+        let store = FireNotificationStore(appViewModel: FireAppViewModel())
+        let recent = makeNotification(id: 1, read: false)
+        let full = makeNotification(id: 2, read: true)
+
+        store.apply(
+            centerState: NotificationCenterState(
+                counters: NotificationCountersState(allUnread: 7, unread: 4, highPriority: 1),
+                recent: [recent],
+                hasLoadedRecent: true,
+                recentSeenNotificationId: 1,
+                full: [full],
+                hasLoadedFull: true,
+                totalRowsNotifications: 10,
+                fullSeenNotificationId: 2,
+                fullLoadMoreNotifications: "/notifications?offset=60",
+                fullNextOffset: 60
+            ),
+            updateRecent: true,
+            updateFull: true
+        )
+
+        XCTAssertEqual(store.unreadCount, 7)
+        XCTAssertEqual(store.recentNotifications.map(\.id), [1])
+        XCTAssertEqual(store.fullNotifications.map(\.id), [2])
+        XCTAssertEqual(store.fullNextOffset, 60)
+        XCTAssertTrue(store.hasMoreFull)
+    }
+
+    @MainActor
+    func testResetClearsNotificationState() {
+        let store = FireNotificationStore(appViewModel: FireAppViewModel())
+        store.apply(
+            centerState: NotificationCenterState(
+                counters: NotificationCountersState(allUnread: 2, unread: 2, highPriority: 0),
+                recent: [makeNotification(id: 1, read: false)],
+                hasLoadedRecent: true,
+                recentSeenNotificationId: 1,
+                full: [makeNotification(id: 2, read: true)],
+                hasLoadedFull: true,
+                totalRowsNotifications: 2,
+                fullSeenNotificationId: 2,
+                fullLoadMoreNotifications: nil,
+                fullNextOffset: 20
+            ),
+            updateRecent: true,
+            updateFull: true
+        )
+
+        store.reset()
+
+        XCTAssertEqual(store.unreadCount, 0)
+        XCTAssertTrue(store.recentNotifications.isEmpty)
+        XCTAssertTrue(store.fullNotifications.isEmpty)
+        XCTAssertNil(store.fullNextOffset)
+        XCTAssertFalse(store.hasMoreFull)
+        XCTAssertFalse(store.isLoadingRecent)
+        XCTAssertFalse(store.isLoadingFullPage)
+    }
+
+    private func makeNotification(id: UInt64, read: Bool) -> NotificationItemState {
+        NotificationItemState(
+            id: id,
+            userId: 1,
+            notificationType: 2,
+            read: read,
+            highPriority: false,
+            createdAt: nil,
+            createdTimestampUnixMs: nil,
+            postNumber: 1,
+            topicId: 100 + id,
+            slug: "topic-\(id)",
+            fancyTitle: "Topic \(id)",
+            actingUserAvatarTemplate: nil,
+            data: NotificationDataState(
+                displayUsername: "alice",
+                originalPostId: nil,
+                originalPostType: nil,
+                originalUsername: nil,
+                revisionNumber: nil,
+                topicTitle: "Topic \(id)",
+                badgeName: nil,
+                badgeId: nil,
+                badgeSlug: nil,
+                groupName: nil,
+                inboxCount: nil,
+                count: nil,
+                username: "alice",
+                username2: nil,
+                avatarTemplate: nil,
+                excerpt: nil,
+                payloadJson: nil
+            )
+        )
+    }
+}

--- a/native/ios-app/Tests/Unit/FireSearchStoreTests.swift
+++ b/native/ios-app/Tests/Unit/FireSearchStoreTests.swift
@@ -1,0 +1,114 @@
+import XCTest
+@testable import Fire
+
+final class FireSearchStoreTests: XCTestCase {
+    func testMergePreservesExistingOrderAndAppendsNewIDs() {
+        let existing = SearchResultState(
+            posts: [makePost(id: 1), makePost(id: 2)],
+            topics: [makeTopic(id: 11, views: 10)],
+            users: [makeUser(id: 21, username: "alice")],
+            groupedResult: makeGroupedResult()
+        )
+        let incoming = SearchResultState(
+            posts: [makePost(id: 2), makePost(id: 3)],
+            topics: [makeTopic(id: 12, views: 30)],
+            users: [makeUser(id: 22, username: "bob")],
+            groupedResult: makeGroupedResult(moreUsers: true)
+        )
+
+        let merged = FireSearchStore.merge(existing: existing, incoming: incoming)
+
+        XCTAssertEqual(merged.posts.map(\.id), [1, 2, 3])
+        XCTAssertEqual(merged.topics.map(\.id), [11, 12])
+        XCTAssertEqual(merged.users.map(\.id), [21, 22])
+        XCTAssertTrue(merged.groupedResult.moreUsers)
+    }
+
+    func testMergeReplacesExistingItemsWithIncomingPayload() {
+        let existing = SearchResultState(
+            posts: [],
+            topics: [makeTopic(id: 11, views: 10)],
+            users: [],
+            groupedResult: makeGroupedResult()
+        )
+        let incoming = SearchResultState(
+            posts: [],
+            topics: [makeTopic(id: 11, views: 99)],
+            users: [],
+            groupedResult: makeGroupedResult()
+        )
+
+        let merged = FireSearchStore.merge(existing: existing, incoming: incoming)
+
+        XCTAssertEqual(merged.topics.map(\.id), [11])
+        XCTAssertEqual(merged.topics.first?.views, 99)
+    }
+
+    @MainActor
+    func testResetClearsTransientSearchState() {
+        let store = FireSearchStore(appViewModel: FireAppViewModel())
+        store.query = "rust"
+        store.setScope(.user)
+        store.reset()
+
+        XCTAssertEqual(store.query, "")
+        XCTAssertEqual(store.scope, .all)
+        XCTAssertNil(store.result)
+        XCTAssertEqual(store.currentPage, 1)
+        XCTAssertFalse(store.isSearching)
+        XCTAssertFalse(store.isAppending)
+        XCTAssertNil(store.errorMessage)
+    }
+
+    private func makeGroupedResult(
+        morePosts: Bool = false,
+        moreUsers: Bool = false
+    ) -> GroupedSearchResultState {
+        GroupedSearchResultState(
+            term: "rust",
+            morePosts: morePosts,
+            moreUsers: moreUsers,
+            moreCategories: false,
+            moreFullPageResults: false,
+            searchLogId: nil
+        )
+    }
+
+    private func makePost(id: UInt64) -> SearchPostState {
+        SearchPostState(
+            id: id,
+            topicId: 100 + id,
+            username: "user\(id)",
+            avatarTemplate: nil,
+            createdAt: nil,
+            createdTimestampUnixMs: nil,
+            likeCount: 0,
+            blurb: "Post \(id)",
+            postNumber: 1,
+            topicTitleHeadline: "Topic \(id)"
+        )
+    }
+
+    private func makeTopic(id: UInt64, views: UInt64) -> SearchTopicState {
+        SearchTopicState(
+            id: id,
+            title: "Topic \(id)",
+            slug: "topic-\(id)",
+            categoryId: nil,
+            tags: [],
+            postsCount: 1,
+            views: UInt32(views),
+            closed: false,
+            archived: false
+        )
+    }
+
+    private func makeUser(id: UInt64, username: String) -> SearchUserState {
+        SearchUserState(
+            id: id,
+            username: username,
+            name: nil,
+            avatarTemplate: nil
+        )
+    }
+}

--- a/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
+++ b/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
@@ -552,7 +552,6 @@ final class FireSessionSecurityTests: XCTestCase {
             initialSession: authenticatedSession(),
             challengeRecoveryStore: recoveryStore
         )
-        viewModel.searchQuery = "rust"
 
         let recovered = await viewModel.handleCloudflareChallengeIfNeeded(
             FireUniFfiError.CloudflareChallenge
@@ -564,7 +563,6 @@ final class FireSessionSecurityTests: XCTestCase {
             viewModel.errorMessage,
             "需要先完成 Cloudflare 验证。请在登录页完成验证后点 Sync，再重试。"
         )
-        XCTAssertEqual(viewModel.searchQuery, "")
         XCTAssertFalse(viewModel.session.hasLoginSession)
         XCTAssertFalse(viewModel.session.readiness.canReadAuthenticatedApi)
         XCTAssertTrue(viewModel.session.readiness.hasCloudflareClearance)
@@ -581,7 +579,6 @@ final class FireSessionSecurityTests: XCTestCase {
             initialSession: authenticatedSession(),
             challengeRecoveryStore: recoveryStore
         )
-        viewModel.searchQuery = "rust"
 
         let recovered = await viewModel.handleLoginRequiredIfNeeded(
             FireUniFfiError.LoginRequired(details: "您需要登录才能执行此操作。")
@@ -590,7 +587,6 @@ final class FireSessionSecurityTests: XCTestCase {
         XCTAssertTrue(recovered)
         XCTAssertTrue(viewModel.isPresentingLogin)
         XCTAssertEqual(viewModel.errorMessage, "您需要登录才能执行此操作。")
-        XCTAssertEqual(viewModel.searchQuery, "")
         XCTAssertFalse(viewModel.session.hasLoginSession)
         XCTAssertFalse(viewModel.session.readiness.canReadAuthenticatedApi)
         XCTAssertTrue(viewModel.session.readiness.hasCloudflareClearance)
@@ -607,7 +603,6 @@ final class FireSessionSecurityTests: XCTestCase {
             initialSession: authenticatedSession(),
             challengeRecoveryStore: recoveryStore
         )
-        viewModel.searchQuery = "rust"
 
         let recovered = await viewModel.handleCloudflareChallengeIfNeeded(
             FireUniFfiError.Network(details: "offline")
@@ -616,7 +611,6 @@ final class FireSessionSecurityTests: XCTestCase {
         XCTAssertFalse(recovered)
         XCTAssertFalse(viewModel.isPresentingLogin)
         XCTAssertNil(viewModel.errorMessage)
-        XCTAssertEqual(viewModel.searchQuery, "rust")
         XCTAssertTrue(viewModel.session.hasLoginSession)
         XCTAssertTrue(viewModel.session.readiness.canReadAuthenticatedApi)
         let calls = await recoveryStore.recordedCalls()

--- a/native/ios-app/Tests/Unit/FireTopicPresentationTests.swift
+++ b/native/ios-app/Tests/Unit/FireTopicPresentationTests.swift
@@ -333,6 +333,8 @@ final class FireTopicPresentationTests: XCTestCase {
     @MainActor
     func testActiveTopicDetailOwnersRetainTopicIDsUntilLastOwnerLeaves() {
         let viewModel = FireAppViewModel()
+        let topicDetailStore = FireTopicDetailStore(appViewModel: viewModel)
+        viewModel.bindTopicDetailStore(topicDetailStore)
         let visibleTopicIDs: Set<UInt64> = [1, 2]
 
         viewModel.beginTopicDetailLifecycle(topicId: 42, ownerToken: "owner-a")

--- a/native/ios-app/project.yml
+++ b/native/ios-app/project.yml
@@ -5,12 +5,6 @@ packages:
   CrashReporter:
     url: https://github.com/microsoft/plcrashreporter.git
     exactVersion: 1.12.2
-  Nuke:
-    url: https://github.com/kean/Nuke.git
-    exactVersion: 13.0.1
-  SnapshotTesting:
-    url: https://github.com/pointfreeco/swift-snapshot-testing.git
-    exactVersion: 1.19.2
 fileGroups:
   - Configs/Fire-Debug.xcconfig
   - Configs/Fire-Local-Debug.example.xcconfig
@@ -60,8 +54,6 @@ targets:
       - sdk: libiconv.tbd
       - package: CrashReporter
         product: CrashReporter
-      - package: Nuke
-        product: Nuke
     settings:
       base:
         CODE_SIGN_STYLE: $(FIRE_CODE_SIGN_STYLE)
@@ -119,8 +111,6 @@ targets:
       - path: Tests/Unit
     dependencies:
       - target: Fire
-      - package: SnapshotTesting
-        product: SnapshotTesting
     settings:
       base:
         GENERATE_INFOPLIST_FILE: YES

--- a/native/ios-app/project.yml
+++ b/native/ios-app/project.yml
@@ -5,6 +5,12 @@ packages:
   CrashReporter:
     url: https://github.com/microsoft/plcrashreporter.git
     exactVersion: 1.12.2
+  Nuke:
+    url: https://github.com/kean/Nuke.git
+    exactVersion: 13.0.1
+  SnapshotTesting:
+    url: https://github.com/pointfreeco/swift-snapshot-testing.git
+    exactVersion: 1.19.2
 fileGroups:
   - Configs/Fire-Debug.xcconfig
   - Configs/Fire-Local-Debug.example.xcconfig
@@ -19,12 +25,17 @@ schemes:
         Fire: all
         FireTests:
           - test
+        FireUITests:
+          - test
     test:
       gatherCoverageData: true
       targets:
         - name: FireTests
           parallelizable: true
           randomExecutionOrder: true
+        - name: FireUITests
+          parallelizable: false
+          randomExecutionOrder: false
 settings:
   base:
     SWIFT_VERSION: "5.10"
@@ -49,6 +60,8 @@ targets:
       - sdk: libiconv.tbd
       - package: CrashReporter
         product: CrashReporter
+      - package: Nuke
+        product: Nuke
     settings:
       base:
         CODE_SIGN_STYLE: $(FIRE_CODE_SIGN_STYLE)
@@ -106,9 +119,22 @@ targets:
       - path: Tests/Unit
     dependencies:
       - target: Fire
+      - package: SnapshotTesting
+        product: SnapshotTesting
     settings:
       base:
         GENERATE_INFOPLIST_FILE: YES
         SWIFT_INCLUDE_PATHS:
           - "$(inherited)"
           - "$(SRCROOT)/Generated"
+  FireUITests:
+    type: bundle.ui-testing
+    platform: iOS
+    deploymentTarget: "17.0"
+    sources:
+      - path: Tests/UI
+    dependencies:
+      - target: Fire
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES


### PR DESCRIPTION
## Summary
- extract search and notification state from `FireAppViewModel` into dedicated stores
- add shared entity-index and ordered-ID primitives plus home feed/list-kit store wiring
- switch affected iOS screens and docs to the W2 store-split architecture

## Verification
- `xcodebuild test -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'platform=iOS Simulator,id=EF568FD9-DF26-4B62-B7AB-7C66851CF3D9' -only-testing:FireTests`
