### PR TITLE
fix: harden iOS private message detail and mailbox flow

### DIFF
--- a/native/ios-app/App/FirePrivateMessagesView.swift
+++ b/native/ios-app/App/FirePrivateMessagesView.swift
@@ -29,6 +29,20 @@ final class FirePrivateMessagesViewModel: ObservableObject {
         self.fetchPrivateMessages = fetchPrivateMessages
     }
 
+    private func deduplicatedRows(_ rows: [TopicRowState]) -> [TopicRowState] {
+        var seenTopicIDs = Set<UInt64>()
+        return rows.filter { row in
+            seenTopicIDs.insert(row.topic.id).inserted
+        }
+    }
+
+    private func deduplicatedUsers(_ users: [TopicUserState]) -> [TopicUserState] {
+        var seenUserIDs = Set<UInt64>()
+        return users.filter { user in
+            seenUserIDs.insert(user.id).inserted
+        }
+    }
+
     func loadIfNeeded() async {
         guard rows.isEmpty, !isLoading else { return }
         await load(reset: true)
@@ -80,17 +94,39 @@ final class FirePrivateMessagesViewModel: ObservableObject {
             guard generation == loadGeneration, requestKind == selectedKind else {
                 return
             }
+
+            let uniqueRows = deduplicatedRows(response.rows)
+            let uniqueUsers = deduplicatedUsers(response.users)
+            let freshRows: [TopicRowState]
+            let freshUsers: [TopicUserState]
+
             if reset {
-                rows = response.rows
-                users = response.users
+                rows = uniqueRows
+                users = uniqueUsers
+                freshRows = uniqueRows
+                freshUsers = uniqueUsers
             } else {
                 let existingIDs = Set(rows.map(\.topic.id))
-                rows.append(contentsOf: response.rows.filter { !existingIDs.contains($0.topic.id) })
+                freshRows = uniqueRows.filter { !existingIDs.contains($0.topic.id) }
+                rows.append(contentsOf: freshRows)
                 let existingUserIDs = Set(users.map(\.id))
-                users.append(contentsOf: response.users.filter { !existingUserIDs.contains($0.id) })
+                freshUsers = uniqueUsers.filter { !existingUserIDs.contains($0.id) }
+                users.append(contentsOf: freshUsers)
             }
-            nextPage = response.nextPage
-            hasMore = response.nextPage != nil || response.moreTopicsUrl != nil
+
+            let resolvedNextPage: UInt32? = {
+                guard let candidate = response.nextPage else {
+                    return nil
+                }
+                guard let requestPage else {
+                    return candidate
+                }
+                return candidate > requestPage ? candidate : nil
+            }()
+
+            let receivedFreshContent = !freshRows.isEmpty || !freshUsers.isEmpty
+            nextPage = resolvedNextPage
+            hasMore = resolvedNextPage != nil && (reset || receivedFreshContent)
             errorMessage = nil
         } catch {
             guard generation == loadGeneration, requestKind == selectedKind else {
@@ -125,7 +161,9 @@ struct FirePrivateMessagesView: View {
     }
 
     private var usersByID: [UInt64: TopicUserState] {
-        Dictionary(uniqueKeysWithValues: mailboxViewModel.users.map { ($0.id, $0) })
+        mailboxViewModel.users.reduce(into: [:]) { partialResult, user in
+            partialResult[user.id] = user
+        }
     }
 
     var body: some View {

--- a/native/ios-app/App/FireTopicDetailView.swift
+++ b/native/ios-app/App/FireTopicDetailView.swift
@@ -219,10 +219,14 @@ struct FireTopicDetailView: View {
     }
 
     private var isPrivateMessageThread: Bool {
-        detail?.archetype == "private_message" || !displayedParticipants.isEmpty
+        FireTopicPresentation.isPrivateMessageArchetype(detail?.archetype)
     }
 
     private var displayedParticipants: [TopicParticipantState] {
+        guard isPrivateMessageThread else {
+            return []
+        }
+
         let source = !(detail?.details.participants.isEmpty ?? true)
             ? detail?.details.participants ?? []
             : topic.participants

--- a/native/ios-app/App/FireTopicPresentation.swift
+++ b/native/ios-app/App/FireTopicPresentation.swift
@@ -42,6 +42,14 @@ struct FireTopicThreadComposition {
 }
 
 enum FireTopicPresentation {
+    static func isPrivateMessageArchetype(_ archetype: String?) -> Bool {
+        let trimmed = archetype?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !trimmed.isEmpty else {
+            return false
+        }
+        return trimmed.caseInsensitiveCompare("private_message") == .orderedSame
+    }
+
     static func formatTimestamp(_ rawValue: String?) -> String? {
         guard let rawValue, !rawValue.isEmpty else {
             return nil

--- a/native/ios-app/Tests/Unit/FireTopicPresentationTests.swift
+++ b/native/ios-app/Tests/Unit/FireTopicPresentationTests.swift
@@ -54,6 +54,13 @@ final class FireTopicPresentationTests: XCTestCase {
         XCTAssertEqual(FireTopicPresentation.minimumReplyLength(from: 0), 1)
     }
 
+    func testPrivateMessageArchetypeRequiresPrivateMessageValue() {
+        XCTAssertTrue(FireTopicPresentation.isPrivateMessageArchetype("private_message"))
+        XCTAssertTrue(FireTopicPresentation.isPrivateMessageArchetype(" Private_Message "))
+        XCTAssertFalse(FireTopicPresentation.isPrivateMessageArchetype("regular"))
+        XCTAssertFalse(FireTopicPresentation.isPrivateMessageArchetype(nil))
+    }
+
     func testTopicRowStateCarriesRustStatusLabels() {
         let row = TopicRowState(
             topic: TopicSummaryState(
@@ -443,6 +450,67 @@ final class FireTopicPresentationTests: XCTestCase {
         XCTAssertEqual(viewModel.errorMessage, "offline")
     }
 
+    @MainActor
+    func testPrivateMessagesViewModelStopsWhenNextPageCannotBeResolved() async {
+        let loader = PrivateMessageMailboxLoader(
+            steps: [
+                .success(
+                    makePrivateMessageMailboxResponse(
+                        topicID: 101,
+                        username: "alice",
+                        moreTopicsUrl: "/topics/private-messages/alice",
+                        nextPage: nil
+                    )
+                )
+            ]
+        )
+        let viewModel = FirePrivateMessagesViewModel { kind, page in
+            try await loader.fetch(kind: kind, page: page)
+        }
+
+        await viewModel.refresh()
+        await viewModel.loadMoreIfNeeded(currentTopicID: 101)
+
+        let callCount = await loader.callCount()
+        XCTAssertEqual(callCount, 1)
+        XCTAssertEqual(viewModel.rows.map(\.topic.id), [101])
+    }
+
+    @MainActor
+    func testPrivateMessagesViewModelStopsAfterAppendReturnsNoFreshRows() async {
+        let loader = PrivateMessageMailboxLoader(
+            steps: [
+                .success(
+                    makePrivateMessageMailboxResponse(
+                        topicID: 101,
+                        username: "alice",
+                        moreTopicsUrl: "/topics/private-messages/alice?page=2",
+                        nextPage: 2
+                    )
+                ),
+                .success(
+                    makePrivateMessageMailboxResponse(
+                        topicID: 101,
+                        username: "alice",
+                        moreTopicsUrl: "/topics/private-messages/alice?page=3",
+                        nextPage: 3
+                    )
+                )
+            ]
+        )
+        let viewModel = FirePrivateMessagesViewModel { kind, page in
+            try await loader.fetch(kind: kind, page: page)
+        }
+
+        await viewModel.refresh()
+        await viewModel.loadMoreIfNeeded(currentTopicID: 101)
+        await viewModel.loadMoreIfNeeded(currentTopicID: 101)
+
+        let callCount = await loader.callCount()
+        XCTAssertEqual(callCount, 2)
+        XCTAssertEqual(viewModel.rows.map(\.topic.id), [101])
+    }
+
     private func makeBootstrap(
         currentUsername: String?,
         preloadedJson: String?,
@@ -555,7 +623,9 @@ final class FireTopicPresentationTests: XCTestCase {
 
     private func makePrivateMessageMailboxResponse(
         topicID: UInt64,
-        username: String
+        username: String,
+        moreTopicsUrl: String? = nil,
+        nextPage: UInt32? = nil
     ) -> TopicListState {
         let user = TopicUserState(id: topicID, username: username, avatarTemplate: nil)
         let participant = TopicParticipantState(
@@ -618,8 +688,8 @@ final class FireTopicPresentationTests: XCTestCase {
             topics: [topic],
             users: [user],
             rows: [row],
-            moreTopicsUrl: nil,
-            nextPage: nil
+            moreTopicsUrl: moreTopicsUrl,
+            nextPage: nextPage
         )
     }
 }


### PR DESCRIPTION
## Summary
- restrict iOS topic detail PM UI to real `private_message` threads instead of any topic carrying participants metadata
- harden private message mailbox pagination so it stops when page progression or fresh content is missing
- add regression tests for PM archetype detection and mailbox pagination guardrails

## Testing
- xcodebuild test -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' -only-testing:FireTests/FireTopicPresentationTests