### PR TITLE
fix(ios): stabilize home tag sync and list animations

### DIFF
--- a/docs/backend-api/03-bootstrap-and-site.md
+++ b/docs/backend-api/03-bootstrap-and-site.md
@@ -34,8 +34,8 @@
 - 客户端接入备注：
   - 登录回调页、用户页、话题页等“非首页” HTML 里也可能带 `data-preloaded`，但有时只包含 `currentUser` 等局部字段，不一定带完整的 `site` / `siteSettings`
   - 某些 LinuxDo 页面里，`data-preloaded.currentUser`、`siteSettings`、`site`、`topicTrackingStateMeta` 本身不是对象，而是“JSON 字符串”；客户端在提取字段前需要先解包这层字符串
-  - iOS 当前把登录页收口做成“自动探测、手动 Sync”：只有同时拿到 `current-username`、有效 `_t` / `_forum_session` Cookie，以及可复用的首页 bootstrap HTML 时，才允许用户点击“完成登录”
-  - iOS 当前在登录页优先通过浏览器上下文内的 `fetch("/")` 抓首页 HTML；只有这份首页 HTML 不够完整时，才回退到当前页面 `document.documentElement.outerHTML`
+  - iOS 当前把登录页收口做成“自动探测、手动 Sync”：实时探测会先轻量检查当前页的用户名 / bootstrap 标记与同站 auth Cookie，只在 auth Cookie 已就绪但当前页元数据仍不完整时，才补一次浏览器上下文内的首页 `fetch("/")`；只有最终同时拿到 `current-username`、有效 `_t` / `_forum_session` Cookie，以及可复用的首页 bootstrap HTML 时，才允许用户点击“完成登录”
+  - iOS 当前在真正提交登录时仍会优先通过浏览器上下文内的 `fetch("/")` 抓首页 HTML；只有这份首页 HTML 不够完整时，才回退到当前页面 `document.documentElement.outerHTML`，并会用优选后的 HTML 回填缺失的 `current-username` / `csrf-token`
   - 在把 bootstrap 视为“已就绪”前，应该确认至少拿到了当前用户、站点级 `site` 元数据（分类/标签能力）和 `siteSettings`（最小长度、reactions、长轮询域等）；缺失时继续回源 `GET /` 刷新，而不要仅凭 `hasPreloadedData=true` 就跳过
   - 当前 Fire 实现还会在首页 bootstrap 仍缺少 `site` 元数据时自动补一次 `GET /site.json`，用于回填 `categories`、`top_tags`、`can_tag_topics`
   - iOS 当前在真正提交登录前后都会先后各做一次平台 Cookie 刷新：先把 `WKHTTPCookieStore` 里的同站 Cookie 回灌到共享层，再执行 `sync_login_context` / bootstrap 刷新，最后再把浏览器最新 Cookie 状态回灌一次，确保 `_t`、`_forum_session`、`cf_clearance` 以浏览器为准

--- a/docs/backend-api/03-bootstrap-and-site.md
+++ b/docs/backend-api/03-bootstrap-and-site.md
@@ -34,8 +34,11 @@
 - 客户端接入备注：
   - 登录回调页、用户页、话题页等“非首页” HTML 里也可能带 `data-preloaded`，但有时只包含 `currentUser` 等局部字段，不一定带完整的 `site` / `siteSettings`
   - 某些 LinuxDo 页面里，`data-preloaded.currentUser`、`siteSettings`、`site`、`topicTrackingStateMeta` 本身不是对象，而是“JSON 字符串”；客户端在提取字段前需要先解包这层字符串
+  - iOS 当前把登录页收口做成“自动探测、手动 Sync”：只有同时拿到 `current-username`、有效 `_t` / `_forum_session` Cookie，以及可复用的首页 bootstrap HTML 时，才允许用户点击“完成登录”
+  - iOS 当前在登录页优先通过浏览器上下文内的 `fetch("/")` 抓首页 HTML；只有这份首页 HTML 不够完整时，才回退到当前页面 `document.documentElement.outerHTML`
   - 在把 bootstrap 视为“已就绪”前，应该确认至少拿到了当前用户、站点级 `site` 元数据（分类/标签能力）和 `siteSettings`（最小长度、reactions、长轮询域等）；缺失时继续回源 `GET /` 刷新，而不要仅凭 `hasPreloadedData=true` 就跳过
   - 当前 Fire 实现还会在首页 bootstrap 仍缺少 `site` 元数据时自动补一次 `GET /site.json`，用于回填 `categories`、`top_tags`、`can_tag_topics`
+  - iOS 当前在真正提交登录前后都会先后各做一次平台 Cookie 刷新：先把 `WKHTTPCookieStore` 里的同站 Cookie 回灌到共享层，再执行 `sync_login_context` / bootstrap 刷新，最后再把浏览器最新 Cookie 状态回灌一次，确保 `_t`、`_forum_session`、`cf_clearance` 以浏览器为准
   - 当前 Fire 还会从 `siteSettings` 提取 composer 约束：
     - `min_post_length`
     - `min_topic_title_length`
@@ -88,6 +91,9 @@
   - `discourse-logged-out: 1`
   - `Set-Cookie: _t=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT`
 - 客户端不要继续把这种响应后的会话当作“仍可写入”；应立即清掉本地登录态并提示重新登录
+- Fire 共享层现在把 `discourse-logged-out`、清空 `_t` / `_forum_session` 的 `Set-Cookie`、`error_type=not_logged_in` 统一视为登录失效信号，并先推进内部 session epoch，再清掉本地登录态
+- Fire 共享层现在会在 `sync_login_context`、`apply_platform_cookies` 导致 auth Cookie 轮换时、显式登出、被动失效时推进 session epoch；晚到的旧请求响应仍可写入非认证 Cookie（例如 `cf_clearance`），但不得再覆盖 `_t` / `_forum_session`，也不得把旧会话“复活”
+- 当前 `BAD CSRF` 只触发一次性 CSRF 刷新与单次重试；如果同一请求同时已经暴露登录失效信号，则优先按登录失效收口，而不是继续保留本地登录态
 - 否则后续最常见的表现是：前面的列表、详情等匿名可读请求仍然成功，但稍后的 `/topics/timings`、点赞、回复等写请求才返回 `403` / `error_type=not_logged_in`
 
 ### `GET /challenge`
@@ -121,6 +127,8 @@
 - 备注：
   - 当前客户端没有把这一步当成独立业务接口暴露，而是视为 Cloudflare 内部续期流程
   - 当前客户端回放请求时未显式固定 `Content-Type` 为 `application/x-www-form-urlencoded`；拦截到的原始运行时请求体更接近 JSON 形态
+  - 当前 Fire iOS 一期没有直接在宿主里回放这条 `rc` 内部接口；iOS 改为在会话已连接、已有 `cf_clearance`、且首页 bootstrap 已暴露 Turnstile `sitekey` 时，启动一个离屏 `WKWebView` 定时加载首页，并把浏览器里更新后的 Cookie 再次同步回共享层
+  - 共享层仍会保留并发送 `cf_clearance`；挑战完成、平台 Cookie 读取、离屏 WebView 续期都仍属于宿主职责
 
 ## 站点信息、分类、标签、表情
 

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -246,9 +246,6 @@ final class FireAppViewModel: ObservableObject {
         guard !isSyncingLoginSession else {
             return
         }
-        guard canSyncLoginSession else {
-            return
-        }
 
         isSyncingLoginSession = true
         Task {

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -78,11 +78,13 @@ enum FireSearchScope: String, CaseIterable, Identifiable {
     }
 }
 
-protocol FireChallengeSessionRecovering: Sendable {
-    func logoutLocal(preserveCfClearance: Bool) async throws -> SessionState
+protocol FireChallengeSessionRecovering {
+    func logoutLocalAndClearPlatformCookies(
+        preserveCfClearance: Bool
+    ) async throws -> SessionState
 }
 
-extension FireSessionStore: FireChallengeSessionRecovering {}
+extension FireWebViewLoginCoordinator: FireChallengeSessionRecovering {}
 
 @MainActor
 final class FireAppViewModel: ObservableObject {
@@ -104,6 +106,7 @@ final class FireAppViewModel: ObservableObject {
     @Published var isPresentingLogin = false
     @Published var isPreparingLogin = false
     @Published var isSyncingLoginSession = false
+    @Published private(set) var canSyncLoginSession = false
     @Published var isLoggingOut = false
 
     // MARK: - Private
@@ -114,6 +117,7 @@ final class FireAppViewModel: ObservableObject {
     private var initialStateTask: Task<Void, Never>?
     private var initialStateLoadingDelayTask: Task<Void, Never>?
     private var initialStateLoadGeneration: UInt64 = 0
+    private var loginSyncReadinessTask: Task<Void, Never>?
     private let loginURL = URL(string: "https://linux.do")!
     private let challengeRecoveryStore: (any FireChallengeSessionRecovering)?
     // MessageBus
@@ -222,6 +226,7 @@ final class FireAppViewModel: ObservableObject {
         }
 
         errorMessage = nil
+        canSyncLoginSession = false
         isPreparingLogin = true
 
         Task {
@@ -241,6 +246,9 @@ final class FireAppViewModel: ObservableObject {
         guard !isSyncingLoginSession else {
             return
         }
+        guard canSyncLoginSession else {
+            return
+        }
 
         isSyncingLoginSession = true
         Task {
@@ -253,6 +261,7 @@ final class FireAppViewModel: ObservableObject {
                     await applySession(try await loginCoordinator.completeLogin(from: webView))
                     isPresentingLogin = false
                     await refreshHomeFeedIfPossible(force: true)
+                    canSyncLoginSession = false
                 }
             } catch {
                 if await handleRecoverableSessionErrorIfNeeded(error) {
@@ -296,6 +305,7 @@ final class FireAppViewModel: ObservableObject {
                 stopMessageBus()
                 errorMessage = nil
                 await applySession(try await loginCoordinator.logout())
+                canSyncLoginSession = false
                 clearTopicState()
                 notificationStore?.reset()
             } catch {
@@ -1034,6 +1044,7 @@ final class FireAppViewModel: ObservableObject {
     }
 
     func handleDiagnosticsScenePhaseChange(_ phase: String, isAuthenticated: Bool) {
+        FireCfClearanceRefreshService.shared.setSceneActive(phase == "active")
         Task {
             guard let sessionStore else { return }
             let logger = sessionStore.makeLogger(target: Self.diagnosticsLifecycleLogTarget)
@@ -1212,6 +1223,38 @@ final class FireAppViewModel: ObservableObject {
         } else if !session.readiness.canOpenMessageBus {
             stopMessageBus()
         }
+
+        if let coordinator = try? await loginCoordinatorValue() {
+            FireCfClearanceRefreshService.shared.updateSession(
+                session,
+                loginCoordinator: coordinator
+            )
+        }
+    }
+
+    func refreshLoginSyncReadiness(from webView: WKWebView) {
+        loginSyncReadinessTask?.cancel()
+        loginSyncReadinessTask = Task { [weak self] in
+            guard let self else { return }
+            do {
+                let coordinator = try await loginCoordinatorValue()
+                let readiness = try await coordinator.probeLoginSyncReadiness(from: webView)
+                guard !Task.isCancelled else { return }
+                let previous = canSyncLoginSession
+                canSyncLoginSession = readiness.isReady
+                if previous != readiness.isReady {
+                    FireAPMManager.shared.recordBreadcrumb(
+                        target: "auth.login",
+                        message: readiness.isReady
+                            ? "login sync readiness satisfied"
+                            : "login sync readiness cleared"
+                    )
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                canSyncLoginSession = false
+            }
+        }
     }
 
     private func scheduleMessageBusRetry() {
@@ -1315,7 +1358,9 @@ final class FireAppViewModel: ObservableObject {
 
         do {
             let recoveryStore = try await challengeRecoveryStoreValue()
-            let cleared = try await recoveryStore.logoutLocal(preserveCfClearance: true)
+            let cleared = try await recoveryStore.logoutLocalAndClearPlatformCookies(
+                preserveCfClearance: true
+            )
             await applySession(cleared)
         } catch {
             await applySession(.placeholder(baseUrl: session.bootstrap.baseUrl))
@@ -1323,6 +1368,7 @@ final class FireAppViewModel: ObservableObject {
 
         clearTopicState()
         notificationStore?.reset()
+        canSyncLoginSession = false
         errorMessage = message
         isPresentingLogin = true
     }
@@ -1513,7 +1559,7 @@ final class FireAppViewModel: ObservableObject {
             return challengeRecoveryStore
         }
 
-        return try await sessionStoreValue()
+        return try await loginCoordinatorValue()
     }
 
     private func loginCoordinatorValue() async throws -> FireWebViewLoginCoordinator {

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -88,6 +88,9 @@ extension FireWebViewLoginCoordinator: FireChallengeSessionRecovering {}
 
 @MainActor
 final class FireAppViewModel: ObservableObject {
+    typealias LoginCoordinatorPreloader = @Sendable () async throws -> Void
+    typealias LoginNetworkWarmup = @Sendable () async -> Void
+
     private static let messageBusErrorPrefix = "实时同步连接失败："
     private static let loginRequiredMessage = "登录状态已失效，请重新登录。"
     private static let authDiagnosticsLogTarget = "ios.auth"
@@ -120,6 +123,8 @@ final class FireAppViewModel: ObservableObject {
     private var loginSyncReadinessTask: Task<Void, Never>?
     private let loginURL = URL(string: "https://linux.do")!
     private let challengeRecoveryStore: (any FireChallengeSessionRecovering)?
+    private let loginCoordinatorPreloader: LoginCoordinatorPreloader?
+    private let loginNetworkWarmup: LoginNetworkWarmup?
     // MessageBus
     private var messageBusCoordinator: FireMessageBusCoordinator?
     private var isMessageBusActive = false
@@ -132,10 +137,14 @@ final class FireAppViewModel: ObservableObject {
 
     init(
         initialSession: SessionState = .placeholder(),
-        challengeRecoveryStore: (any FireChallengeSessionRecovering)? = nil
+        challengeRecoveryStore: (any FireChallengeSessionRecovering)? = nil,
+        loginCoordinatorPreloader: LoginCoordinatorPreloader? = nil,
+        loginNetworkWarmup: LoginNetworkWarmup? = nil
     ) {
         self.session = initialSession
         self.challengeRecoveryStore = challengeRecoveryStore
+        self.loginCoordinatorPreloader = loginCoordinatorPreloader
+        self.loginNetworkWarmup = loginNetworkWarmup
     }
 
     func bindHomeFeedStore(_ store: FireHomeFeedStore) {
@@ -222,20 +231,23 @@ final class FireAppViewModel: ObservableObject {
 
     func openLogin() {
         guard !isPreparingLogin else {
+            if !isPresentingLogin {
+                isPresentingLogin = true
+            }
             return
         }
 
         errorMessage = nil
         canSyncLoginSession = false
+        isPresentingLogin = true
         isPreparingLogin = true
 
         Task {
             defer { isPreparingLogin = false }
 
             do {
-                _ = try await loginCoordinatorValue()
-                try await prepareLoginNetworkAccess()
-                isPresentingLogin = true
+                try await preloadLoginCoordinator()
+                await warmLoginNetworkAccess()
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -1172,6 +1184,32 @@ final class FireAppViewModel: ObservableObject {
         let (_, response) = try await session.data(for: request)
         guard response is HTTPURLResponse else {
             throw FireLoginPreparationError.invalidResponse
+        }
+    }
+
+    private func preloadLoginCoordinator() async throws {
+        if let loginCoordinatorPreloader {
+            try await loginCoordinatorPreloader()
+            return
+        }
+
+        _ = try await loginCoordinatorValue()
+    }
+
+    private func warmLoginNetworkAccess() async {
+        if let loginNetworkWarmup {
+            await loginNetworkWarmup()
+            return
+        }
+
+        do {
+            try await prepareLoginNetworkAccess()
+        } catch {
+            FireAPMManager.shared.recordBreadcrumb(
+                level: "warn",
+                target: "auth.login",
+                message: "login network warmup failed: \(error.localizedDescription)"
+            )
         }
     }
 

--- a/native/ios-app/App/FireComponents.swift
+++ b/native/ios-app/App/FireComponents.swift
@@ -497,6 +497,8 @@ struct FireToolbarIcon: View {
 // MARK: - Button Styles
 
 struct FirePrimaryButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.subheadline.weight(.semibold))
@@ -513,8 +515,10 @@ struct FirePrimaryButtonStyle: ButtonStyle {
                         )
                     )
             )
+            .opacity(isEnabled ? 1 : 0.55)
             .scaleEffect(configuration.isPressed ? 0.97 : 1)
             .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+            .animation(.easeOut(duration: 0.15), value: isEnabled)
     }
 }
 

--- a/native/ios-app/App/FireLoginWebView.swift
+++ b/native/ios-app/App/FireLoginWebView.swift
@@ -42,6 +42,47 @@ final class FireWebViewBox: ObservableObject {
     }
 }
 
+final class FireLoginWebViewProbeBridge: NSObject, WKHTTPCookieStoreObserver {
+    private weak var observedWebView: WKWebView?
+    private weak var observedCookieStore: WKHTTPCookieStore?
+    private let onProbeRequested: (WKWebView) -> Void
+
+    init(onProbeRequested: @escaping (WKWebView) -> Void) {
+        self.onProbeRequested = onProbeRequested
+    }
+
+    deinit {
+        observedCookieStore?.remove(self)
+    }
+
+    func attach(to webView: WKWebView) {
+        let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
+        if observedCookieStore !== cookieStore {
+            observedCookieStore?.remove(self)
+            cookieStore.add(self)
+            observedCookieStore = cookieStore
+        }
+        observedWebView = webView
+    }
+
+    func detach() {
+        observedCookieStore?.remove(self)
+        observedCookieStore = nil
+        observedWebView = nil
+    }
+
+    func requestProbe() {
+        guard let observedWebView else {
+            return
+        }
+        onProbeRequested(observedWebView)
+    }
+
+    func cookiesDidChange(in cookieStore: WKHTTPCookieStore) {
+        requestProbe()
+    }
+}
+
 struct FireLoginWebView: UIViewRepresentable {
     let url: URL
     @ObservedObject var webViewBox: FireWebViewBox
@@ -50,6 +91,7 @@ struct FireLoginWebView: UIViewRepresentable {
     func makeUIView(context: Context) -> WKWebView {
         let webView = WKWebView(frame: .zero)
         webView.navigationDelegate = context.coordinator
+        context.coordinator.attach(to: webView)
         webView.allowsBackForwardNavigationGestures = true
         webView.load(URLRequest(url: url))
         webViewBox.attach(webView)
@@ -57,7 +99,13 @@ struct FireLoginWebView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: WKWebView, context: Context) {
+        context.coordinator.attach(to: uiView)
         webViewBox.webView = uiView
+    }
+
+    static func dismantleUIView(_ uiView: WKWebView, coordinator: Coordinator) {
+        coordinator.detach()
+        uiView.navigationDelegate = nil
     }
 
     func makeCoordinator() -> Coordinator {
@@ -68,30 +116,41 @@ struct FireLoginWebView: UIViewRepresentable {
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
-        private let webViewBox: FireWebViewBox
-        private let onNavigationStateChange: (WKWebView) -> Void
+        private let probeBridge: FireLoginWebViewProbeBridge
 
         init(
             webViewBox: FireWebViewBox,
             onNavigationStateChange: @escaping (WKWebView) -> Void
         ) {
-            self.webViewBox = webViewBox
-            self.onNavigationStateChange = onNavigationStateChange
+            self.probeBridge = FireLoginWebViewProbeBridge { webView in
+                webViewBox.syncState(from: webView)
+                onNavigationStateChange(webView)
+            }
+        }
+
+        func attach(to webView: WKWebView) {
+            probeBridge.attach(to: webView)
+        }
+
+        func detach() {
+            probeBridge.detach()
+        }
+
+        private func handleStateChange(for webView: WKWebView) {
+            probeBridge.attach(to: webView)
+            probeBridge.requestProbe()
         }
 
         func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-            webViewBox.syncState(from: webView)
-            onNavigationStateChange(webView)
+            handleStateChange(for: webView)
         }
 
         func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
-            webViewBox.syncState(from: webView)
-            onNavigationStateChange(webView)
+            handleStateChange(for: webView)
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            webViewBox.syncState(from: webView)
-            onNavigationStateChange(webView)
+            handleStateChange(for: webView)
         }
 
         func webView(
@@ -99,8 +158,7 @@ struct FireLoginWebView: UIViewRepresentable {
             didFail navigation: WKNavigation!,
             withError error: Error
         ) {
-            webViewBox.syncState(from: webView)
-            onNavigationStateChange(webView)
+            handleStateChange(for: webView)
         }
 
         func webView(
@@ -108,13 +166,11 @@ struct FireLoginWebView: UIViewRepresentable {
             didFailProvisionalNavigation navigation: WKNavigation!,
             withError error: Error
         ) {
-            webViewBox.syncState(from: webView)
-            onNavigationStateChange(webView)
+            handleStateChange(for: webView)
         }
 
         func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-            webViewBox.syncState(from: webView)
-            onNavigationStateChange(webView)
+            handleStateChange(for: webView)
         }
     }
 }

--- a/native/ios-app/App/FireLoginWebView.swift
+++ b/native/ios-app/App/FireLoginWebView.swift
@@ -45,6 +45,7 @@ final class FireWebViewBox: ObservableObject {
 struct FireLoginWebView: UIViewRepresentable {
     let url: URL
     @ObservedObject var webViewBox: FireWebViewBox
+    let onNavigationStateChange: (WKWebView) -> Void
 
     func makeUIView(context: Context) -> WKWebView {
         let webView = WKWebView(frame: .zero)
@@ -60,26 +61,37 @@ struct FireLoginWebView: UIViewRepresentable {
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(webViewBox: webViewBox)
+        Coordinator(
+            webViewBox: webViewBox,
+            onNavigationStateChange: onNavigationStateChange
+        )
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
         private let webViewBox: FireWebViewBox
+        private let onNavigationStateChange: (WKWebView) -> Void
 
-        init(webViewBox: FireWebViewBox) {
+        init(
+            webViewBox: FireWebViewBox,
+            onNavigationStateChange: @escaping (WKWebView) -> Void
+        ) {
             self.webViewBox = webViewBox
+            self.onNavigationStateChange = onNavigationStateChange
         }
 
         func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
             webViewBox.syncState(from: webView)
+            onNavigationStateChange(webView)
         }
 
         func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
             webViewBox.syncState(from: webView)
+            onNavigationStateChange(webView)
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
             webViewBox.syncState(from: webView)
+            onNavigationStateChange(webView)
         }
 
         func webView(
@@ -88,6 +100,7 @@ struct FireLoginWebView: UIViewRepresentable {
             withError error: Error
         ) {
             webViewBox.syncState(from: webView)
+            onNavigationStateChange(webView)
         }
 
         func webView(
@@ -96,16 +109,19 @@ struct FireLoginWebView: UIViewRepresentable {
             withError error: Error
         ) {
             webViewBox.syncState(from: webView)
+            onNavigationStateChange(webView)
         }
 
         func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
             webViewBox.syncState(from: webView)
+            onNavigationStateChange(webView)
         }
     }
 }
 
 struct FireLoginScreen: View {
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
     @ObservedObject var viewModel: FireAppViewModel
     @StateObject private var webViewBox = FireWebViewBox()
 
@@ -129,7 +145,10 @@ struct FireLoginScreen: View {
 
                 FireLoginWebView(
                     url: URL(string: "https://linux.do")!,
-                    webViewBox: webViewBox
+                    webViewBox: webViewBox,
+                    onNavigationStateChange: { webView in
+                        viewModel.refreshLoginSyncReadiness(from: webView)
+                    }
                 )
                 .frame(maxHeight: .infinity)
             }
@@ -160,6 +179,12 @@ struct FireLoginScreen: View {
             }
             .onAppear {
                 viewModel.setAPMRoute("auth.login")
+            }
+            .onChange(of: scenePhase) { _, phase in
+                guard phase == .active, let webView = webViewBox.webView else {
+                    return
+                }
+                viewModel.refreshLoginSyncReadiness(from: webView)
             }
             .onDisappear {
                 viewModel.restoreTopLevelAPMRoute()
@@ -227,7 +252,11 @@ private struct FireLoginBottomBar: View {
                     }
                 }
                 .buttonStyle(FirePrimaryButtonStyle())
-                .disabled(webViewBox.webView == nil || viewModel.isSyncingLoginSession)
+                .disabled(
+                    webViewBox.webView == nil
+                        || viewModel.isSyncingLoginSession
+                        || !viewModel.canSyncLoginSession
+                )
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 10)

--- a/native/ios-app/App/FireLoginWebView.swift
+++ b/native/ios-app/App/FireLoginWebView.swift
@@ -15,11 +15,30 @@ final class FireWebViewBox: ObservableObject {
     }
 
     func syncState(from webView: WKWebView) {
-        canGoBack = webView.canGoBack
-        canGoForward = webView.canGoForward
-        isLoading = webView.isLoading
-        pageTitle = webView.title ?? "LinuxDo Login"
-        currentURL = webView.url?.host ?? webView.url?.absoluteString
+        let nextCanGoBack = webView.canGoBack
+        if canGoBack != nextCanGoBack {
+            canGoBack = nextCanGoBack
+        }
+
+        let nextCanGoForward = webView.canGoForward
+        if canGoForward != nextCanGoForward {
+            canGoForward = nextCanGoForward
+        }
+
+        let nextIsLoading = webView.isLoading
+        if isLoading != nextIsLoading {
+            isLoading = nextIsLoading
+        }
+
+        let nextPageTitle = webView.title ?? "LinuxDo Login"
+        if pageTitle != nextPageTitle {
+            pageTitle = nextPageTitle
+        }
+
+        let nextCurrentURL = webView.url?.host ?? webView.url?.absoluteString
+        if currentURL != nextCurrentURL {
+            currentURL = nextCurrentURL
+        }
     }
 
     func goBack() {
@@ -42,20 +61,24 @@ final class FireWebViewBox: ObservableObject {
     }
 }
 
-final class FireLoginWebViewProbeBridge: NSObject, WKHTTPCookieStoreObserver {
+public final class FireLoginWebViewProbeBridge: NSObject, WKHTTPCookieStoreObserver {
+    private static let cookieProbeDebounceDelay: TimeInterval = 0.35
+
     private weak var observedWebView: WKWebView?
     private weak var observedCookieStore: WKHTTPCookieStore?
+    private var pendingProbeWorkItem: DispatchWorkItem?
     private let onProbeRequested: (WKWebView) -> Void
 
-    init(onProbeRequested: @escaping (WKWebView) -> Void) {
+    public init(onProbeRequested: @escaping (WKWebView) -> Void) {
         self.onProbeRequested = onProbeRequested
     }
 
     deinit {
+        pendingProbeWorkItem?.cancel()
         observedCookieStore?.remove(self)
     }
 
-    func attach(to webView: WKWebView) {
+    public func attach(to webView: WKWebView) {
         let cookieStore = webView.configuration.websiteDataStore.httpCookieStore
         if observedCookieStore !== cookieStore {
             observedCookieStore?.remove(self)
@@ -65,21 +88,42 @@ final class FireLoginWebViewProbeBridge: NSObject, WKHTTPCookieStoreObserver {
         observedWebView = webView
     }
 
-    func detach() {
+    public func detach() {
+        pendingProbeWorkItem?.cancel()
+        pendingProbeWorkItem = nil
         observedCookieStore?.remove(self)
         observedCookieStore = nil
         observedWebView = nil
     }
 
-    func requestProbe() {
+    public func requestProbe() {
+        requestProbe(after: 0)
+    }
+
+    private func requestProbe(after delay: TimeInterval) {
+        pendingProbeWorkItem?.cancel()
         guard let observedWebView else {
             return
         }
-        onProbeRequested(observedWebView)
+
+        let workItem = DispatchWorkItem { [weak self, weak observedWebView] in
+            guard self != nil, let observedWebView else {
+                return
+            }
+            self?.pendingProbeWorkItem = nil
+            self?.onProbeRequested(observedWebView)
+        }
+        pendingProbeWorkItem = workItem
+
+        if delay <= 0 {
+            DispatchQueue.main.async(execute: workItem)
+        } else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: workItem)
+        }
     }
 
-    func cookiesDidChange(in cookieStore: WKHTTPCookieStore) {
-        requestProbe()
+    public func cookiesDidChange(in cookieStore: WKHTTPCookieStore) {
+        requestProbe(after: Self.cookieProbeDebounceDelay)
     }
 }
 
@@ -116,16 +160,15 @@ struct FireLoginWebView: UIViewRepresentable {
     }
 
     final class Coordinator: NSObject, WKNavigationDelegate {
+        private let webViewBox: FireWebViewBox
         private let probeBridge: FireLoginWebViewProbeBridge
 
         init(
             webViewBox: FireWebViewBox,
             onNavigationStateChange: @escaping (WKWebView) -> Void
         ) {
-            self.probeBridge = FireLoginWebViewProbeBridge { webView in
-                webViewBox.syncState(from: webView)
-                onNavigationStateChange(webView)
-            }
+            self.webViewBox = webViewBox
+            self.probeBridge = FireLoginWebViewProbeBridge(onProbeRequested: onNavigationStateChange)
         }
 
         func attach(to webView: WKWebView) {
@@ -136,21 +179,26 @@ struct FireLoginWebView: UIViewRepresentable {
             probeBridge.detach()
         }
 
-        private func handleStateChange(for webView: WKWebView) {
+        private func syncBrowserState(from webView: WKWebView) {
+            webViewBox.syncState(from: webView)
+        }
+
+        private func handleTerminalStateChange(for webView: WKWebView) {
+            syncBrowserState(from: webView)
             probeBridge.attach(to: webView)
             probeBridge.requestProbe()
         }
 
         func webView(_ webView: WKWebView, didStartProvisionalNavigation navigation: WKNavigation!) {
-            handleStateChange(for: webView)
+            syncBrowserState(from: webView)
         }
 
         func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
-            handleStateChange(for: webView)
+            syncBrowserState(from: webView)
         }
 
         func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-            handleStateChange(for: webView)
+            handleTerminalStateChange(for: webView)
         }
 
         func webView(
@@ -158,7 +206,7 @@ struct FireLoginWebView: UIViewRepresentable {
             didFail navigation: WKNavigation!,
             withError error: Error
         ) {
-            handleStateChange(for: webView)
+            handleTerminalStateChange(for: webView)
         }
 
         func webView(
@@ -166,11 +214,11 @@ struct FireLoginWebView: UIViewRepresentable {
             didFailProvisionalNavigation navigation: WKNavigation!,
             withError error: Error
         ) {
-            handleStateChange(for: webView)
+            handleTerminalStateChange(for: webView)
         }
 
         func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-            handleStateChange(for: webView)
+            handleTerminalStateChange(for: webView)
         }
     }
 }
@@ -310,6 +358,7 @@ private struct FireLoginBottomBar: View {
                 .buttonStyle(FirePrimaryButtonStyle())
                 .disabled(
                     webViewBox.webView == nil
+                        || webViewBox.isLoading
                         || viewModel.isSyncingLoginSession
                         || !viewModel.canSyncLoginSession
                 )

--- a/native/ios-app/App/ListKit/FireCollectionHost.swift
+++ b/native/ios-app/App/ListKit/FireCollectionHost.swift
@@ -5,6 +5,8 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
     UIViewControllerRepresentable
 {
     let sections: [FireListSectionModel<SectionID, ItemID>]
+    let layoutVersion: AnyHashable
+    let contentVersion: AnyHashable
     let makeLayout: () -> UICollectionViewLayout
     let showsVerticalScrollIndicator: Bool
     let backgroundColor: UIColor
@@ -18,6 +20,8 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
 
     init(
         sections: [FireListSectionModel<SectionID, ItemID>],
+        layoutVersion: AnyHashable = 0,
+        contentVersion: AnyHashable = 0,
         showsVerticalScrollIndicator: Bool = true,
         backgroundColor: UIColor = .clear,
         animatingDifferences: Bool = true,
@@ -30,6 +34,8 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
         rowContent: @escaping (ItemID) -> RowContent
     ) {
         self.sections = sections
+        self.layoutVersion = layoutVersion
+        self.contentVersion = contentVersion
         self.showsVerticalScrollIndicator = showsVerticalScrollIndicator
         self.backgroundColor = backgroundColor
         self.animatingDifferences = animatingDifferences
@@ -48,6 +54,8 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
         let controller: FireDiffableListController<SectionID, ItemID, RowContent> =
             FireDiffableListController(
                 layout: makeLayout(),
+                layoutVersion: layoutVersion,
+                contentVersion: contentVersion,
                 showsVerticalScrollIndicator: showsVerticalScrollIndicator,
                 backgroundColor: backgroundColor,
                 onSelectItem: onSelectItem,
@@ -64,13 +72,17 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
         _ uiViewController: FireDiffableListController<SectionID, ItemID, RowContent>,
         context: Context
     ) {
-        uiViewController.updateLayout(makeLayout())
+        uiViewController.updateLayoutIfNeeded(
+            version: layoutVersion,
+            makeLayout: makeLayout
+        )
         uiViewController.updateAppearance(
             showsVerticalScrollIndicator: showsVerticalScrollIndicator,
             backgroundColor: backgroundColor
         )
         uiViewController.setSections(
             sections,
+            contentVersion: contentVersion,
             animatingDifferences: animatingDifferences
         )
     }

--- a/native/ios-app/App/ListKit/FireDiffableListController.swift
+++ b/native/ios-app/App/ListKit/FireDiffableListController.swift
@@ -12,6 +12,47 @@ struct FireCollectionScrollAnchor<ItemID: Hashable>: Equatable {
     let offsetFromTop: CGFloat
 }
 
+enum FireCollectionScrollAnchorRestorePolicy {
+    case always
+    case never
+    case whenNotAnimatingDifferences
+
+    func shouldRestore(animatingDifferences: Bool) -> Bool {
+        switch self {
+        case .always:
+            return true
+        case .never:
+            return false
+        case .whenNotAnimatingDifferences:
+            return !animatingDifferences
+        }
+    }
+}
+
+func fireCollectionNeedsLayoutUpdate(
+    currentVersion: AnyHashable?,
+    incomingVersion: AnyHashable
+) -> Bool {
+    currentVersion != incomingVersion
+}
+
+func fireCollectionNeedsSectionUpdate<SectionID: Hashable, ItemID: Hashable>(
+    current: [FireListSectionModel<SectionID, ItemID>],
+    incoming: [FireListSectionModel<SectionID, ItemID>]
+) -> Bool {
+    current != incoming
+}
+
+func fireCollectionCommonItems<SectionID: Hashable, ItemID: Hashable>(
+    current: [FireListSectionModel<SectionID, ItemID>],
+    incoming: [FireListSectionModel<SectionID, ItemID>]
+) -> [ItemID] {
+    let existingItems = Set(current.flatMap(\.items))
+    return incoming
+        .flatMap(\.items)
+        .filter { existingItems.contains($0) }
+}
+
 @MainActor
 final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, RowContent: View>: UIViewController,
     UICollectionViewDelegate
@@ -22,18 +63,24 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
     private let onVisibleItemsChanged: (([ItemID]) -> Void)?
     private let onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)?
     private let onRefresh: (() async -> Void)?
+    private let scrollAnchorRestorePolicy: FireCollectionScrollAnchorRestorePolicy
     private var listLayout: UICollectionViewLayout
+    private var layoutVersion: AnyHashable
+    private var contentVersion: AnyHashable
     private var showsVerticalScrollIndicator: Bool
     private var backgroundColor: UIColor
 
     private var collectionView: UICollectionView?
     private var dataSource: UICollectionViewDiffableDataSource<SectionID, ItemID>?
+    private var currentSections: [FireListSectionModel<SectionID, ItemID>] = []
     private var lastVisibleItemIDs: [ItemID] = []
     private var lastScrollMetrics: FireCollectionScrollMetrics?
     private var isRefreshing = false
 
     init(
         layout: UICollectionViewLayout,
+        layoutVersion: AnyHashable = 0,
+        contentVersion: AnyHashable = 0,
         showsVerticalScrollIndicator: Bool = true,
         backgroundColor: UIColor = .clear,
         onSelectItem: ((ItemID) -> Void)? = nil,
@@ -41,9 +88,12 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
         onVisibleItemsChanged: (([ItemID]) -> Void)? = nil,
         onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)? = nil,
         onRefresh: (() async -> Void)? = nil,
+        scrollAnchorRestorePolicy: FireCollectionScrollAnchorRestorePolicy = .whenNotAnimatingDifferences,
         rowContent: @escaping (ItemID) -> RowContent
     ) {
         self.listLayout = layout
+        self.layoutVersion = layoutVersion
+        self.contentVersion = contentVersion
         self.showsVerticalScrollIndicator = showsVerticalScrollIndicator
         self.backgroundColor = backgroundColor
         self.onSelectItem = onSelectItem
@@ -51,6 +101,7 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
         self.onVisibleItemsChanged = onVisibleItemsChanged
         self.onScrollMetricsChanged = onScrollMetricsChanged
         self.onRefresh = onRefresh
+        self.scrollAnchorRestorePolicy = scrollAnchorRestorePolicy
         self.rowContent = rowContent
         super.init(nibName: nil, bundle: nil)
     }
@@ -109,7 +160,16 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
         }
     }
 
-    func updateLayout(_ layout: UICollectionViewLayout) {
+    func updateLayoutIfNeeded(
+        version: AnyHashable,
+        makeLayout: () -> UICollectionViewLayout
+    ) {
+        guard fireCollectionNeedsLayoutUpdate(currentVersion: layoutVersion, incomingVersion: version)
+        else {
+            return
+        }
+        layoutVersion = version
+        let layout = makeLayout()
         listLayout = layout
         collectionView?.setCollectionViewLayout(layout, animated: false)
     }
@@ -126,18 +186,41 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
 
     func setSections(
         _ sections: [FireListSectionModel<SectionID, ItemID>],
+        contentVersion: AnyHashable,
         animatingDifferences: Bool
     ) {
         guard let dataSource else { return }
+        let sectionsChanged = fireCollectionNeedsSectionUpdate(
+            current: currentSections,
+            incoming: sections
+        )
+        let contentChanged = self.contentVersion != contentVersion
+        guard sectionsChanged || contentChanged else {
+            return
+        }
+        let reconfiguredItems = contentChanged
+            ? fireCollectionCommonItems(current: currentSections, incoming: sections)
+            : []
+        currentSections = sections
+        self.contentVersion = contentVersion
 
-        let scrollAnchor = currentScrollAnchor()
+        // Animated diffable updates should keep UIKit's insertion/reorder animation intact.
+        // Restoring contentOffset after those animations turns local diffs into visible snaps.
+        let effectiveAnimatingDifferences = sectionsChanged && animatingDifferences
+        let shouldRestoreScrollAnchor = scrollAnchorRestorePolicy.shouldRestore(
+            animatingDifferences: effectiveAnimatingDifferences
+        )
+        let scrollAnchor = shouldRestoreScrollAnchor ? currentScrollAnchor() : nil
         var snapshot = NSDiffableDataSourceSnapshot<SectionID, ItemID>()
         for section in sections {
             snapshot.appendSections([section.id])
             snapshot.appendItems(section.items, toSection: section.id)
         }
+        if !reconfiguredItems.isEmpty {
+            snapshot.reconfigureItems(reconfiguredItems)
+        }
 
-        dataSource.apply(snapshot, animatingDifferences: animatingDifferences) { [weak self] in
+        dataSource.apply(snapshot, animatingDifferences: effectiveAnimatingDifferences) { [weak self] in
             guard let self else { return }
             self.restoreScrollAnchor(scrollAnchor)
             self.publishVisibleItems()

--- a/native/ios-app/App/ListKit/Home/FireHomeCollectionView.swift
+++ b/native/ios-app/App/ListKit/Home/FireHomeCollectionView.swift
@@ -21,6 +21,18 @@ private enum FireHomeCollectionItem: Hashable {
 struct FireHomeCollectionView: View {
     @EnvironmentObject private var homeFeedStore: FireHomeFeedStore
 
+    private struct FireHomeCollectionContentVersion: Hashable {
+        let allCategories: [FireTopicCategoryPresentation]
+        let topTags: [String]
+        let selectedTopicKind: TopicListKindState
+        let selectedHomeCategoryId: UInt64?
+        let selectedHomeTags: [String]
+        let topicRows: [FireTopicRowPresentation]
+        let nextTopicsPage: UInt32?
+        let isLoadingTopics: Bool
+        let isAppendingTopics: Bool
+    }
+
     let onShowCategoryBrowser: () -> Void
     let onShowTagPicker: () -> Void
     let onSelectTopic: (UInt64) -> Void
@@ -29,6 +41,20 @@ struct FireHomeCollectionView: View {
 
     private var parentCategories: [FireTopicCategoryPresentation] {
         homeFeedStore.allCategories.filter { $0.parentCategoryId == nil }
+    }
+
+    private var contentVersion: FireHomeCollectionContentVersion {
+        FireHomeCollectionContentVersion(
+            allCategories: homeFeedStore.allCategories,
+            topTags: homeFeedStore.topTags,
+            selectedTopicKind: homeFeedStore.selectedTopicKind,
+            selectedHomeCategoryId: homeFeedStore.selectedHomeCategoryId,
+            selectedHomeTags: homeFeedStore.selectedHomeTags,
+            topicRows: homeFeedStore.topicRows,
+            nextTopicsPage: homeFeedStore.nextTopicsPage,
+            isLoadingTopics: homeFeedStore.isLoadingTopics,
+            isAppendingTopics: homeFeedStore.isAppendingTopics
+        )
     }
 
     private var sections: [FireListSectionModel<FireHomeCollectionSection, FireHomeCollectionItem>] {
@@ -61,6 +87,7 @@ struct FireHomeCollectionView: View {
     var body: some View {
         FireCollectionHost(
             sections: sections,
+            contentVersion: contentVersion,
             backgroundColor: .systemBackground,
             animatingDifferences: true,
             onSelectItem: handleSelection(_:),
@@ -213,10 +240,6 @@ struct FireHomeCollectionView: View {
     private var tagChipsRow: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 6) {
-                ForEach(homeFeedStore.selectedHomeTags, id: \.self) { tag in
-                    selectedTagChip(tag)
-                }
-
                 Button(action: onShowTagPicker) {
                     HStack(spacing: 4) {
                         Image(systemName: "plus")
@@ -233,6 +256,10 @@ struct FireHomeCollectionView: View {
                     )
                 }
                 .buttonStyle(.plain)
+
+                ForEach(homeFeedStore.selectedHomeTags, id: \.self) { tag in
+                    selectedTagChip(tag)
+                }
             }
             .padding(.vertical, 2)
         }

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		795E7AB547CA854593A42D91 /* FireHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E60D1F8BA725E4D60AFBA3 /* FireHomeView.swift */; };
 		7C7F1371B83C02B96B266900 /* FireDeveloperToolsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FDDE688920A8904B16F9A2 /* FireDeveloperToolsView.swift */; };
 		7FC4730D00066ED2E1605539 /* FireComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27F174773C4A2B3D0A4D29DD /* FireComponents.swift */; };
+		82797BA3DC5987C3299458A0 /* FireDiffableListControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69F74C914E52980E241EA87E /* FireDiffableListControllerTests.swift */; };
 		82D925C1A3A758CB7309295E /* FirePostEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46BDAC8FBC21B254D1B0BE8A /* FirePostEditorView.swift */; };
 		83E741D10CEEBE061C2B0B30 /* FireHomeCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC115AA696CF29500E0027DD /* FireHomeCollectionView.swift */; };
 		852C8492BAACCFDD0529DE22 /* FireProfileViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 419222F55DFE2BC290CD5335 /* FireProfileViewModel.swift */; };
@@ -154,6 +155,7 @@
 		6210541C2E8219CE500CFC04 /* FireProfileStatsRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileStatsRow.swift; sourceTree = "<group>"; };
 		6725F42C679E922AA3DD1FBF /* FireLoginWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireLoginWebView.swift; sourceTree = "<group>"; };
 		67647993BFF688FB02B71DBB /* FireTopicDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailView.swift; sourceTree = "<group>"; };
+		69F74C914E52980E241EA87E /* FireDiffableListControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDiffableListControllerTests.swift; sourceTree = "<group>"; };
 		6E8372AD9A5A2CC34FBD3AEF /* FireProfileHeaderComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileHeaderComponents.swift; sourceTree = "<group>"; };
 		7218ECE4CE5CE67428ADD4DD /* FirePresentationIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePresentationIdentity.swift; sourceTree = "<group>"; };
 		7337AE7EB0411AC9B53AD853 /* Fire-Local-Debug.example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Fire-Local-Debug.example.xcconfig"; sourceTree = "<group>"; };
@@ -365,6 +367,7 @@
 			children = (
 				2EFBB6F3B1D7E3DD79D98C17 /* FireAPMEventStoreTests.swift */,
 				299683BEDEC559B03C136C34 /* FireAppRouteTests.swift */,
+				69F74C914E52980E241EA87E /* FireDiffableListControllerTests.swift */,
 				BADC2ED47CF65AD5BE795908 /* FireEntityStateTests.swift */,
 				C2E8287F8F1E148177E1A223 /* FireNotificationStoreTests.swift */,
 				EC77525391DD1C7EA7329451 /* FirePushRegistrationCoordinatorTests.swift */,
@@ -598,6 +601,7 @@
 			files = (
 				180BEE1FEF5E76FF92403C34 /* FireAPMEventStoreTests.swift in Sources */,
 				3330A9C7E4C8BA80778F79EB /* FireAppRouteTests.swift in Sources */,
+				82797BA3DC5987C3299458A0 /* FireDiffableListControllerTests.swift in Sources */,
 				9B0DABDC5BA87A4CAFF3232D /* FireEntityStateTests.swift in Sources */,
 				8823DAD708691783D2AB85A4 /* FireNotificationStoreTests.swift in Sources */,
 				3F8B5F1239E17802675A013B /* FirePushRegistrationCoordinatorTests.swift in Sources */,

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0006B08A873FC6192E616F01 /* FireApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996D95DE48DA65385BD587F7 /* FireApp.swift */; };
 		01F9189B11F5E6217DEBB203 /* FireFilteredTopicListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C810E3D0B2CF415495A3D5C4 /* FireFilteredTopicListView.swift */; };
 		03AA550F53B37A6C6189FBFB /* FireBookmarkEditorSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC90B1231DCA76399CB693E2 /* FireBookmarkEditorSheet.swift */; };
+		0AABB8FE83B25A7D6D7C67FC /* FireCfClearanceRefreshService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01E5248AEF9002E2919AC0F /* FireCfClearanceRefreshService.swift */; };
 		0ED224A3C2B64ED1DE67CA99 /* FireTopicPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A14122231F5DBCCFFC5AD36C /* FireTopicPresentation.swift */; };
 		12ED42BB059E1EFA35A00827 /* FireTopicEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FA800E223882F74B7EB5812 /* FireTopicEditorView.swift */; };
 		178E55B850EED60EE530A0F2 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9B970247E0258DD4D4F34101 /* Foundation.framework */; };
@@ -203,6 +204,7 @@
 		EAE00F2C2E4EB9A7A99D327A /* FireRouteParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireRouteParser.swift; sourceTree = "<group>"; };
 		EC7384EAE1C43817CAE71D9F /* FireHomeFeedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireHomeFeedStore.swift; sourceTree = "<group>"; };
 		EC77525391DD1C7EA7329451 /* FirePushRegistrationCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePushRegistrationCoordinatorTests.swift; sourceTree = "<group>"; };
+		F01E5248AEF9002E2919AC0F /* FireCfClearanceRefreshService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireCfClearanceRefreshService.swift; sourceTree = "<group>"; };
 		F02D3C136EFF0589DC131FB9 /* FireProfileTrustLevelPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileTrustLevelPill.swift; sourceTree = "<group>"; };
 		F5F3291447D7DA0AEF9AA413 /* SessionState+Helpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionState+Helpers.swift"; sourceTree = "<group>"; };
 		F75C8AF749DA8EF7CB5E3A64 /* FireNotificationHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNotificationHistoryView.swift; sourceTree = "<group>"; };
@@ -261,6 +263,7 @@
 			isa = PBXGroup;
 			children = (
 				C313FFDD8D569FA6D9B1C0E0 /* FireAuthCookieKeychainStore.swift */,
+				F01E5248AEF9002E2919AC0F /* FireCfClearanceRefreshService.swift */,
 				8834ADE6E3ADB8A03391560C /* FireSessionStore.swift */,
 				B5E5271F93B7DF18859B101F /* FireWebViewLoginCoordinator.swift */,
 				410518D5B5DA1358F677892E /* APM */,
@@ -634,6 +637,7 @@
 				03AA550F53B37A6C6189FBFB /* FireBookmarkEditorSheet.swift in Sources */,
 				F171E34C843A4BD06FB50408 /* FireBookmarksView.swift in Sources */,
 				999638A7F6D5A424815E6F2F /* FireCategoriesView.swift in Sources */,
+				0AABB8FE83B25A7D6D7C67FC /* FireCfClearanceRefreshService.swift in Sources */,
 				F8963543E87EACAD49C9B131 /* FireCollectionHost.swift in Sources */,
 				7FC4730D00066ED2E1605539 /* FireComponents.swift in Sources */,
 				5B4072DC893E7612141A8F34 /* FireComposerView.swift in Sources */,

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -40,7 +40,7 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
 - `FireWebViewLoginCoordinator.swift`
   - reads `WKWebView` cookies, `current-username`, `csrf-token`, page HTML, and the live browser user agent
   - prefers homepage HTML fetched through the current WebView browser context before falling back to the visible page HTML, so the first shared bootstrap sync stays as close as possible to the browser-authenticated session
-  - continuously supports an “auto-detect, manual Sync” login flow: navigation/scene changes can re-probe readiness, but the user-visible `完成登录` action remains the only commit point
+  - continuously supports an “auto-detect, manual Sync” login flow: navigation, scene-activation, and WebKit cookie-store changes can all re-probe readiness, but the user-visible `完成登录` action remains the only commit point
   - only treats login as ready to sync once it can read `current-username`, same-site auth cookies, and reusable bootstrap HTML
   - converts them into `LoginSyncState`
   - refreshes platform cookies both before and after login sync so Rust always sees the latest WebKit `_t`, `_forum_session`, and `cf_clearance` values
@@ -209,7 +209,7 @@ Current UX note:
 - The app now opens login as a full-screen browser instead of a partial sheet.
 - The app now keeps the same onboarding page visible during cold-start auto-login, hiding login actions until restore fails and only showing loading if bootstrap takes longer than 500ms.
 - The login browser can navigate back from Google or other intermediate pages without forcing the user to close and reopen login.
-- The login browser now auto-probes whether a manual Sync would actually succeed, and keeps `完成登录` disabled until username, auth cookies, and reusable bootstrap HTML are all present.
+- The login browser now auto-probes whether a manual Sync would actually succeed, re-checking on navigation, scene resume, and WebKit auth-cookie changes, and keeps `完成登录` disabled until username, auth cookies, and reusable bootstrap HTML are all present.
 - The login shell and reading workspace now adapt to both light and dark system appearance while preserving the same hierarchy and contrast model.
 - The network preflight is a best-effort connectivity warm-up. iOS does not provide a generic "internet permission" API for arbitrary web access, so this only shifts the first prompt/request earlier; it does not create a separate permission flow.
 - The current topic browser now runs against the real shared Rust core through generated UniFFI Swift bindings.

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -40,11 +40,11 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
 - `FireWebViewLoginCoordinator.swift`
   - reads `WKWebView` cookies, `current-username`, `csrf-token`, page HTML, and the live browser user agent
   - prefers homepage HTML fetched through the current WebView browser context before falling back to the visible page HTML, so the first shared bootstrap sync stays as close as possible to the browser-authenticated session
-  - continuously supports an “auto-detect, manual Sync” login flow: navigation, scene-activation, and WebKit cookie-store changes can all re-probe readiness, but the user-visible `完成登录` action remains the only commit point
+  - continuously supports an “auto-detect, manual Sync” login flow: navigation, scene-activation, and debounced WebKit cookie-store changes can all re-probe readiness, but the user-visible `完成登录` action remains the only commit point
   - only treats login as ready to sync once it can read `current-username`, same-site auth cookies, and reusable bootstrap HTML
   - converts them into `LoginSyncState`
   - refreshes platform cookies both before and after login sync so Rust always sees the latest WebKit `_t`, `_forum_session`, and `cf_clearance` values
-  - completes login by syncing platform cookies into Keychain and Rust, then backfilling bootstrap whenever the captured page leaves username/session metadata incomplete
+  - completes login by syncing platform cookies into Keychain and Rust, backfilling missing `current-username` / `csrf-token` from the preferred bootstrap HTML whenever the visible page leaves metadata incomplete
   - if the follow-up Rust bootstrap refresh is challenged by Cloudflare again, it clears the partial native session and keeps the WebView login flow open so the user can finish the challenge and sync again
   - clears host-side LinuxDo auth cookies after a successful explicit logout while preserving `cf_clearance`
 - `FireCfClearanceRefreshService.swift`
@@ -56,13 +56,14 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - now wraps the embedded `WKWebView` in a full-screen native browser shell with adaptive light/dark chrome, a compact top bar, and a bottom command dock
   - exposes back, forward, home, reload, and session sync controls so OAuth hops can return to LinuxDo without closing the flow
   - enables back/forward swipe gestures on the embedded `WKWebView`
+  - avoids mutating observed browser state from `UIViewRepresentable.updateUIView`, so SwiftUI updates do not loop back into `WKWebView` host state and freeze the login entry flow
 - `App/FireApp.swift`
   - owns app-level URL opening and routes both `fire://...` custom schemes and LinuxDo universal links into the shared typed in-app route model before SwiftUI screens load
 - `App/Routing/`
   - defines the typed `FireAppRoute` model, route parser, and shared destination view used by external URL opens, notification taps, and in-app search / notification navigation
 - `App/FireAppViewModel.swift`
-  - performs a lightweight network preflight before presenting the login browser
-  - moves the first system-level network prompt, when one appears on-device, out of the login page itself
+  - presents the login browser immediately, then runs a lightweight best-effort network warm-up in the background
+  - still tries to move the first system-level network prompt, when one appears on-device, out of the in-page login interaction itself, without blocking WebView presentation
   - restores the persisted session cache, replays Keychain cookies through Rust on cold start, repairs incomplete authenticated session identity, refreshes CSRF when the restored cache is otherwise ready, and keeps the topic browser in sync with login state
   - holds the onboarding screen in a bootstrap state while cold-start auto-login runs, hiding login actions during restore and only revealing a loading indicator if that bootstrap takes longer than 500ms
   - now builds `FireSessionStore` lazily on a detached task so Rust/logging initialization does not block the first SwiftUI render on the main actor
@@ -209,9 +210,9 @@ Current UX note:
 - The app now opens login as a full-screen browser instead of a partial sheet.
 - The app now keeps the same onboarding page visible during cold-start auto-login, hiding login actions until restore fails and only showing loading if bootstrap takes longer than 500ms.
 - The login browser can navigate back from Google or other intermediate pages without forcing the user to close and reopen login.
-- The login browser now auto-probes whether a manual Sync would actually succeed, re-checking on navigation, scene resume, and WebKit auth-cookie changes, and keeps `完成登录` disabled until username, auth cookies, and reusable bootstrap HTML are all present.
+- The login browser now auto-probes whether a manual Sync would actually succeed, re-checking on navigation, scene resume, and debounced WebKit auth-cookie changes, and keeps `完成登录` disabled until username, auth cookies, and reusable bootstrap HTML are all present.
 - The login shell and reading workspace now adapt to both light and dark system appearance while preserving the same hierarchy and contrast model.
-- The network preflight is a best-effort connectivity warm-up. iOS does not provide a generic "internet permission" API for arbitrary web access, so this only shifts the first prompt/request earlier; it does not create a separate permission flow.
+- The network warm-up is best-effort and no longer blocks login browser presentation. iOS does not provide a generic "internet permission" API for arbitrary web access, so this only tries to shift the first prompt/request earlier; it does not create a separate permission flow.
 - The current topic browser now runs against the real shared Rust core through generated UniFFI Swift bindings.
 - The app now includes a native search screen for topic/post/user discovery on top of the shared Rust `/search.json` API.
 - The app now uses one typed route model for supported custom URL opens, local-notification taps, and search / notification jumps to topic, profile, and badge destinations.

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -25,6 +25,7 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - passes the platform workspace root (`Application Support/Fire`) into Rust during initialization
   - restores the persisted session snapshot on cold start, then re-injects Keychain cookies before authenticated requests
   - delegates platform-cookie apply semantics plus bootstrap/CSRF refresh decisions to Rust instead of reimplementing them in Swift
+  - relies on Rust-owned session epoch fencing so late network responses can no longer overwrite rotated `_t` / `_forum_session` cookies or revive a locally cleared session
   - persists the latest Rust session snapshot as a full `Application Support/Fire/session.json` and mirrors the current Rust-owned auth cookie batch back into Keychain whenever it changes
   - lets Rust initialize shared logs under `Application Support/Fire/logs`
   - wraps `syncLoginContext`, async `refreshBootstrap`, async `refreshCsrfToken`, async topic fetches, and async logout
@@ -39,10 +40,17 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
 - `FireWebViewLoginCoordinator.swift`
   - reads `WKWebView` cookies, `current-username`, `csrf-token`, page HTML, and the live browser user agent
   - prefers homepage HTML fetched through the current WebView browser context before falling back to the visible page HTML, so the first shared bootstrap sync stays as close as possible to the browser-authenticated session
+  - continuously supports an “auto-detect, manual Sync” login flow: navigation/scene changes can re-probe readiness, but the user-visible `完成登录` action remains the only commit point
+  - only treats login as ready to sync once it can read `current-username`, same-site auth cookies, and reusable bootstrap HTML
   - converts them into `LoginSyncState`
+  - refreshes platform cookies both before and after login sync so Rust always sees the latest WebKit `_t`, `_forum_session`, and `cf_clearance` values
   - completes login by syncing platform cookies into Keychain and Rust, then backfilling bootstrap whenever the captured page leaves username/session metadata incomplete
   - if the follow-up Rust bootstrap refresh is challenged by Cloudflare again, it clears the partial native session and keeps the WebView login flow open so the user can finish the challenge and sync again
   - clears host-side LinuxDo auth cookies after a successful explicit logout while preserving `cf_clearance`
+- `FireCfClearanceRefreshService.swift`
+  - owns an offscreen `WKWebView` that periodically reloads `https://linux.do/` once the shared session is authenticated, scene-active, and bootstrap has exposed a Turnstile sitekey
+  - re-syncs WebKit cookies back into Rust after each refresh cycle so host-owned `cf_clearance` state stays warm without forcing the foreground login WebView open
+  - starts/stops automatically from session and scene-phase changes, and records APM breadcrumbs for refresh lifecycle and failures
 - `App/FireLoginWebView.swift`
   - presents the login browser as a full-screen flow
   - now wraps the embedded `WKWebView` in a full-screen native browser shell with adaptive light/dark chrome, a compact top bar, and a bottom command dock
@@ -63,6 +71,8 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - now acts as a session/runtime facade for feature stores instead of also owning every screen's transient state directly
   - now owns the foreground MessageBus transport lifecycle on iOS and forwards runtime refresh work into the bound feature stores instead of publishing home/topic-detail state itself
   - now treats Rust-owned `CloudflareChallenge` errors as the signal to clear the local authenticated snapshot, return the shell to onboarding, and auto-present the login WebView so challenge recovery stays inside the browser flow
+  - now also treats Rust-owned `LoginRequired` invalidation the same way, clearing host-side auth cookies while preserving `cf_clearance` so passive session loss, explicit logout, and bootstrap-challenged recovery all converge on one reset path
+  - now probes login sync readiness from the embedded `WKWebView` and keeps the `完成登录` button disabled until the shared login prerequisites are actually satisfied
   - now also emits host-owned APM spans for cold-start restore, login sync, bootstrap refresh, latest-feed load, topic-detail load, reply submit, notification refresh, and MessageBus start
 - `App/Stores/FireHomeFeedStore.swift`
   - owns selected feed kind, selected category/tags, paginated home rows, and bootstrap-derived category/tag metadata for the authenticated home shell
@@ -150,9 +160,10 @@ Expected integration flow:
 2. Build the app target. Xcode runs `scripts/sync_uniffi_bindings.sh` before compile and refreshes the UniFFI Swift/FFI/staticlib outputs in `Generated/`.
 3. Keep the native files in `Sources/FireAppSession/` in the same Xcode target.
 4. Create a single `FireSessionStore` instance early in app launch and call `restoreColdStartSession()`.
-5. Drive the login `WKWebView` through `FireWebViewLoginCoordinator.completeLogin(from:)`.
-6. After login or restore, render the topic feeds and topic detail through `fetchTopicList` / `fetchTopicDetail`.
-7. On explicit logout, call `FireWebViewLoginCoordinator.logout()` so the Rust snapshot, persisted session file, and host-side LinuxDo auth cookies stay aligned.
+5. Let the login `WKWebView` probe readiness through `FireAppViewModel.refreshLoginSyncReadiness(from:)`, and only call `FireWebViewLoginCoordinator.completeLogin(from:)` once the UI has enabled `完成登录`.
+6. After login or restore, let `FireCfClearanceRefreshService.shared` track the active session so same-site Cloudflare cookies can be refreshed in the background when bootstrap has a Turnstile sitekey.
+7. After login or restore, render the topic feeds and topic detail through `fetchTopicList` / `fetchTopicDetail`.
+8. On explicit logout or shared-layer login invalidation, clear local auth state through the login coordinator path so the Rust snapshot, persisted session file, and host-side LinuxDo auth cookies stay aligned while preserving `cf_clearance`.
 
 Xcode project generation rules:
 
@@ -198,6 +209,7 @@ Current UX note:
 - The app now opens login as a full-screen browser instead of a partial sheet.
 - The app now keeps the same onboarding page visible during cold-start auto-login, hiding login actions until restore fails and only showing loading if bootstrap takes longer than 500ms.
 - The login browser can navigate back from Google or other intermediate pages without forcing the user to close and reopen login.
+- The login browser now auto-probes whether a manual Sync would actually succeed, and keeps `完成登录` disabled until username, auth cookies, and reusable bootstrap HTML are all present.
 - The login shell and reading workspace now adapt to both light and dark system appearance while preserving the same hierarchy and contrast model.
 - The network preflight is a best-effort connectivity warm-up. iOS does not provide a generic "internet permission" API for arbitrary web access, so this only shifts the first prompt/request earlier; it does not create a separate permission flow.
 - The current topic browser now runs against the real shared Rust core through generated UniFFI Swift bindings.
@@ -220,6 +232,7 @@ Current UX note:
 - The app now keeps the in-app notification list synchronized from Rust-owned notification runtime state when MessageBus notification events arrive, instead of only updating the unread badge count.
 - iOS now schedules background refresh work for `/notification-alert/{userId}` and presents host-owned local notifications from a dedicated one-shot Rust MessageBus poll path.
 - The authenticated shell now also requests APNs registration, caches the resulting device token locally, and exposes host-side registration diagnostics without attempting backend token upload yet.
+- iOS now also runs a default-on offscreen Cloudflare cookie refresh loop for authenticated sessions that still expose a Turnstile sitekey in bootstrap, re-syncing refreshed WebKit cookies back into Rust while the scene stays active.
 - The app now exposes a diagnostics screen for tail-first log inspection, preview-first request-trace body paging, and local support-bundle export.
 - The profile screen now consumes Rust-derived session display labels, so authenticated recovery states are described consistently across hosts instead of being inferred separately in Swift.
 - The profile area now includes a native private-message mailbox, and public profile headers can open a pre-addressed private-message composer when the viewed user allows PMs.

--- a/native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift
+++ b/native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift
@@ -1,0 +1,178 @@
+import Foundation
+import WebKit
+
+@MainActor
+final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate {
+    static let shared = FireCfClearanceRefreshService()
+
+    private static let refreshInterval: Duration = .seconds(240)
+    private static let refreshURL = URL(string: "https://linux.do/")!
+
+    private weak var loginCoordinator: FireWebViewLoginCoordinator?
+    private var session: SessionState = .placeholder()
+    private var sceneActive = false
+    private var refreshTask: Task<Void, Never>?
+    private var webView: WKWebView?
+    private var loadContinuation: CheckedContinuation<Void, Error>?
+
+    func updateSession(
+        _ session: SessionState,
+        loginCoordinator: FireWebViewLoginCoordinator
+    ) {
+        self.session = session
+        self.loginCoordinator = loginCoordinator
+        reconfigureLoop(reason: "session_update")
+    }
+
+    func setSceneActive(_ active: Bool) {
+        sceneActive = active
+        reconfigureLoop(reason: active ? "scene_active" : "scene_inactive")
+    }
+
+    nonisolated static func shouldAutoRefresh(
+        session: SessionState,
+        sceneActive: Bool
+    ) -> Bool {
+        sceneActive
+            && session.readiness.canReadAuthenticatedApi
+            && session.readiness.hasCloudflareClearance
+            && !(session.bootstrap.turnstileSitekey?.isEmpty ?? true)
+    }
+
+    private var shouldRun: Bool {
+        Self.shouldAutoRefresh(session: session, sceneActive: sceneActive)
+    }
+
+    private func reconfigureLoop(reason: String) {
+        if shouldRun {
+            guard refreshTask == nil else { return }
+            FireAPMManager.shared.recordBreadcrumb(
+                target: "cf.refresh",
+                message: "cf clearance refresh started reason=\(reason)"
+            )
+            refreshTask = Task { [weak self] in
+                await self?.runRefreshLoop()
+            }
+        } else {
+            refreshTask?.cancel()
+            refreshTask = nil
+            tearDownWebView()
+            FireAPMManager.shared.recordBreadcrumb(
+                target: "cf.refresh",
+                message: "cf clearance refresh stopped reason=\(reason)"
+            )
+        }
+    }
+
+    private func runRefreshLoop() async {
+        defer {
+            refreshTask = nil
+            if !shouldRun {
+                tearDownWebView()
+            }
+        }
+
+        while !Task.isCancelled && shouldRun {
+            await performRefreshCycle()
+            do {
+                try await Task.sleep(for: Self.refreshInterval)
+            } catch {
+                break
+            }
+        }
+    }
+
+    private func performRefreshCycle() async {
+        guard shouldRun, let loginCoordinator else {
+            return
+        }
+
+        do {
+            try await loadRefreshPage()
+            let refreshed = try await loginCoordinator.refreshPlatformCookies()
+            session = refreshed
+            FireAPMManager.shared.recordBreadcrumb(
+                target: "cf.refresh",
+                message: "cf clearance refresh cycle succeeded"
+            )
+        } catch {
+            FireAPMManager.shared.recordBreadcrumb(
+                level: "warning",
+                target: "cf.refresh",
+                message: "cf clearance refresh cycle failed: \(error.localizedDescription)"
+            )
+        }
+    }
+
+    private func ensureWebView() -> WKWebView {
+        if let webView {
+            return webView
+        }
+
+        let configuration = WKWebViewConfiguration()
+        configuration.websiteDataStore = .default()
+        let webView = WKWebView(frame: .zero, configuration: configuration)
+        webView.isHidden = true
+        webView.navigationDelegate = self
+        self.webView = webView
+        return webView
+    }
+
+    private func tearDownWebView() {
+        loadContinuation?.resume(throwing: CancellationError())
+        loadContinuation = nil
+        webView?.stopLoading()
+        webView?.navigationDelegate = nil
+        webView = nil
+    }
+
+    private func loadRefreshPage() async throws {
+        let webView = ensureWebView()
+        let request = URLRequest(
+            url: Self.refreshURL,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 30
+        )
+        try await withCheckedThrowingContinuation { continuation in
+            if let loadContinuation {
+                loadContinuation.resume(throwing: CancellationError())
+            }
+            loadContinuation = continuation
+            webView.load(request)
+        }
+    }
+
+    private func resumeLoad(_ result: Result<Void, Error>) {
+        guard let loadContinuation else { return }
+        loadContinuation.resume(with: result)
+        self.loadContinuation = nil
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        resumeLoad(.success(()))
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFail navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        resumeLoad(.failure(error))
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        didFailProvisionalNavigation navigation: WKNavigation!,
+        withError error: Error
+    ) {
+        resumeLoad(.failure(error))
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        resumeLoad(.failure(NSError(
+            domain: "FireCfClearanceRefreshService",
+            code: 1,
+            userInfo: [NSLocalizedDescriptionKey: "Cloudflare refresh WebView terminated"]
+        )))
+    }
+}

--- a/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
+++ b/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
@@ -74,11 +74,54 @@ enum FireBootstrapHTMLHeuristics {
         return score
     }
 
+    static func isReusableLoginBootstrap(_ html: String?) -> Bool {
+        score(html) >= 8
+    }
+
     private static func nonEmpty(_ html: String?) -> String? {
         guard let html, !html.isEmpty else {
             return nil
         }
         return html
+    }
+}
+
+public struct FireLoginSyncReadiness: Sendable, Equatable {
+    public let isReady: Bool
+    public let username: String?
+    public let hasAuthCookies: Bool
+    public let hasBootstrapHTML: Bool
+    public let preferredBootstrapScore: Int
+
+    public init(
+        isReady: Bool,
+        username: String?,
+        hasAuthCookies: Bool,
+        hasBootstrapHTML: Bool,
+        preferredBootstrapScore: Int
+    ) {
+        self.isReady = isReady
+        self.username = username
+        self.hasAuthCookies = hasAuthCookies
+        self.hasBootstrapHTML = hasBootstrapHTML
+        self.preferredBootstrapScore = preferredBootstrapScore
+    }
+}
+
+public enum FireWebViewLoginCoordinatorError: LocalizedError {
+    case loginSyncNotReady(FireLoginSyncReadiness)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .loginSyncNotReady(readiness):
+            if !readiness.hasAuthCookies {
+                return "登录状态尚未写入站点 Cookie，请稍后再试。"
+            }
+            if !readiness.hasBootstrapHTML {
+                return "登录页还未拿到可用的站点引导数据，请稍后再试。"
+            }
+            return "登录状态尚未准备完成，请稍后再试。"
+        }
     }
 }
 
@@ -110,8 +153,14 @@ public final class FireWebViewLoginCoordinator {
     }
 
     public func completeLogin(from webView: WKWebView) async throws -> SessionState {
+        _ = try await refreshPlatformCookies()
         let captured = try await captureLoginState(from: webView)
-        return try await completeLogin(captured)
+        let readiness = loginSyncReadiness(for: captured)
+        guard readiness.isReady else {
+            throw FireWebViewLoginCoordinatorError.loginSyncNotReady(readiness)
+        }
+        _ = try await completeLogin(captured)
+        return try await refreshPlatformCookies()
     }
 
     func completeLogin(_ captured: FireCapturedLoginState) async throws -> SessionState {
@@ -128,6 +177,7 @@ public final class FireWebViewLoginCoordinator {
             // refresh is still challenged. The WebView login flow remains open so
             // the user can complete the challenge and retry Sync.
             _ = try? await sessionStore.logoutLocal(preserveCfClearance: true)
+            try? await clearPlatformLoginCookies(preserveCfClearance: true)
             throw error
         }
     }
@@ -196,6 +246,19 @@ public final class FireWebViewLoginCoordinator {
             from: WKWebsiteDataStore.default().httpCookieStore
         )
         return try await sessionStore.applyPlatformCookies(cookies)
+    }
+
+    public func probeLoginSyncReadiness(from webView: WKWebView) async throws -> FireLoginSyncReadiness {
+        let captured = try await captureLoginState(from: webView)
+        return loginSyncReadiness(for: captured)
+    }
+
+    public func logoutLocalAndClearPlatformCookies(
+        preserveCfClearance: Bool = true
+    ) async throws -> SessionState {
+        let state = try await sessionStore.logoutLocal(preserveCfClearance: preserveCfClearance)
+        try await clearPlatformLoginCookies(preserveCfClearance: preserveCfClearance)
+        return state
     }
 
     private func relevantCookies(from webView: WKWebView) async throws -> [PlatformCookieState] {
@@ -305,5 +368,34 @@ public final class FireWebViewLoginCoordinator {
             browserFetchedHomeHTML: browserFetchedHomeHTML,
             currentPageHTML: currentPageHTML
         )
+    }
+
+    func loginSyncReadiness(for captured: FireCapturedLoginState) -> FireLoginSyncReadiness {
+        let username = captured.username?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hasUsername = !(username?.isEmpty ?? true)
+        let activeCookies = captured.cookies.filter { cookie in
+            let value = cookie.value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return !value.isEmpty && !(cookie.expiresAtUnixMs.map { $0 <= currentUnixMs() } ?? false)
+        }
+        let hasAuthCookies =
+            activeCookies.contains(where: { $0.name == "_t" })
+            && activeCookies.contains(where: { $0.name == "_forum_session" })
+        let preferredHTML = preferredBootstrapHTML(
+            browserFetchedHomeHTML: captured.homeHTML,
+            currentPageHTML: nil
+        )
+        let preferredBootstrapScore = FireBootstrapHTMLHeuristics.score(preferredHTML)
+        let hasBootstrapHTML = FireBootstrapHTMLHeuristics.isReusableLoginBootstrap(preferredHTML)
+        return FireLoginSyncReadiness(
+            isReady: hasUsername && hasAuthCookies && hasBootstrapHTML,
+            username: username,
+            hasAuthCookies: hasAuthCookies,
+            hasBootstrapHTML: hasBootstrapHTML,
+            preferredBootstrapScore: preferredBootstrapScore
+        )
+    }
+
+    private func currentUnixMs() -> Int64 {
+        Int64(Date().timeIntervalSince1970 * 1000)
     }
 }

--- a/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
+++ b/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
@@ -2,6 +2,8 @@ import Foundation
 import WebKit
 
 enum FireBootstrapHTMLHeuristics {
+    static let reusableLoginBootstrapScoreThreshold = 8
+
     static func preferredHTML(
         browserFetchedHomeHTML: String?,
         currentPageHTML: String?
@@ -75,7 +77,7 @@ enum FireBootstrapHTMLHeuristics {
     }
 
     static func isReusableLoginBootstrap(_ html: String?) -> Bool {
-        score(html) >= 8
+        score(html) >= reusableLoginBootstrapScoreThreshold
     }
 
     private static func nonEmpty(_ html: String?) -> String? {
@@ -83,6 +85,55 @@ enum FireBootstrapHTMLHeuristics {
             return nil
         }
         return html
+    }
+}
+
+enum FireBootstrapHTMLMetadataParser {
+    static func currentUsername(from html: String?) -> String? {
+        metaContent(named: "current-username", in: html)
+    }
+
+    static func csrfToken(from html: String?) -> String? {
+        metaContent(named: "csrf-token", in: html)
+    }
+
+    private static func metaContent(named name: String, in html: String?) -> String? {
+        guard let html, !html.isEmpty else {
+            return nil
+        }
+
+        let escapedName = NSRegularExpression.escapedPattern(for: name)
+        let patterns = [
+            #"<meta\b[^>]*\bname\s*=\s*["']\#(escapedName)["'][^>]*\bcontent\s*=\s*["']([^"']+)["'][^>]*>"#,
+            #"<meta\b[^>]*\bcontent\s*=\s*["']([^"']+)["'][^>]*\bname\s*=\s*["']\#(escapedName)["'][^>]*>"#,
+        ]
+
+        for pattern in patterns {
+            guard
+                let regex = try? NSRegularExpression(
+                    pattern: pattern,
+                    options: [.caseInsensitive]
+                )
+            else {
+                continue
+            }
+
+            let range = NSRange(html.startIndex..<html.endIndex, in: html)
+            guard
+                let match = regex.firstMatch(in: html, options: [], range: range),
+                match.numberOfRanges > 1,
+                let contentRange = Range(match.range(at: 1), in: html)
+            else {
+                continue
+            }
+
+            let content = html[contentRange].trimmingCharacters(in: .whitespacesAndNewlines)
+            if !content.isEmpty {
+                return content
+            }
+        }
+
+        return nil
     }
 }
 
@@ -139,6 +190,7 @@ extension FireSessionStore: FireLoginSessionStoring {}
 @MainActor
 public final class FireWebViewLoginCoordinator {
     private let sessionStore: any FireLoginSessionStoring
+    private var probeHomeFallbackCache: FireLoginProbeHomeFallbackCache?
 
     public init(sessionStore: FireSessionStore) {
         self.sessionStore = sessionStore
@@ -190,26 +242,8 @@ public final class FireWebViewLoginCoordinator {
 
     public func captureLoginState(from webView: WKWebView) async throws -> FireCapturedLoginState {
         let currentURL = webView.url?.absoluteString
-        async let username = readStringJavaScript(
-            script: """
-            (function() {
-              var meta = document.querySelector('meta[name="current-username"]');
-              if (meta && meta.content) return meta.content;
-              return null;
-            })();
-            """,
-            in: webView
-        )
-        async let csrfToken = readStringJavaScript(
-            script: """
-            (function() {
-              var meta = document.querySelector('meta[name="csrf-token"]');
-              if (meta && meta.content) return meta.content;
-              return null;
-            })();
-            """,
-            in: webView
-        )
+        async let username = readCurrentUsername(in: webView)
+        async let csrfToken = readCsrfToken(in: webView)
         async let currentPageHTML = readStringJavaScript(
             script: "document.documentElement.outerHTML",
             in: webView
@@ -227,15 +261,20 @@ public final class FireWebViewLoginCoordinator {
         let capturedHomeHTML = try await homeHTML
         let capturedBrowserUserAgent = try await browserUserAgent
         let capturedCookies = try await cookies
+        let preferredHomeHTML = preferredBootstrapHTML(
+            browserFetchedHomeHTML: capturedHomeHTML,
+            currentPageHTML: capturedCurrentPageHTML
+        )
+        let resolvedUsername =
+            capturedUsername ?? FireBootstrapHTMLMetadataParser.currentUsername(from: preferredHomeHTML)
+        let resolvedCsrfToken =
+            capturedCsrfToken ?? FireBootstrapHTMLMetadataParser.csrfToken(from: preferredHomeHTML)
 
         return FireCapturedLoginState(
             currentURL: currentURL,
-            username: capturedUsername,
-            csrfToken: capturedCsrfToken,
-            homeHTML: preferredBootstrapHTML(
-                browserFetchedHomeHTML: capturedHomeHTML,
-                currentPageHTML: capturedCurrentPageHTML
-            ),
+            username: resolvedUsername,
+            csrfToken: resolvedCsrfToken,
+            homeHTML: preferredHomeHTML,
             browserUserAgent: capturedBrowserUserAgent,
             cookies: capturedCookies
         )
@@ -249,8 +288,55 @@ public final class FireWebViewLoginCoordinator {
     }
 
     public func probeLoginSyncReadiness(from webView: WKWebView) async throws -> FireLoginSyncReadiness {
-        let captured = try await captureLoginState(from: webView)
-        return loginSyncReadiness(for: captured)
+        let currentURL = webView.url?.absoluteString
+        async let username = readCurrentUsername(in: webView)
+        async let currentPageBootstrapScore = readCurrentPageBootstrapScore(in: webView)
+        async let cookies = relevantCookies(from: webView)
+
+        let capturedUsername = try await username
+        let capturedCurrentPageBootstrapScore = try await currentPageBootstrapScore
+        let capturedCookies = try await cookies
+
+        var resolvedUsername = normalizeUsername(capturedUsername)
+        var preferredBootstrapScore = capturedCurrentPageBootstrapScore
+        let hasAuthCookies = containsAuthCookies(in: capturedCookies)
+
+        if !hasAuthCookies {
+            probeHomeFallbackCache = nil
+        } else if shouldProbeHomeFallback(
+            in: webView,
+            currentPageBootstrapScore: capturedCurrentPageBootstrapScore,
+            username: resolvedUsername
+        ) {
+            if let cachedFallback = probeHomeFallbackCache, cachedFallback.currentURL == currentURL {
+                if resolvedUsername == nil {
+                    resolvedUsername = cachedFallback.username
+                }
+                preferredBootstrapScore = max(
+                    preferredBootstrapScore,
+                    cachedFallback.bootstrapScore
+                )
+            } else {
+                let homeHTML = try await fetchHomeHTML(in: webView)
+                let homeBootstrapScore = FireBootstrapHTMLHeuristics.score(homeHTML)
+                let homeUsername = FireBootstrapHTMLMetadataParser.currentUsername(from: homeHTML)
+                probeHomeFallbackCache = FireLoginProbeHomeFallbackCache(
+                    currentURL: currentURL,
+                    username: homeUsername,
+                    bootstrapScore: homeBootstrapScore
+                )
+                if resolvedUsername == nil {
+                    resolvedUsername = normalizeUsername(homeUsername)
+                }
+                preferredBootstrapScore = max(preferredBootstrapScore, homeBootstrapScore)
+            }
+        }
+
+        return loginSyncReadiness(
+            username: resolvedUsername,
+            cookies: capturedCookies,
+            preferredBootstrapScore: preferredBootstrapScore
+        )
     }
 
     public func logoutLocalAndClearPlatformCookies(
@@ -283,6 +369,10 @@ public final class FireWebViewLoginCoordinator {
     }
 
     private func fetchHomeHTML(in webView: WKWebView) async throws -> String? {
+        guard !webView.isLoading, isLinuxDoHost(webView.url) else {
+            return nil
+        }
+
         let value = try await webView.callAsyncJavaScript(
             """
             const response = await fetch("/", {
@@ -342,8 +432,85 @@ public final class FireWebViewLoginCoordinator {
         }
     }
 
+    private func readCurrentUsername(in webView: WKWebView) async throws -> String? {
+        try await readStringJavaScript(
+            script: """
+            (function() {
+              try {
+                var meta = document.querySelector('meta[name="current-username"]');
+                if (meta && meta.content) return meta.content;
+                if (
+                  typeof Discourse !== 'undefined'
+                  && Discourse.User
+                  && typeof Discourse.User.current === 'function'
+                ) {
+                  var currentUser = Discourse.User.current();
+                  if (currentUser && currentUser.username) return currentUser.username;
+                }
+              } catch (error) {}
+              return null;
+            })();
+            """,
+            in: webView
+        )
+    }
+
+    private func readCsrfToken(in webView: WKWebView) async throws -> String? {
+        try await readStringJavaScript(
+            script: """
+            (function() {
+              var meta = document.querySelector('meta[name="csrf-token"]');
+              if (meta && meta.content) return meta.content;
+              return null;
+            })();
+            """,
+            in: webView
+        )
+    }
+
+    private func readCurrentPageBootstrapScore(in webView: WKWebView) async throws -> Int {
+        try await readIntJavaScript(
+            script: """
+            (function() {
+              try {
+                var score = 0;
+                if (document.querySelector('#data-discourse-setup,[data-preloaded]')) score += 8;
+                if (document.querySelector('meta[name="shared_session_key"]')) score += 4;
+                if (document.querySelector('meta[name="current-username"]')) score += 2;
+                if (document.querySelector('meta[name="csrf-token"]')) score += 1;
+                return score;
+              } catch (error) {
+                return 0;
+              }
+            })();
+            """,
+            in: webView
+        ) ?? 0
+    }
+
     private func readStringJavaScript(script: String, in webView: WKWebView) async throws -> String? {
-        let value: Any? = try await withCheckedThrowingContinuation {
+        let value = try await evaluateJavaScript(script: script, in: webView)
+
+        guard let string = value as? String, !string.isEmpty, string != "null" else {
+            return nil
+        }
+        return string
+    }
+
+    private func readIntJavaScript(script: String, in webView: WKWebView) async throws -> Int? {
+        let value = try await evaluateJavaScript(script: script, in: webView)
+
+        if let number = value as? NSNumber {
+            return number.intValue
+        }
+        if let string = value as? String {
+            return Int(string)
+        }
+        return nil
+    }
+
+    private func evaluateJavaScript(script: String, in webView: WKWebView) async throws -> Any? {
+        try await withCheckedThrowingContinuation {
             (continuation: CheckedContinuation<Any?, Error>) in
             webView.evaluateJavaScript(script) { result, error in
                 if let error {
@@ -353,11 +520,6 @@ public final class FireWebViewLoginCoordinator {
                 }
             }
         }
-
-        guard let string = value as? String, !string.isEmpty, string != "null" else {
-            return nil
-        }
-        return string
     }
 
     private func preferredBootstrapHTML(
@@ -371,31 +533,80 @@ public final class FireWebViewLoginCoordinator {
     }
 
     func loginSyncReadiness(for captured: FireCapturedLoginState) -> FireLoginSyncReadiness {
-        let username = captured.username?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let hasUsername = !(username?.isEmpty ?? true)
-        let activeCookies = captured.cookies.filter { cookie in
-            let value = cookie.value.trimmingCharacters(in: .whitespacesAndNewlines)
-            return !value.isEmpty && !(cookie.expiresAtUnixMs.map { $0 <= currentUnixMs() } ?? false)
-        }
-        let hasAuthCookies =
-            activeCookies.contains(where: { $0.name == "_t" })
-            && activeCookies.contains(where: { $0.name == "_forum_session" })
         let preferredHTML = preferredBootstrapHTML(
             browserFetchedHomeHTML: captured.homeHTML,
             currentPageHTML: nil
         )
-        let preferredBootstrapScore = FireBootstrapHTMLHeuristics.score(preferredHTML)
-        let hasBootstrapHTML = FireBootstrapHTMLHeuristics.isReusableLoginBootstrap(preferredHTML)
+        return loginSyncReadiness(
+            username: captured.username,
+            cookies: captured.cookies,
+            preferredBootstrapScore: FireBootstrapHTMLHeuristics.score(preferredHTML)
+        )
+    }
+
+    func loginSyncReadiness(
+        username: String?,
+        cookies: [PlatformCookieState],
+        preferredBootstrapScore: Int
+    ) -> FireLoginSyncReadiness {
+        let normalizedUsername = normalizeUsername(username)
+        let hasUsername = !(normalizedUsername?.isEmpty ?? true)
+        let hasAuthCookies = containsAuthCookies(in: cookies)
+        let hasBootstrapHTML =
+            preferredBootstrapScore >= FireBootstrapHTMLHeuristics.reusableLoginBootstrapScoreThreshold
+
         return FireLoginSyncReadiness(
             isReady: hasUsername && hasAuthCookies && hasBootstrapHTML,
-            username: username,
+            username: normalizedUsername,
             hasAuthCookies: hasAuthCookies,
             hasBootstrapHTML: hasBootstrapHTML,
             preferredBootstrapScore: preferredBootstrapScore
         )
     }
 
+    private func shouldProbeHomeFallback(
+        in webView: WKWebView,
+        currentPageBootstrapScore: Int,
+        username: String?
+    ) -> Bool {
+        guard !webView.isLoading, isLinuxDoHost(webView.url) else {
+            return false
+        }
+
+        return username == nil
+            || currentPageBootstrapScore < FireBootstrapHTMLHeuristics.reusableLoginBootstrapScoreThreshold
+    }
+
+    private func normalizeUsername(_ username: String?) -> String? {
+        let trimmed = username?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == true ? nil : trimmed
+    }
+
+    private func containsAuthCookies(in cookies: [PlatformCookieState]) -> Bool {
+        let activeCookies = cookies.filter { cookie in
+            let value = cookie.value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return !value.isEmpty && !(cookie.expiresAtUnixMs.map { $0 <= currentUnixMs() } ?? false)
+        }
+
+        return activeCookies.contains(where: { $0.name == "_t" })
+            && activeCookies.contains(where: { $0.name == "_forum_session" })
+    }
+
+    private func isLinuxDoHost(_ url: URL?) -> Bool {
+        guard let host = url?.host?.lowercased() else {
+            return false
+        }
+
+        return host == "linux.do" || host.hasSuffix(".linux.do")
+    }
+
     private func currentUnixMs() -> Int64 {
         Int64(Date().timeIntervalSince1970 * 1000)
     }
+}
+
+private struct FireLoginProbeHomeFallbackCache {
+    let currentURL: String?
+    let username: String?
+    let bootstrapScore: Int
 }

--- a/native/ios-app/Tests/Unit/FireDiffableListControllerTests.swift
+++ b/native/ios-app/Tests/Unit/FireDiffableListControllerTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Fire
+
+final class FireDiffableListControllerTests: XCTestCase {
+    func testLayoutUpdateHelperSkipsIdenticalVersions() {
+        XCTAssertFalse(fireCollectionNeedsLayoutUpdate(currentVersion: 1, incomingVersion: 1))
+        XCTAssertTrue(fireCollectionNeedsLayoutUpdate(currentVersion: 1, incomingVersion: 2))
+        XCTAssertTrue(fireCollectionNeedsLayoutUpdate(currentVersion: nil, incomingVersion: 0))
+    }
+
+    func testSectionUpdateHelperSkipsIdenticalSnapshots() {
+        let current = [
+            FireListSectionModel<Int, Int>(id: 0, items: [1, 2, 3])
+        ]
+        XCTAssertFalse(fireCollectionNeedsSectionUpdate(current: current, incoming: current))
+        XCTAssertTrue(
+            fireCollectionNeedsSectionUpdate(
+                current: current,
+                incoming: [FireListSectionModel(id: 0, items: [1, 2, 3, 4])]
+            )
+        )
+    }
+
+    func testCommonItemsHelperReturnsStableIdentifiersForReconfigure() {
+        let current = [
+            FireListSectionModel<Int, Int>(id: 0, items: [1, 2, 3])
+        ]
+        let incoming = [
+            FireListSectionModel<Int, Int>(id: 0, items: [3, 2, 4])
+        ]
+
+        XCTAssertEqual(fireCollectionCommonItems(current: current, incoming: incoming), [3, 2])
+    }
+
+    func testDefaultScrollAnchorRestorePolicySkipsAnimatedDiffs() {
+        XCTAssertFalse(
+            FireCollectionScrollAnchorRestorePolicy.whenNotAnimatingDifferences.shouldRestore(
+                animatingDifferences: true
+            )
+        )
+        XCTAssertTrue(
+            FireCollectionScrollAnchorRestorePolicy.whenNotAnimatingDifferences.shouldRestore(
+                animatingDifferences: false
+            )
+        )
+    }
+
+    func testScrollAnchorRestorePolicySupportsExplicitAlwaysAndNeverModes() {
+        XCTAssertTrue(
+            FireCollectionScrollAnchorRestorePolicy.always.shouldRestore(
+                animatingDifferences: true
+            )
+        )
+        XCTAssertFalse(
+            FireCollectionScrollAnchorRestorePolicy.never.shouldRestore(
+                animatingDifferences: false
+            )
+        )
+    }
+}

--- a/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
+++ b/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
@@ -544,6 +544,21 @@ final class FireSessionSecurityTests: XCTestCase {
         )
     }
 
+    func testBootstrapHTMLMetadataParserReadsMetaFallbackValues() {
+        let html = """
+        <!doctype html>
+        <html>
+          <head>
+            <meta content="alice" name="current-username">
+            <meta name="csrf-token" content="csrf-token">
+          </head>
+        </html>
+        """
+
+        XCTAssertEqual(FireBootstrapHTMLMetadataParser.currentUsername(from: html), "alice")
+        XCTAssertEqual(FireBootstrapHTMLMetadataParser.csrfToken(from: html), "csrf-token")
+    }
+
     @MainActor
     func testLoginSyncReadinessRequiresUsernameAuthCookiesAndBootstrapHTML() async {
         let store = MockLoginSessionStore(
@@ -631,6 +646,52 @@ final class FireSessionSecurityTests: XCTestCase {
     }
 
     @MainActor
+    func testOpenLoginPresentsLoginImmediatelyBeforeWarmupCompletes() async {
+        let gate = AsyncGate()
+        let viewModel = FireAppViewModel(
+            loginCoordinatorPreloader: {
+                await gate.wait()
+            },
+            loginNetworkWarmup: {}
+        )
+
+        viewModel.openLogin()
+
+        XCTAssertTrue(viewModel.isPresentingLogin)
+        XCTAssertTrue(viewModel.isPreparingLogin)
+
+        await gate.open()
+        let finishedPreparing = await waitUntil { !viewModel.isPreparingLogin }
+        XCTAssertTrue(finishedPreparing)
+        XCTAssertFalse(viewModel.isPreparingLogin)
+    }
+
+    @MainActor
+    func testOpenLoginKeepsPresentedWhenCoordinatorPreloadFails() async {
+        struct SampleLoginOpenError: LocalizedError {
+            var errorDescription: String? { "login init failed" }
+        }
+
+        let viewModel = FireAppViewModel(
+            loginCoordinatorPreloader: {
+                throw SampleLoginOpenError()
+            },
+            loginNetworkWarmup: {}
+        )
+
+        viewModel.openLogin()
+
+        XCTAssertTrue(viewModel.isPresentingLogin)
+
+        let finishedPreparing = await waitUntil { !viewModel.isPreparingLogin }
+        let surfacedError = await waitUntil { viewModel.errorMessage != nil }
+        XCTAssertTrue(finishedPreparing)
+        XCTAssertTrue(surfacedError)
+        XCTAssertFalse(viewModel.isPreparingLogin)
+        XCTAssertEqual(viewModel.errorMessage, "login init failed")
+    }
+
+    @MainActor
     func testChallengeRecoveryClearsLocalSessionAndPresentsLogin() async {
         let recoveryStore = MockChallengeRecoveryStore(
             result: .success(challengedLoggedOutSession())
@@ -705,35 +766,41 @@ final class FireSessionSecurityTests: XCTestCase {
     }
 
     @MainActor
-    func testLoginWebViewProbeBridgeRequestsProbeWhenCookiesChange() {
+    func testLoginWebViewProbeBridgeDebouncesCookieTriggeredProbes() {
         let expectation = expectation(description: "probe requested")
         let webView = WKWebView(frame: .zero)
         var probedWebView: WKWebView?
+        var probeCount = 0
         let bridge = FireLoginWebViewProbeBridge { webView in
+            probeCount += 1
             probedWebView = webView
             expectation.fulfill()
         }
 
         bridge.attach(to: webView)
         bridge.cookiesDidChange(in: webView.configuration.websiteDataStore.httpCookieStore)
+        bridge.cookiesDidChange(in: webView.configuration.websiteDataStore.httpCookieStore)
+        bridge.cookiesDidChange(in: webView.configuration.websiteDataStore.httpCookieStore)
 
         wait(for: [expectation], timeout: 1.0)
+        XCTAssertEqual(probeCount, 1)
         XCTAssertTrue(probedWebView === webView)
     }
 
     @MainActor
     func testLoginWebViewProbeBridgeStopsRequestingProbeAfterDetach() {
         let webView = WKWebView(frame: .zero)
-        var probeCount = 0
+        let expectation = expectation(description: "probe should not fire")
+        expectation.isInverted = true
         let bridge = FireLoginWebViewProbeBridge { _ in
-            probeCount += 1
+            expectation.fulfill()
         }
 
         bridge.attach(to: webView)
         bridge.detach()
         bridge.cookiesDidChange(in: webView.configuration.websiteDataStore.httpCookieStore)
 
-        XCTAssertEqual(probeCount, 0)
+        wait(for: [expectation], timeout: 0.5)
     }
 
     private func makeSessionFileURL(name: String) throws -> URL {
@@ -742,6 +809,22 @@ final class FireSessionSecurityTests: XCTestCase {
         let testsURL = workspaceURL.appendingPathComponent("Tests", isDirectory: true)
         try FileManager.default.createDirectory(at: testsURL, withIntermediateDirectories: true)
         return testsURL.appendingPathComponent("\(name)-\(UUID().uuidString).json", isDirectory: false)
+    }
+
+    @MainActor
+    private func waitUntil(
+        timeoutNanoseconds: UInt64 = 1_000_000_000,
+        condition: @escaping @MainActor () -> Bool
+    ) async -> Bool {
+        let deadline = DispatchTime.now().uptimeNanoseconds + timeoutNanoseconds
+        while DispatchTime.now().uptimeNanoseconds < deadline {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+
+        return condition()
     }
 
     private func makePlatformCookie(
@@ -1203,6 +1286,32 @@ private actor ColdStartRefreshRecorder {
             bootstrapRefreshCount: bootstrapRefreshCount,
             csrfRefreshCount: csrfRefreshCount
         )
+    }
+}
+
+private actor AsyncGate {
+    private var isOpen = false
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+
+    func wait() async {
+        guard !isOpen else {
+            return
+        }
+
+        await withCheckedContinuation { continuation in
+            waiters.append(continuation)
+        }
+    }
+
+    func open() {
+        guard !isOpen else {
+            return
+        }
+
+        isOpen = true
+        let pendingWaiters = waiters
+        waiters.removeAll()
+        pendingWaiters.forEach { $0.resume() }
     }
 }
 

--- a/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
+++ b/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WebKit
 import XCTest
 @testable import Fire
 
@@ -701,6 +702,38 @@ final class FireSessionSecurityTests: XCTestCase {
         XCTAssertTrue(viewModel.session.readiness.canReadAuthenticatedApi)
         let calls = await recoveryStore.recordedCalls()
         XCTAssertTrue(calls.isEmpty)
+    }
+
+    @MainActor
+    func testLoginWebViewProbeBridgeRequestsProbeWhenCookiesChange() {
+        let expectation = expectation(description: "probe requested")
+        let webView = WKWebView(frame: .zero)
+        var probedWebView: WKWebView?
+        let bridge = FireLoginWebViewProbeBridge { webView in
+            probedWebView = webView
+            expectation.fulfill()
+        }
+
+        bridge.attach(to: webView)
+        bridge.cookiesDidChange(in: webView.configuration.websiteDataStore.httpCookieStore)
+
+        wait(for: [expectation], timeout: 1.0)
+        XCTAssertTrue(probedWebView === webView)
+    }
+
+    @MainActor
+    func testLoginWebViewProbeBridgeStopsRequestingProbeAfterDetach() {
+        let webView = WKWebView(frame: .zero)
+        var probeCount = 0
+        let bridge = FireLoginWebViewProbeBridge { _ in
+            probeCount += 1
+        }
+
+        bridge.attach(to: webView)
+        bridge.detach()
+        bridge.cookiesDidChange(in: webView.configuration.websiteDataStore.httpCookieStore)
+
+        XCTAssertEqual(probeCount, 0)
     }
 
     private func makeSessionFileURL(name: String) throws -> URL {

--- a/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
+++ b/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
@@ -544,6 +544,92 @@ final class FireSessionSecurityTests: XCTestCase {
     }
 
     @MainActor
+    func testLoginSyncReadinessRequiresUsernameAuthCookiesAndBootstrapHTML() async {
+        let store = MockLoginSessionStore(
+            syncResult: partialAuthenticatedSession(),
+            refreshResult: .success(readySession(username: "alice")),
+            logoutLocalResult: SessionState.placeholder()
+        )
+        let coordinator = FireWebViewLoginCoordinator(loginSessionStore: store)
+        let ready = coordinator.loginSyncReadiness(
+            for: FireCapturedLoginState(
+                currentURL: "https://linux.do",
+                username: "alice",
+                csrfToken: "csrf-token",
+                homeHTML: """
+                <!doctype html>
+                <html>
+                  <head><meta name="current-username" content="alice"></head>
+                  <body>
+                    <div id="data-discourse-setup" data-preloaded="{&quot;currentUser&quot;:{&quot;username&quot;:&quot;alice&quot;}}"></div>
+                  </body>
+                </html>
+                """,
+                browserUserAgent: "Mozilla/5.0",
+                cookies: [
+                    makePlatformCookie(name: "_t", value: "token"),
+                    makePlatformCookie(name: "_forum_session", value: "forum"),
+                ]
+            )
+        )
+        let missingBootstrap = coordinator.loginSyncReadiness(
+            for: FireCapturedLoginState(
+                currentURL: "https://linux.do",
+                username: "alice",
+                csrfToken: "csrf-token",
+                homeHTML: "<html><body>Done</body></html>",
+                browserUserAgent: "Mozilla/5.0",
+                cookies: [
+                    makePlatformCookie(name: "_t", value: "token"),
+                    makePlatformCookie(name: "_forum_session", value: "forum"),
+                ]
+            )
+        )
+        let missingCookies = coordinator.loginSyncReadiness(
+            for: FireCapturedLoginState(
+                currentURL: "https://linux.do",
+                username: "alice",
+                csrfToken: "csrf-token",
+                homeHTML: """
+                <!doctype html>
+                <html><body><div id="data-discourse-setup" data-preloaded="{}"></div></body></html>
+                """,
+                browserUserAgent: "Mozilla/5.0",
+                cookies: [makePlatformCookie(name: "_t", value: "token")]
+            )
+        )
+
+        XCTAssertTrue(ready.isReady)
+        XCTAssertTrue(ready.hasAuthCookies)
+        XCTAssertTrue(ready.hasBootstrapHTML)
+        XCTAssertFalse(missingBootstrap.isReady)
+        XCTAssertFalse(missingBootstrap.hasBootstrapHTML)
+        XCTAssertFalse(missingCookies.isReady)
+        XCTAssertFalse(missingCookies.hasAuthCookies)
+    }
+
+    func testCfClearanceRefreshServiceRequiresAuthenticatedSessionSceneAndSitekey() {
+        XCTAssertFalse(
+            FireCfClearanceRefreshService.shouldAutoRefresh(
+                session: authenticatedSession(),
+                sceneActive: true
+            )
+        )
+        XCTAssertFalse(
+            FireCfClearanceRefreshService.shouldAutoRefresh(
+                session: authenticatedSession(turnstileSitekey: "sitekey"),
+                sceneActive: false
+            )
+        )
+        XCTAssertTrue(
+            FireCfClearanceRefreshService.shouldAutoRefresh(
+                session: authenticatedSession(turnstileSitekey: "sitekey"),
+                sceneActive: true
+            )
+        )
+    }
+
+    @MainActor
     func testChallengeRecoveryClearsLocalSessionAndPresentsLogin() async {
         let recoveryStore = MockChallengeRecoveryStore(
             result: .success(challengedLoggedOutSession())
@@ -955,7 +1041,7 @@ final class FireSessionSecurityTests: XCTestCase {
         )
     }
 
-    private func authenticatedSession() -> SessionState {
+    private func authenticatedSession(turnstileSitekey: String? = nil) -> SessionState {
         SessionState(
             cookies: CookieState(
                 tToken: "token",
@@ -972,7 +1058,7 @@ final class FireSessionSecurityTests: XCTestCase {
                 currentUserId: 1,
                 notificationChannelPosition: 42,
                 longPollingBaseUrl: "https://linux.do",
-                turnstileSitekey: nil,
+                turnstileSitekey: turnstileSitekey,
                 topicTrackingStateMeta: nil,
                 preloadedJson: "{}",
                 hasPreloadedData: true,
@@ -1176,7 +1262,7 @@ private actor MockChallengeRecoveryStore: FireChallengeSessionRecovering {
         self.result = result
     }
 
-    func logoutLocal(preserveCfClearance: Bool) async throws -> SessionState {
+    func logoutLocalAndClearPlatformCookies(preserveCfClearance: Bool) async throws -> SessionState {
         calls.append(preserveCfClearance)
         return try result.get()
     }

--- a/rust/crates/fire-core/src/cookies.rs
+++ b/rust/crates/fire-core/src/cookies.rs
@@ -1,24 +1,29 @@
 use std::collections::HashSet;
 use std::sync::{Arc, RwLock};
 
-use fire_models::{CookieSnapshot, SessionSnapshot};
+use fire_models::CookieSnapshot;
 use http::header::HeaderValue;
 use openwire::CookieJar;
 use time::{format_description::well_known::Rfc2822, OffsetDateTime};
 use url::Url;
 
+use crate::core::FireSessionRuntimeState;
 use crate::sync_utils::{read_rwlock, write_rwlock};
 
 #[derive(Clone)]
 pub(crate) struct FireSessionCookieJar {
     base_url: Url,
-    session: Arc<RwLock<SessionSnapshot>>,
+    session: Arc<RwLock<FireSessionRuntimeState>>,
 }
 
 impl FireSessionCookieJar {
-    pub(crate) fn new(base_url: Url, session: Arc<RwLock<SessionSnapshot>>) -> Self {
+    pub(crate) fn new(base_url: Url, session: Arc<RwLock<FireSessionRuntimeState>>) -> Self {
         Self { base_url, session }
     }
+}
+
+tokio::task_local! {
+    pub(crate) static FIRE_REQUEST_EPOCH: u64;
 }
 
 impl CookieJar for FireSessionCookieJar {
@@ -28,6 +33,7 @@ impl CookieJar for FireSessionCookieJar {
         }
 
         let mut patch = CookieSnapshot::default();
+        let request_epoch = FIRE_REQUEST_EPOCH.try_with(|epoch| *epoch).ok();
         for header in cookie_headers {
             let Ok(value) = header.to_str() else {
                 continue;
@@ -35,6 +41,10 @@ impl CookieJar for FireSessionCookieJar {
             let Some(cookie) = parse_set_cookie(value, url) else {
                 continue;
             };
+            let is_auth_cookie = matches!(cookie.name.as_str(), "_t" | "_forum_session");
+            if is_auth_cookie && is_stale_request_epoch(&self.session, request_epoch) {
+                continue;
+            }
 
             match cookie.name.as_str() {
                 "_t" => patch.t_token = Some(cookie.value.clone()),
@@ -50,12 +60,13 @@ impl CookieJar for FireSessionCookieJar {
         }
 
         let mut session = write_rwlock(&self.session, "session");
-        session.cookies.merge_patch(&patch);
+        session.snapshot.cookies.merge_patch(&patch);
     }
 
     fn cookies(&self, url: &Url) -> Option<HeaderValue> {
         let session = read_rwlock(&self.session, "session");
-        if session.cookies.platform_cookies.is_empty() {
+        let snapshot = &session.snapshot;
+        if snapshot.cookies.platform_cookies.is_empty() {
             if !same_origin_scope(&self.base_url, url) {
                 return None;
             }
@@ -63,7 +74,7 @@ impl CookieJar for FireSessionCookieJar {
             return None;
         }
 
-        let cookies = build_cookie_header(&session.cookies, &self.base_url, url);
+        let cookies = build_cookie_header(&snapshot.cookies, &self.base_url, url);
         if cookies.is_empty() {
             return None;
         }
@@ -163,6 +174,17 @@ fn push_cookie_pair(pairs: &mut Vec<String>, name: &str, value: Option<&str>) {
         return;
     };
     pairs.push(format!("{name}={value}"));
+}
+
+fn is_stale_request_epoch(
+    session: &Arc<RwLock<FireSessionRuntimeState>>,
+    request_epoch: Option<u64>,
+) -> bool {
+    let Some(request_epoch) = request_epoch else {
+        return false;
+    };
+    let current_epoch = read_rwlock(session, "session").epoch;
+    current_epoch != request_epoch
 }
 
 fn cookie_send_precedence(

--- a/rust/crates/fire-core/src/core/messagebus.rs
+++ b/rust/crates/fire-core/src/core/messagebus.rs
@@ -28,11 +28,11 @@ use url::{form_urlencoded::Serializer, Url};
 use super::{
     network::{
         classify_http_status_error, header_value, request_origin, take_trace_cancellation_guard,
-        FireCallProfile, FireNetworkLayer, FireRequestProfile, TracedRequest,
+        FireCallProfile, FireNetworkLayer, FireRequestEpoch, FireRequestProfile, TracedRequest,
     },
     notifications::{merge_notification_event_data, FireNotificationRuntime},
     presence::{merge_topic_presence_event_data, FireTopicPresenceRuntime},
-    FireCore,
+    FireCore, FireSessionRuntimeState,
 };
 use crate::{
     diagnostics::FireDiagnosticsStore,
@@ -80,7 +80,7 @@ struct MessageBusPollContext {
     base_url: Url,
     network: FireNetworkLayer,
     diagnostics: Arc<FireDiagnosticsStore>,
-    session: Arc<RwLock<SessionSnapshot>>,
+    session: Arc<RwLock<FireSessionRuntimeState>>,
     runtime: Arc<Mutex<FireMessageBusRuntime>>,
     notifications: Arc<Mutex<FireNotificationRuntime>>,
     topic_presence: Arc<Mutex<FireTopicPresenceRuntime>>,
@@ -234,6 +234,7 @@ impl FireCore {
             &self.diagnostics,
             &self.base_url,
             &snapshot,
+            self.snapshot_with_epoch().1,
             &client_id,
             &[(channel.clone(), last_message_id)],
         )?;
@@ -510,11 +511,12 @@ fn build_message_bus_poll_request(
     context: &MessageBusPollContext,
     subscriptions: &[(String, i64)],
 ) -> Result<TracedRequest, FireCoreError> {
-    let snapshot = read_rwlock(&context.session, "session").clone();
+    let state = read_rwlock(&context.session, "session");
     build_message_bus_poll_request_for_snapshot(
         &context.diagnostics,
         &context.base_url,
-        &snapshot,
+        &state.snapshot,
+        state.epoch,
         &context.client_id,
         subscriptions,
     )
@@ -524,6 +526,7 @@ fn build_message_bus_poll_request_for_snapshot(
     diagnostics: &Arc<FireDiagnosticsStore>,
     base_url: &Url,
     snapshot: &SessionSnapshot,
+    epoch: u64,
     client_id: &str,
     subscriptions: &[(String, i64)],
 ) -> Result<TracedRequest, FireCoreError> {
@@ -562,6 +565,7 @@ fn build_message_bus_poll_request_for_snapshot(
     request
         .extensions_mut()
         .insert(FireRequestProfile::MessageBusPoll);
+    request.extensions_mut().insert(FireRequestEpoch(epoch));
     let trace_id = diagnostics.prepare_request_trace(MESSAGE_BUS_OPERATION, &mut request);
     Ok(TracedRequest { trace_id, request })
 }

--- a/rust/crates/fire-core/src/core/mod.rs
+++ b/rust/crates/fire-core/src/core/mod.rs
@@ -271,7 +271,10 @@ impl FireCore {
             let after = auth_cookie_epoch_key(&session.snapshot);
             if before != after {
                 session.epoch = session.epoch.saturating_add(1);
-                info!(session_epoch = session.epoch, reason, "advanced session epoch");
+                info!(
+                    session_epoch = session.epoch,
+                    reason, "advanced session epoch"
+                );
             }
             session.snapshot.clone()
         };

--- a/rust/crates/fire-core/src/core/mod.rs
+++ b/rust/crates/fire-core/src/core/mod.rs
@@ -46,12 +46,18 @@ const CLIENT_POOL_MAX_IDLE_PER_HOST: usize = 4;
 const MESSAGE_BUS_HTTP2_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(30);
 
 #[derive(Clone)]
+pub(crate) struct FireSessionRuntimeState {
+    pub(crate) snapshot: SessionSnapshot,
+    pub(crate) epoch: u64,
+}
+
+#[derive(Clone)]
 pub struct FireCore {
     base_url: Url,
     workspace_path: Option<PathBuf>,
     network: network::FireNetworkLayer,
     diagnostics: Arc<FireDiagnosticsStore>,
-    session: Arc<RwLock<SessionSnapshot>>,
+    session: Arc<RwLock<FireSessionRuntimeState>>,
     message_bus: Arc<Mutex<messagebus::FireMessageBusRuntime>>,
     notifications: Arc<Mutex<notifications::FireNotificationRuntime>>,
     topic_presence: Arc<Mutex<presence::FireTopicPresenceRuntime>>,
@@ -73,13 +79,16 @@ impl FireCore {
                 "initialized fire workspace logging"
             );
         }
-        let session = SessionSnapshot {
-            cookies: CookieSnapshot::default(),
-            bootstrap: BootstrapArtifacts {
-                base_url: base_url.as_str().to_string(),
-                ..BootstrapArtifacts::default()
+        let session = FireSessionRuntimeState {
+            snapshot: SessionSnapshot {
+                cookies: CookieSnapshot::default(),
+                bootstrap: BootstrapArtifacts {
+                    base_url: base_url.as_str().to_string(),
+                    ..BootstrapArtifacts::default()
+                },
+                browser_user_agent: None,
             },
-            browser_user_agent: None,
+            epoch: 1,
         };
         let session = Arc::new(RwLock::new(session));
         let cookie_jar = Arc::new(FireSessionCookieJar::new(base_url.clone(), session.clone()));
@@ -152,7 +161,12 @@ impl FireCore {
     }
 
     pub fn snapshot(&self) -> SessionSnapshot {
-        read_rwlock(&self.session, "session").clone()
+        read_rwlock(&self.session, "session").snapshot.clone()
+    }
+
+    pub(crate) fn snapshot_with_epoch(&self) -> (SessionSnapshot, u64) {
+        let state = read_rwlock(&self.session, "session");
+        (state.snapshot.clone(), state.epoch)
     }
 
     pub fn shared_client(&self) -> Client {
@@ -234,11 +248,42 @@ impl FireCore {
     {
         let snapshot = {
             let mut session = write_rwlock(&self.session, "session");
-            mutate(&mut session);
-            session.clone()
+            mutate(&mut session.snapshot);
+            session.snapshot.clone()
         };
         notifications::reconcile_notification_runtime(&self.notifications, &snapshot);
         presence::reconcile_topic_presence_runtime(&self.topic_presence, &snapshot);
         snapshot
     }
+
+    pub(crate) fn update_session_advancing_epoch_if_auth_changed<F>(
+        &self,
+        reason: &'static str,
+        mutate: F,
+    ) -> SessionSnapshot
+    where
+        F: FnOnce(&mut SessionSnapshot),
+    {
+        let snapshot = {
+            let mut session = write_rwlock(&self.session, "session");
+            let before = auth_cookie_epoch_key(&session.snapshot);
+            mutate(&mut session.snapshot);
+            let after = auth_cookie_epoch_key(&session.snapshot);
+            if before != after {
+                session.epoch = session.epoch.saturating_add(1);
+                info!(session_epoch = session.epoch, reason, "advanced session epoch");
+            }
+            session.snapshot.clone()
+        };
+        notifications::reconcile_notification_runtime(&self.notifications, &snapshot);
+        presence::reconcile_topic_presence_runtime(&self.topic_presence, &snapshot);
+        snapshot
+    }
+}
+
+fn auth_cookie_epoch_key(snapshot: &SessionSnapshot) -> (Option<String>, Option<String>) {
+    (
+        snapshot.cookies.t_token.clone(),
+        snapshot.cookies.forum_session.clone(),
+    )
 }

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -20,7 +20,7 @@ use super::{
     NETWORK_CONNECT_TIMEOUT,
 };
 use crate::{
-    cookies::FireSessionCookieJar,
+    cookies::{FireSessionCookieJar, FIRE_REQUEST_EPOCH},
     diagnostics::{
         FireDiagnosticsStore, FireNetworkTraceCancellationGuard,
         FireNetworkTraceEventListenerFactory,
@@ -90,6 +90,9 @@ pub(crate) enum FireCallProfile {
     MessageBusPoll,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FireRequestEpoch(pub(crate) u64);
+
 #[derive(Clone)]
 pub(crate) struct FireNetworkLayer {
     client: Client,
@@ -100,7 +103,7 @@ pub(crate) struct FireNetworkLayer {
 pub(crate) struct FireCommonHeaderInterceptor {
     origin: String,
     referer: String,
-    session: Arc<RwLock<fire_models::SessionSnapshot>>,
+    session: Arc<RwLock<super::FireSessionRuntimeState>>,
 }
 
 #[derive(Clone)]
@@ -115,7 +118,10 @@ impl FireTraceSnapshotInterceptor {
 }
 
 impl FireCommonHeaderInterceptor {
-    pub(crate) fn new(base_url: Url, session: Arc<RwLock<fire_models::SessionSnapshot>>) -> Self {
+    pub(crate) fn new(
+        base_url: Url,
+        session: Arc<RwLock<super::FireSessionRuntimeState>>,
+    ) -> Self {
         Self {
             origin: request_origin(&base_url),
             referer: request_referer(&base_url),
@@ -127,7 +133,7 @@ impl FireCommonHeaderInterceptor {
         let Some(profile) = request.extensions().get::<FireRequestProfile>().copied() else {
             return;
         };
-        let snapshot = read_rwlock(&self.session, "session").clone();
+        let snapshot = read_rwlock(&self.session, "session").snapshot.clone();
         apply_common_profile_headers(
             request.headers_mut(),
             profile,
@@ -183,7 +189,7 @@ pub(crate) struct TracedRequest {
 impl FireNetworkLayer {
     pub(crate) fn new(
         base_url: &Url,
-        session: Arc<RwLock<fire_models::SessionSnapshot>>,
+        session: Arc<RwLock<super::FireSessionRuntimeState>>,
         diagnostics: Arc<FireDiagnosticsStore>,
         cookie_jar: Arc<FireSessionCookieJar>,
     ) -> Result<Self, FireCoreError> {
@@ -221,6 +227,12 @@ impl FireNetworkLayer {
         profile: FireCallProfile,
     ) -> Result<(u64, Response<ResponseBody>), FireCoreError> {
         let trace_id = traced.trace_id;
+        let request_epoch = traced
+            .request
+            .extensions()
+            .get::<FireRequestEpoch>()
+            .copied()
+            .unwrap_or(FireRequestEpoch(0));
         debug!(
             trace_id,
             method = %traced.request.method(),
@@ -233,10 +245,8 @@ impl FireNetworkLayer {
             "Request cancelled",
             "Future dropped before the trace reached a terminal state",
         );
-        let mut response = match apply_call_profile(self.client.new_call(traced.request), profile)
-            .execute()
-            .await
-        {
+        let execute = apply_call_profile(self.client.new_call(traced.request), profile).execute();
+        let mut response = match FIRE_REQUEST_EPOCH.scope(request_epoch.0, execute).await {
             Ok(response) => response,
             Err(source) => {
                 self.diagnostics
@@ -288,6 +298,7 @@ impl FireCore {
         operation: &'static str,
     ) -> Result<TracedRequest, FireCoreError> {
         let uri = self.base_url.join("/")?;
+        let (_, epoch) = self.snapshot_with_epoch();
         let mut request = Request::builder()
             .method(Method::GET)
             .uri(uri.as_str())
@@ -297,6 +308,7 @@ impl FireCore {
         request
             .extensions_mut()
             .insert(FireRequestProfile::HomeHtml);
+        request.extensions_mut().insert(FireRequestEpoch(epoch));
         let trace_id = self
             .diagnostics
             .prepare_request_trace(operation, &mut request);
@@ -311,6 +323,7 @@ impl FireCore {
         extra_headers: &[(&str, String)],
     ) -> Result<TracedRequest, FireCoreError> {
         let mut uri = self.base_url.join(path)?;
+        let (_, epoch) = self.snapshot_with_epoch();
         if !query_params.is_empty() {
             let mut serializer = uri.query_pairs_mut();
             for (key, value) in query_params {
@@ -331,6 +344,7 @@ impl FireCore {
             .body(RequestBody::empty())
             .map_err(FireCoreError::RequestBuild)?;
         request.extensions_mut().insert(FireRequestProfile::JsonApi);
+        request.extensions_mut().insert(FireRequestEpoch(epoch));
         let trace_id = self
             .diagnostics
             .prepare_request_trace(operation, &mut request);
@@ -390,7 +404,7 @@ impl FireCore {
         }
 
         let uri = self.base_url.join(path)?;
-        let snapshot = self.snapshot();
+        let (snapshot, epoch) = self.snapshot_with_epoch();
 
         let mut builder = Request::builder()
             .method(method)
@@ -417,6 +431,7 @@ impl FireCore {
             .body(RequestBody::from(serializer.finish()))
             .map_err(FireCoreError::RequestBuild)?;
         request.extensions_mut().insert(FireRequestProfile::JsonApi);
+        request.extensions_mut().insert(FireRequestEpoch(epoch));
         let trace_id = self
             .diagnostics
             .prepare_request_trace(operation, &mut request);
@@ -433,7 +448,7 @@ impl FireCore {
         requires_csrf: bool,
     ) -> Result<TracedRequest, FireCoreError> {
         let uri = self.base_url.join(path)?;
-        let snapshot = self.snapshot();
+        let (snapshot, epoch) = self.snapshot_with_epoch();
 
         let mut builder = Request::builder()
             .method(method)
@@ -454,6 +469,7 @@ impl FireCore {
 
         let mut request = builder.body(body).map_err(FireCoreError::RequestBuild)?;
         request.extensions_mut().insert(FireRequestProfile::JsonApi);
+        request.extensions_mut().insert(FireRequestEpoch(epoch));
         let trace_id = self
             .diagnostics
             .prepare_request_trace(operation, &mut request);
@@ -518,9 +534,20 @@ impl FireCore {
             return Ok((trace_id, response));
         }
 
+        let invalidation = response_login_invalidation_signal(response.headers());
         let body = self.read_response_text(trace_id, response).await?;
         self.diagnostics
             .record_http_status_error(trace_id, StatusCode::FORBIDDEN.as_u16(), &body);
+        if let Some(error) = response_login_invalidation_error(
+            self,
+            operation,
+            trace_id,
+            StatusCode::FORBIDDEN,
+            invalidation,
+            &body,
+        ) {
+            return Err(error);
+        }
 
         if !is_bad_csrf_body(&body) {
             warn!(
@@ -597,34 +624,29 @@ pub(crate) async fn expect_success(
 ) -> Result<Response<ResponseBody>, FireCoreError> {
     if response.status().is_success() {
         if operation != "logout" {
+            let response_status = response.status();
             let invalidation = response_login_invalidation_signal(response.headers());
-            let has_local_login = {
-                let snapshot = core.snapshot();
-                snapshot.cookies.has_login_session() || snapshot.cookies.has_forum_session()
-            };
-            if has_local_login && invalidation.any() {
+            if invalidation.any() {
                 let body = core.read_response_text(trace_id, response).await?;
-                warn!(
+                let error = response_login_invalidation_error(
+                    core,
                     operation,
                     trace_id,
-                    discourse_logged_out = invalidation.discourse_logged_out,
-                    cleared_t_cookie = invalidation.cleared_t_cookie,
-                    cleared_forum_session = invalidation.cleared_forum_session,
-                    body_prefix = %body.chars().take(200).collect::<String>(),
-                    "successful response invalidated login session"
-                );
-                let _ = core.logout_local(true);
-                return Err(FireCoreError::LoginRequired {
-                    operation,
-                    message: LOGIN_INVALIDATED_MESSAGE.to_string(),
-                });
+                    response_status,
+                    invalidation,
+                    &body,
+                )
+                .expect("invalidation signal should always produce a login-required error");
+                return Err(error);
             }
         }
         return Ok(response);
     }
 
     let mut response = response;
-    let status = response.status().as_u16();
+    let response_status = response.status();
+    let status = response_status.as_u16();
+    let invalidation = response_login_invalidation_signal(response.headers());
     let _trace_guard = take_trace_cancellation_guard(&mut response).unwrap_or_else(|| {
         core.diagnostics.cancellation_guard(
             trace_id,
@@ -646,6 +668,16 @@ pub(crate) async fn expect_success(
     );
     core.diagnostics
         .record_http_status_error(trace_id, status, &body);
+    if let Some(error) = response_login_invalidation_error(
+        core,
+        operation,
+        trace_id,
+        response_status,
+        invalidation,
+        &body,
+    ) {
+        return Err(error);
+    }
     Err(classify_http_status_error(operation, status, body))
 }
 
@@ -747,6 +779,43 @@ fn clears_cookie(set_cookie_header: &str, name: &str) -> bool {
     }
 
     lower.contains("max-age=0") || lower.contains("expires=thu, 01 jan 1970 00:00:00 gmt")
+}
+
+fn response_login_invalidation_error(
+    core: &FireCore,
+    operation: &'static str,
+    trace_id: u64,
+    status: StatusCode,
+    invalidation: LoginInvalidationSignal,
+    body: &str,
+) -> Option<FireCoreError> {
+    let login_required_message = not_logged_in_message(status.as_u16(), body);
+    if !invalidation.any() && login_required_message.is_none() {
+        return None;
+    }
+
+    let has_local_login = {
+        let snapshot = core.snapshot();
+        snapshot.cookies.has_login_session() || snapshot.cookies.has_forum_session()
+    };
+
+    warn!(
+        operation,
+        trace_id,
+        status = status.as_u16(),
+        discourse_logged_out = invalidation.discourse_logged_out,
+        cleared_t_cookie = invalidation.cleared_t_cookie,
+        cleared_forum_session = invalidation.cleared_forum_session,
+        body_prefix = %body.chars().take(200).collect::<String>(),
+        "response invalidated login session"
+    );
+    if has_local_login {
+        let _ = core.logout_local(true);
+    }
+    Some(FireCoreError::LoginRequired {
+        operation,
+        message: login_required_message.unwrap_or_else(|| LOGIN_INVALIDATED_MESSAGE.to_string()),
+    })
 }
 
 pub(crate) fn is_cloudflare_challenge_body(body: &str) -> bool {

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -118,10 +118,7 @@ impl FireTraceSnapshotInterceptor {
 }
 
 impl FireCommonHeaderInterceptor {
-    pub(crate) fn new(
-        base_url: Url,
-        session: Arc<RwLock<super::FireSessionRuntimeState>>,
-    ) -> Self {
+    pub(crate) fn new(base_url: Url, session: Arc<RwLock<super::FireSessionRuntimeState>>) -> Self {
         Self {
             origin: request_origin(&base_url),
             referer: request_referer(&base_url),

--- a/rust/crates/fire-core/src/core/session.rs
+++ b/rust/crates/fire-core/src/core/session.rs
@@ -12,7 +12,7 @@ impl FireCore {
             cookie_count = cookies.len(),
             "merging platform cookies into session"
         );
-        self.update_session(|session| {
+        self.update_session_advancing_epoch_if_auth_changed("merge platform cookies", |session| {
             session.cookies.merge_platform_cookies(&cookies);
             debug!(
                 phase = ?session.login_phase(),
@@ -27,7 +27,7 @@ impl FireCore {
             cookie_count = cookies.len(),
             "applying platform cookies into session"
         );
-        self.update_session(|session| {
+        self.update_session_advancing_epoch_if_auth_changed("apply platform cookies", |session| {
             session.cookies.apply_platform_cookies(&cookies);
             debug!(
                 phase = ?session.login_phase(),
@@ -113,7 +113,7 @@ impl FireCore {
             .home_html
             .as_deref()
             .map(|html| parse_home_state(self.base_url(), html));
-        self.update_session(|session| {
+        self.update_session_advancing_epoch_if_auth_changed("sync login context", |session| {
             session.cookies.apply_platform_cookies(&input.cookies);
             if let Some(browser_user_agent) = input
                 .browser_user_agent
@@ -157,7 +157,7 @@ impl FireCore {
         self.stop_message_bus(true);
         self.clear_notification_state();
         self.clear_topic_presence_state();
-        self.update_session(|session| {
+        self.update_session_advancing_epoch_if_auth_changed("logout local", |session| {
             session.clear_login_state(preserve_cf_clearance);
             debug!(
                 phase = ?session.login_phase(),
@@ -170,6 +170,7 @@ impl FireCore {
 
     pub fn has_login_session(&self) -> bool {
         read_rwlock(&self.session, "session")
+            .snapshot
             .cookies
             .has_login_session()
     }

--- a/rust/crates/fire-core/tests/network.rs
+++ b/rust/crates/fire-core/tests/network.rs
@@ -686,7 +686,10 @@ async fn stale_response_auth_cookies_do_not_override_rotated_session() {
     assert_eq!(result.topics.len(), 1);
     let snapshot = core.snapshot();
     assert_eq!(snapshot.cookies.t_token.as_deref(), Some("fresh-token"));
-    assert_eq!(snapshot.cookies.forum_session.as_deref(), Some("fresh-forum"));
+    assert_eq!(
+        snapshot.cookies.forum_session.as_deref(),
+        Some("fresh-forum")
+    );
 }
 
 #[tokio::test]

--- a/rust/crates/fire-core/tests/network.rs
+++ b/rust/crates/fire-core/tests/network.rs
@@ -4,7 +4,7 @@ use std::sync::atomic::Ordering;
 
 use common::{
     raw_json_response, raw_text_response, sample_home_html, sample_latest_json,
-    sample_topic_detail_json, TestServer,
+    sample_topic_detail_json, TestServer, TestServerStep,
 };
 use fire_core::{FireCore, FireCoreConfig, FireCoreError};
 use fire_models::{
@@ -12,6 +12,7 @@ use fire_models::{
     TopicReplyRequest, TopicTag,
 };
 use serde_json::{json, Value};
+use tokio::time::{sleep, Duration};
 
 #[tokio::test]
 async fn fetch_topic_list_parses_latest_payload() {
@@ -466,6 +467,226 @@ async fn fetch_topic_list_surfaces_login_required_when_success_response_invalida
     assert_eq!(snapshot.cookies.cf_clearance.as_deref(), Some("clearance"));
     assert_eq!(snapshot.bootstrap.current_username, None);
     assert!(!snapshot.bootstrap.has_preloaded_data);
+}
+
+#[tokio::test]
+async fn fetch_topic_list_surfaces_login_required_and_clears_local_state_for_not_logged_in_error() {
+    let body = r#"{"errors":["需要登录才能执行此操作。"],"error_type":"not_logged_in"}"#;
+    let response = raw_json_response(403, "application/json", body);
+    let server = TestServer::spawn(vec![response]).await.expect("server");
+    let core = FireCore::new(FireCoreConfig {
+        base_url: server.base_url(),
+        workspace_path: None,
+    })
+    .expect("core");
+
+    let _ = core.sync_login_context(LoginSyncInput {
+        username: Some("alice".into()),
+        home_html: Some(sample_home_html()),
+        csrf_token: Some("csrf-token".into()),
+        current_url: Some(server.base_url()),
+        browser_user_agent: None,
+        cookies: vec![
+            PlatformCookie {
+                name: "_t".into(),
+                value: "token".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+            PlatformCookie {
+                name: "_forum_session".into(),
+                value: "forum".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+            PlatformCookie {
+                name: "cf_clearance".into(),
+                value: "clearance".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+        ],
+    });
+
+    let error = core
+        .fetch_topic_list(TopicListQuery {
+            kind: TopicListKind::Latest,
+            ..TopicListQuery::default()
+        })
+        .await
+        .expect_err("login-required error should surface");
+    let _ = server.shutdown().await;
+
+    assert!(matches!(
+        error,
+        FireCoreError::LoginRequired { message, .. }
+            if message == "需要登录才能执行此操作。"
+    ));
+
+    let snapshot = core.snapshot();
+    assert_eq!(snapshot.cookies.t_token, None);
+    assert_eq!(snapshot.cookies.forum_session, None);
+    assert_eq!(snapshot.cookies.csrf_token, None);
+    assert_eq!(snapshot.cookies.cf_clearance.as_deref(), Some("clearance"));
+    assert!(!snapshot.bootstrap.has_preloaded_data);
+}
+
+#[tokio::test]
+async fn stale_response_auth_cookies_do_not_restore_logged_out_session() {
+    let body = sample_latest_json();
+    let response = format!(
+        "HTTP/1.1 200 TEST\r\nContent-Type: application/json\r\nContent-Length: {}\r\nSet-Cookie: _t=stale-token; path=/; SameSite=Lax\r\nSet-Cookie: _forum_session=stale-forum; path=/; SameSite=Lax\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let server = TestServer::spawn_scripted(vec![TestServerStep::delayed(
+        response,
+        Duration::from_millis(150),
+    )])
+    .await
+    .expect("server");
+    let core = FireCore::new(FireCoreConfig {
+        base_url: server.base_url(),
+        workspace_path: None,
+    })
+    .expect("core");
+
+    let _ = core.sync_login_context(LoginSyncInput {
+        username: Some("alice".into()),
+        home_html: Some(sample_home_html()),
+        csrf_token: Some("csrf-token".into()),
+        current_url: Some(server.base_url()),
+        browser_user_agent: None,
+        cookies: vec![
+            PlatformCookie {
+                name: "_t".into(),
+                value: "token".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+            PlatformCookie {
+                name: "_forum_session".into(),
+                value: "forum".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+        ],
+    });
+
+    let request_core = core.clone();
+    let task = tokio::spawn(async move {
+        request_core
+            .fetch_topic_list(TopicListQuery {
+                kind: TopicListKind::Latest,
+                ..TopicListQuery::default()
+            })
+            .await
+    });
+
+    sleep(Duration::from_millis(40)).await;
+    let cleared = core.logout_local(true);
+    assert!(!cleared.cookies.has_login_session());
+
+    let result = task.await.expect("task join").expect("topic list");
+    let _ = server.shutdown().await;
+
+    assert_eq!(result.topics.len(), 1);
+    let snapshot = core.snapshot();
+    assert_eq!(snapshot.cookies.t_token, None);
+    assert_eq!(snapshot.cookies.forum_session, None);
+    assert_eq!(snapshot.cookies.cf_clearance, None);
+}
+
+#[tokio::test]
+async fn stale_response_auth_cookies_do_not_override_rotated_session() {
+    let body = sample_latest_json();
+    let response = format!(
+        "HTTP/1.1 200 TEST\r\nContent-Type: application/json\r\nContent-Length: {}\r\nSet-Cookie: _t=stale-token; path=/; SameSite=Lax\r\nSet-Cookie: _forum_session=stale-forum; path=/; SameSite=Lax\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let server = TestServer::spawn_scripted(vec![TestServerStep::delayed(
+        response,
+        Duration::from_millis(150),
+    )])
+    .await
+    .expect("server");
+    let core = FireCore::new(FireCoreConfig {
+        base_url: server.base_url(),
+        workspace_path: None,
+    })
+    .expect("core");
+
+    let _ = core.sync_login_context(LoginSyncInput {
+        username: Some("alice".into()),
+        home_html: Some(sample_home_html()),
+        csrf_token: Some("csrf-token".into()),
+        current_url: Some(server.base_url()),
+        browser_user_agent: None,
+        cookies: vec![
+            PlatformCookie {
+                name: "_t".into(),
+                value: "old-token".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+            PlatformCookie {
+                name: "_forum_session".into(),
+                value: "old-forum".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+        ],
+    });
+
+    let request_core = core.clone();
+    let task = tokio::spawn(async move {
+        request_core
+            .fetch_topic_list(TopicListQuery {
+                kind: TopicListKind::Latest,
+                ..TopicListQuery::default()
+            })
+            .await
+    });
+
+    sleep(Duration::from_millis(40)).await;
+    let rotated = core.sync_login_context(LoginSyncInput {
+        username: Some("alice".into()),
+        home_html: Some(sample_home_html()),
+        csrf_token: Some("csrf-token".into()),
+        current_url: Some(server.base_url()),
+        browser_user_agent: None,
+        cookies: vec![
+            PlatformCookie {
+                name: "_t".into(),
+                value: "fresh-token".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+            PlatformCookie {
+                name: "_forum_session".into(),
+                value: "fresh-forum".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+        ],
+    });
+    assert_eq!(rotated.cookies.t_token.as_deref(), Some("fresh-token"));
+
+    let result = task.await.expect("task join").expect("topic list");
+    let _ = server.shutdown().await;
+
+    assert_eq!(result.topics.len(), 1);
+    let snapshot = core.snapshot();
+    assert_eq!(snapshot.cookies.t_token.as_deref(), Some("fresh-token"));
+    assert_eq!(snapshot.cookies.forum_session.as_deref(), Some("fresh-forum"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- stop the home diffable list from reapplying identical snapshots and rebuilding layout on unrelated SwiftUI updates
- reconfigure stable home items when content changes so tag/category selection state updates immediately
- move the tag picker entry to the front of the home tag row and add focused ListKit regression tests

## Testing
- xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -only-testing:FireTests/FireDiffableListControllerTests test -destination 'platform=iOS Simulator,name=iPhone 16,OS=18.2'