### PR TITLE
Align iOS auth session recovery with Fluxdo

### DIFF
--- a/docs/architecture/fire-native-workspace.md
+++ b/docs/architecture/fire-native-workspace.md
@@ -50,6 +50,7 @@ fire/
   - native UI, files, media, notifications, keychain/keystore
 - Rust-owned:
   - session state
+  - session epoch invalidation for stale network responses and cookies
   - bootstrap parsing results
   - API orchestration
   - MessageBus

--- a/docs/architecture/fire-native-workspace.md
+++ b/docs/architecture/fire-native-workspace.md
@@ -113,8 +113,9 @@ The intended native integration order is:
 7. If homepage HTML is unavailable or stale, or the restored authenticated snapshot is missing username/preloaded bootstrap fields, call `refresh_bootstrap_if_needed`. When homepage bootstrap still lacks site metadata such as categories/top tags, the shared Rust layer now falls back to `/site.json`. Only treat `shared_session_key` as required when MessageBus uses a cross-origin long-polling host.
 8. If the restored session is otherwise ready but the local snapshot still lacks CSRF, call `refresh_csrf_token_if_needed` before surfacing a fully ready authenticated session. The iOS `restoreColdStartSession()` path now performs this repair automatically. Write APIs can reuse the same helper whenever they need a newer token.
 9. Use `fetch_topic_list` (global, category-scoped, tag-scoped, or private-message mailbox variants via `TopicListQuery`) and `fetch_topic_detail` for the authenticated read paths.
-10. On explicit logout, prefer `logout_remote`, then fall back to `logout_local`, clear the persisted session, and remove host-side WebView auth cookies so the native shell and platform browser state agree.
-11. Use `notification_state`, `fetch_recent_notifications`, `fetch_notifications`, `mark_notification_read`, and `mark_all_notifications_read` for the shared in-app notification data path; keep OS-level/system notification presentation on the hosts.
+10. If Rust returns `CloudflareChallenge` for an authenticated operation, keep the current session snapshot, present `/challenge` in a host-owned auth WebView, re-sync the latest same-site browser cookie batch into Rust after verification, and then retry the blocked operation from the host.
+11. On explicit logout, prefer `logout_remote`, then fall back to `logout_local`, clear the persisted session, and remove host-side WebView auth cookies so the native shell and platform browser state agree.
+12. Use `notification_state`, `fetch_recent_notifications`, `fetch_notifications`, `mark_notification_read`, and `mark_all_notifications_read` for the shared in-app notification data path; keep OS-level/system notification presentation on the hosts.
 
 File ownership convention:
 

--- a/docs/architecture/ios-auth-alignment-plan.md
+++ b/docs/architecture/ios-auth-alignment-plan.md
@@ -1,0 +1,253 @@
+# Align iOS Auth Session Recovery With Fluxdo
+
+## Feasibility Assessment
+
+This change is fully achievable inside the current Fire architecture. `fire-core` already owns session state, epoch tracking, cookie transport, login invalidation classification, and shared request execution. The iOS host already owns `WKWebView` login, platform cookie extraction, local cookie mirroring, and Cloudflare WebView surfaces. The remaining work is to close three concrete gaps: full same-site cookie mirroring on iOS, stale-response invalidation in the shared Rust network boundary, and interactive Cloudflare recovery with automatic retry. Fully feasible.
+
+## Current Surface Inventory
+
+- `docs/architecture/fire-native-workspace.md` -- shared architecture contract for auth and session ownership.
+- `native/ios-app/App/SessionState+Helpers.swift` -- mirrors Rust session cookies into `HTTPCookieStorage` and `WKHTTPCookieStore`.
+- `native/ios-app/Sources/FireAppSession/FireSessionStore.swift` -- persists/restores iOS session state and wraps `fire-core`.
+- `native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift` -- extracts username, CSRF, HTML, and cookies from `WKWebView`.
+- `native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift` -- hidden WebView loop for `cf_clearance` refresh.
+- `native/ios-app/App/FireAppViewModel.swift` -- session application, login presentation, and recoverable error routing.
+- `native/ios-app/App/FireLoginWebView.swift` -- login-only auth WebView surface.
+- `native/ios-app/App/FireTabRoot.swift` -- authenticated vs onboarding root presentation.
+- `native/ios-app/App/Stores/FireHomeFeedStore.swift` -- authenticated home topic-list reads.
+- `native/ios-app/App/Stores/FireTopicDetailStore.swift` -- authenticated topic-detail reads and refreshes.
+- `native/ios-app/App/Stores/FireNotificationStore.swift` -- authenticated notification state refreshes.
+- `rust/crates/fire-core/src/core/network.rs` -- shared HTTP request execution, status classification, and CSRF retry behavior.
+- `rust/crates/fire-core/src/cookies.rs` -- session cookie jar ingress/egress and stale-cookie protection.
+- `rust/crates/fire-core/src/error.rs` -- shared Rust error taxonomy.
+- `rust/crates/fire-core/src/core/messagebus.rs` -- shared MessageBus request construction.
+- `rust/crates/fire-uniffi/src/lib.rs` -- Rust-to-Swift/Kotlin error mapping and exported API surface.
+
+## Design
+
+### Key Design Decisions
+
+1. Use full same-site platform cookie mirroring on iOS rather than mirroring only `_t`, `_forum_session`, and `cf_clearance`.
+   Rejected alternative: continue mirroring only critical auth cookies.
+   Reason: restored WebView state must match Rust request state, including browser-context cookies such as `__cf_bm`.
+
+2. Invalidate stale responses at the shared Rust network boundary rather than adding ad hoc request-generation checks in Swift stores.
+   Rejected alternative: let old successful responses complete and only block stale `Set-Cookie`.
+   Reason: stale payloads can still mutate UI state even if stale cookies are blocked.
+
+3. Keep Cloudflare challenge detection in Rust and interactive challenge completion in the iOS host.
+   Rejected alternative: move challenge UI policy into Rust.
+   Reason: challenge completion depends on `WKWebView`, cookie stores, scene presentation, and host-owned UX state.
+
+4. Reuse one auth WebView shell for both login sync and Cloudflare recovery, but distinguish them via explicit flow state.
+   Rejected alternative: maintain a separate challenge-only screen and coordinator tree.
+   Reason: the login WebView already owns the necessary cookie observation and completion hooks.
+
+5. Update `origin/main` first, then land the work as two commits on a dedicated feature branch.
+   Rejected alternative: stack phase work in the old local baseline.
+   Reason: the auth work should sit on the latest reviewed mainline before PR creation.
+
+### Concrete Type / Interface Definitions
+
+`native/ios-app/App/FireAppViewModel.swift`
+
+```swift
+enum FireAuthPresentationState: Identifiable, Equatable {
+    case login
+    case cloudflareRecovery(FireCloudflareChallengeContext)
+
+    var id: String {
+        switch self {
+        case .login:
+            return "login"
+        case let .cloudflareRecovery(context):
+            return "cloudflare-\(context.id.uuidString)"
+        }
+    }
+}
+
+struct FireCloudflareChallengeContext: Equatable {
+    let id: UUID
+    let operation: String
+    let preferredURL: URL
+    let message: String
+}
+```
+
+`rust/crates/fire-core/src/error.rs`
+
+```rust
+pub enum FireCoreError {
+    // ...
+    StaleSessionResponse { operation: &'static str },
+}
+```
+
+`native/ios-app/App/FireAppViewModel.swift`
+
+```swift
+@MainActor
+func performWithCloudflareRecovery<T>(
+    operation: String,
+    work: @escaping () async throws -> T
+) async throws -> T
+```
+
+### Usage Examples
+
+```swift
+let topics = try await appViewModel.performWithCloudflareRecovery(
+    operation: "fetch topic list"
+) {
+    try await sessionStore.fetchTopicList(query: query)
+}
+```
+
+```rust
+if current_epoch != request_epoch.0 {
+    return Err(FireCoreError::StaleSessionResponse { operation });
+}
+```
+
+## Phased Implementation
+
+## Phase 0: Branch Bootstrap
+
+**File: `docs/architecture/ios-auth-alignment-plan.md`**
+
+- Add this implementation plan as the baseline for the feature branch.
+- Record the intended branch, commit split, and verification targets.
+- Reason: future code-review discussion needs a stable written target before the code commits land.
+
+**Branch / workstream**
+
+- Branch: `feature/ios-auth-alignment`
+- Base branch: latest `origin/main`
+- Delivery model: one feature branch, one PR, two initial commits before Phase 2 begins.
+
+**Planned commit split**
+
+- `docs(auth): add ios auth alignment implementation plan`
+- `feat(core): invalidate stale responses by session epoch`
+- Follow-up commits for later phases stay separate from the Phase 1 core diff.
+
+## Phase 1: Stale Response Guard In Shared Rust Core
+
+**File: `rust/crates/fire-core/src/error.rs`**
+
+- Add `StaleSessionResponse { operation }`.
+
+**File: `rust/crates/fire-core/src/core/network.rs`**
+
+- Extend `TracedRequest` with operation metadata.
+- Carry request epoch into the response path.
+- Compare response epoch with the current session epoch before the response is returned to callers.
+- Treat mismatches as a cancellation-style shared error.
+
+**File: `rust/crates/fire-core/src/cookies.rs`**
+
+- Drop the entire `Set-Cookie` batch when the request epoch is stale.
+- Do not special-case only auth cookies anymore.
+
+**File: `rust/crates/fire-core/src/core/messagebus.rs`**
+
+- Keep MessageBus requests compatible with the new `TracedRequest` structure.
+
+**File: `rust/crates/fire-core/tests/network.rs`**
+
+- Cover stale response after local logout.
+- Cover stale response after auth-cookie rotation.
+- Assert that stale payloads do not surface and stale browser-context cookies do not persist.
+
+**File: `rust/crates/fire-uniffi/src/lib.rs`**
+
+- Map `FireCoreError::StaleSessionResponse` to a dedicated UniFFI error variant for host-side handling.
+
+**Verification**
+
+- `cargo test -p fire-core stale_response -- --nocapture`
+- `cargo test -p fire-uniffi maps_ -- --nocapture`
+- `cargo test -p fire-core -p fire-uniffi --quiet`
+- `bash native/ios-app/scripts/sync_uniffi_bindings.sh`
+
+## Phase 2: Full Same-Site Cookie Mirroring On iOS
+
+**File: `native/ios-app/App/SessionState+Helpers.swift`**
+
+- Mirror the full same-site platform cookie batch into `HTTPCookieStorage.shared` and `WKHTTPCookieStore`.
+- Keep scalar fallback only when a platform-cookie variant is unavailable.
+
+**File: `native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift`**
+
+- Split platform cookie clearing into:
+  - full same-site clear with optional preservation list
+  - targeted cookie clear for challenge recovery
+
+## Phase 3: Interactive Cloudflare Recovery Flow
+
+**File: `native/ios-app/App/FireAppViewModel.swift`**
+
+- Introduce an auth presentation enum instead of one login-only boolean.
+- Add a shared `performWithCloudflareRecovery(...)` wrapper usable by both reads and writes.
+
+**File: `native/ios-app/App/FireLoginWebView.swift`**
+
+- Generalize the current login screen into a reusable auth flow shell with `login` and `cloudflareRecovery` modes.
+
+**File: `native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift`**
+
+- Pause automatic refresh during interactive challenge recovery and resume it after success.
+
+## Phase 4: Apply Recovery To Authenticated Read Surfaces
+
+**File: `native/ios-app/App/Stores/FireHomeFeedStore.swift`**
+
+- Wrap topic-list reads in the shared Cloudflare recovery flow.
+
+**File: `native/ios-app/App/Stores/FireTopicDetailStore.swift`**
+
+- Wrap topic-detail loads and mutation-triggered refreshes in the shared recovery flow.
+
+**File: `native/ios-app/App/Stores/FireNotificationStore.swift`**
+
+- Wrap notification-state refreshes in the shared recovery flow.
+
+## Phase 5: Final Verification And Cleanup
+
+**File: `docs/architecture/fire-native-workspace.md`**
+
+- Confirm the Rust-owned stale-response responsibility and iOS-owned challenge completion flow remain documented correctly.
+
+**File: `docs/backend-api*.md`**
+
+- Audited unchanged.
+- Reason: this feature changes host/runtime behavior, not backend protocol semantics.
+
+## Architectural Notes
+
+- Semver impact: no public backend/API contract change, but UniFFI error variants grow and require regenerated bindings on native hosts.
+- Side effects: stale responses will be cancelled rather than delivered; stale cookie batches will be ignored wholesale.
+- Explicitly not changed: anonymous browsing strategy, onboarding root policy, and backend API documentation.
+- Dependencies: no new third-party dependencies; the feature stays within existing `openwire`, UniFFI, and `WKWebView` ownership boundaries.
+
+## File Change Summary
+
+- `docs/architecture/fire-native-workspace.md` -- document Rust-owned stale-response invalidation.
+- `docs/architecture/ios-auth-alignment-plan.md` -- add the auth-alignment implementation baseline and commit plan.
+- `native/ios-app/App/FireAppViewModel.swift` -- planned host-side auth presentation and challenge-recovery coordinator entrypoint.
+- `native/ios-app/App/FireLoginWebView.swift` -- planned shared login/challenge auth WebView shell.
+- `native/ios-app/App/SessionState+Helpers.swift` -- planned full same-site cookie mirroring.
+- `native/ios-app/App/Stores/FireHomeFeedStore.swift` -- planned read-path challenge retry adoption.
+- `native/ios-app/App/Stores/FireNotificationStore.swift` -- planned notification refresh challenge retry adoption.
+- `native/ios-app/App/Stores/FireTopicDetailStore.swift` -- planned detail-read challenge retry adoption.
+- `native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift` -- planned coordination with interactive challenge recovery.
+- `native/ios-app/Sources/FireAppSession/FireSessionStore.swift` -- planned host-side stale-response mapping and persistence audit.
+- `native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift` -- planned full-cookie clear and recovery-cookie extraction updates.
+- `rust/crates/fire-core/src/cookies.rs` -- drop stale cookie batches wholesale.
+- `rust/crates/fire-core/src/core/messagebus.rs` -- keep MessageBus requests aligned with traced-operation metadata.
+- `rust/crates/fire-core/src/core/mod.rs` -- expose current session epoch to the shared network layer.
+- `rust/crates/fire-core/src/core/network.rs` -- discard stale responses by session epoch before surfacing payloads.
+- `rust/crates/fire-core/src/diagnostics.rs` -- allow explicit cancellation of in-progress trace guards.
+- `rust/crates/fire-core/src/error.rs` -- add `StaleSessionResponse`.
+- `rust/crates/fire-core/tests/network.rs` -- verify stale responses do not mutate session state or surface payloads.
+- `rust/crates/fire-uniffi/src/lib.rs` -- map stale-session errors into UniFFI.

--- a/docs/backend-api/03-bootstrap-and-site.md
+++ b/docs/backend-api/03-bootstrap-and-site.md
@@ -92,7 +92,7 @@
   - `Set-Cookie: _t=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT`
 - 客户端不要继续把这种响应后的会话当作“仍可写入”；应立即清掉本地登录态并提示重新登录
 - Fire 共享层现在把 `discourse-logged-out`、清空 `_t` / `_forum_session` 的 `Set-Cookie`、`error_type=not_logged_in` 统一视为登录失效信号，并先推进内部 session epoch，再清掉本地登录态
-- Fire 共享层现在会在 `sync_login_context`、`apply_platform_cookies` 导致 auth Cookie 轮换时、显式登出、被动失效时推进 session epoch；晚到的旧请求响应仍可写入非认证 Cookie（例如 `cf_clearance`），但不得再覆盖 `_t` / `_forum_session`，也不得把旧会话“复活”
+- Fire 共享层现在会在 `sync_login_context`、`apply_platform_cookies` 导致 auth Cookie 轮换时、显式登出、被动失效时推进 session epoch；晚到的旧请求响应会被整体视为 stale response：旧 payload 不再交付，`Set-Cookie` 也会整批丢弃，包括 `cf_clearance`、`__cf_bm` 等浏览器上下文 Cookie
 - 当前 `BAD CSRF` 只触发一次性 CSRF 刷新与单次重试；如果同一请求同时已经暴露登录失效信号，则优先按登录失效收口，而不是继续保留本地登录态
 - 否则后续最常见的表现是：前面的列表、详情等匿名可读请求仍然成功，但稍后的 `/topics/timings`、点赞、回复等写请求才返回 `403` / `error_type=not_logged_in`
 

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -41,9 +41,46 @@ enum FireTopicInteractionError: LocalizedError {
         case .emptyReply:
             "回复内容不能为空。"
         case .requiresCloudflareVerification:
-            "需要先完成 Cloudflare 验证。请在登录页完成验证后点 Sync，再重试。"
+            "需要先完成 Cloudflare 验证。请在验证页完成后重试。"
         }
     }
+}
+
+struct FireCloudflareChallengeContext: Equatable {
+    let id: UUID
+    let operation: String
+    let preferredURL: URL
+    let message: String
+}
+
+enum FireAuthPresentationState: Identifiable, Equatable {
+    case login
+    case cloudflareRecovery(FireCloudflareChallengeContext)
+
+    var id: String {
+        switch self {
+        case .login:
+            return "login"
+        case let .cloudflareRecovery(context):
+            return "cloudflare-\(context.id.uuidString)"
+        }
+    }
+}
+
+private enum FireCloudflareRecoveryError: LocalizedError {
+    case cancelled
+
+    var errorDescription: String? {
+        switch self {
+        case .cancelled:
+            return "Cloudflare 验证已取消。"
+        }
+    }
+}
+
+private struct PendingCloudflareRecovery {
+    let context: FireCloudflareChallengeContext
+    var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
 }
 
 struct FireTopicPostPaginationState {
@@ -90,6 +127,7 @@ extension FireWebViewLoginCoordinator: FireChallengeSessionRecovering {}
 final class FireAppViewModel: ObservableObject {
     typealias LoginCoordinatorPreloader = @Sendable () async throws -> Void
     typealias LoginNetworkWarmup = @Sendable () async -> Void
+    typealias CloudflareRecoveryCookieSync = @Sendable () async throws -> SessionState
 
     private static let messageBusErrorPrefix = "实时同步连接失败："
     private static let loginRequiredMessage = "登录状态已失效，请重新登录。"
@@ -106,9 +144,10 @@ final class FireAppViewModel: ObservableObject {
     @Published var errorMessage: String?
     @Published private(set) var isBootstrappingSession = false
     @Published private(set) var isStartupLoadingVisible = false
-    @Published var isPresentingLogin = false
+    @Published var authPresentationState: FireAuthPresentationState?
     @Published var isPreparingLogin = false
     @Published var isSyncingLoginSession = false
+    @Published var isCompletingCloudflareChallenge = false
     @Published private(set) var canSyncLoginSession = false
     @Published var isLoggingOut = false
 
@@ -121,10 +160,12 @@ final class FireAppViewModel: ObservableObject {
     private var initialStateLoadingDelayTask: Task<Void, Never>?
     private var initialStateLoadGeneration: UInt64 = 0
     private var loginSyncReadinessTask: Task<Void, Never>?
+    private var pendingCloudflareRecovery: PendingCloudflareRecovery?
     private let loginURL = URL(string: "https://linux.do")!
     private let challengeRecoveryStore: (any FireChallengeSessionRecovering)?
     private let loginCoordinatorPreloader: LoginCoordinatorPreloader?
     private let loginNetworkWarmup: LoginNetworkWarmup?
+    private let cloudflareRecoveryCookieSync: CloudflareRecoveryCookieSync?
     // MessageBus
     private var messageBusCoordinator: FireMessageBusCoordinator?
     private var isMessageBusActive = false
@@ -139,12 +180,18 @@ final class FireAppViewModel: ObservableObject {
         initialSession: SessionState = .placeholder(),
         challengeRecoveryStore: (any FireChallengeSessionRecovering)? = nil,
         loginCoordinatorPreloader: LoginCoordinatorPreloader? = nil,
-        loginNetworkWarmup: LoginNetworkWarmup? = nil
+        loginNetworkWarmup: LoginNetworkWarmup? = nil,
+        cloudflareRecoveryCookieSync: CloudflareRecoveryCookieSync? = nil
     ) {
         self.session = initialSession
         self.challengeRecoveryStore = challengeRecoveryStore
         self.loginCoordinatorPreloader = loginCoordinatorPreloader
         self.loginNetworkWarmup = loginNetworkWarmup
+        self.cloudflareRecoveryCookieSync = cloudflareRecoveryCookieSync
+    }
+
+    var isPresentingLogin: Bool {
+        authPresentationState != nil
     }
 
     func bindHomeFeedStore(_ store: FireHomeFeedStore) {
@@ -231,15 +278,15 @@ final class FireAppViewModel: ObservableObject {
 
     func openLogin() {
         guard !isPreparingLogin else {
-            if !isPresentingLogin {
-                isPresentingLogin = true
+            if authPresentationState == nil {
+                presentLoginAuthFlow()
             }
             return
         }
 
         errorMessage = nil
         canSyncLoginSession = false
-        isPresentingLogin = true
+        presentLoginAuthFlow()
         isPreparingLogin = true
 
         Task {
@@ -268,7 +315,7 @@ final class FireAppViewModel: ObservableObject {
                     let loginCoordinator = try await loginCoordinatorValue()
                     errorMessage = nil
                     await applySession(try await loginCoordinator.completeLogin(from: webView))
-                    isPresentingLogin = false
+                    setAuthPresentationState(nil)
                     await refreshHomeFeedIfPossible(force: true)
                     canSyncLoginSession = false
                 }
@@ -279,6 +326,40 @@ final class FireAppViewModel: ObservableObject {
                 errorMessage = error.localizedDescription
             }
         }
+    }
+
+    func completeCloudflareRecovery() {
+        guard pendingCloudflareRecovery != nil else {
+            return
+        }
+        guard !isCompletingCloudflareChallenge else {
+            return
+        }
+
+        isCompletingCloudflareChallenge = true
+        Task {
+            defer { isCompletingCloudflareChallenge = false }
+
+            do {
+                errorMessage = nil
+                let refreshedSession = try await syncCookiesForCloudflareRecovery()
+                await applySession(refreshedSession)
+                setAuthPresentationState(nil)
+                resolvePendingCloudflareRecovery(with: .success(()))
+            } catch {
+                errorMessage = error.localizedDescription
+            }
+        }
+    }
+
+    func dismissAuthPresentation() {
+        if pendingCloudflareRecovery != nil {
+            resolvePendingCloudflareRecovery(
+                with: .failure(FireCloudflareRecoveryError.cancelled)
+            )
+        }
+        canSyncLoginSession = false
+        setAuthPresentationState(nil)
     }
 
     func refreshBootstrap() {
@@ -876,7 +957,9 @@ final class FireAppViewModel: ObservableObject {
 
     func fetchRecentNotificationsData(limit: UInt32? = nil) async throws -> NotificationListState {
         let sessionStore = try await sessionStoreValue()
-        return try await sessionStore.fetchRecentNotifications(limit: limit)
+        return try await performWithCloudflareRecovery(operation: "刷新通知列表") {
+            try await sessionStore.fetchRecentNotifications(limit: limit)
+        }
     }
 
     func fetchNotificationsData(
@@ -884,17 +967,27 @@ final class FireAppViewModel: ObservableObject {
         offset: UInt32? = nil
     ) async throws -> NotificationListState {
         let sessionStore = try await sessionStoreValue()
-        return try await sessionStore.fetchNotifications(limit: limit, offset: offset)
+        return try await performWithCloudflareRecovery(operation: "加载更多通知") {
+            try await sessionStore.fetchNotifications(limit: limit, offset: offset)
+        }
     }
 
     func markNotificationReadState(id: UInt64) async throws -> NotificationCenterState {
         let sessionStore = try await sessionStoreValue()
-        return try await sessionStore.markNotificationRead(id: id)
+        return try await performWriteWithCloudflareRetry(
+            operationDescription: "标记通知已读"
+        ) {
+            try await sessionStore.markNotificationRead(id: id)
+        }
     }
 
     func markAllNotificationsReadState() async throws -> NotificationCenterState {
         let sessionStore = try await sessionStoreValue()
-        return try await sessionStore.markAllNotificationsRead()
+        return try await performWriteWithCloudflareRetry(
+            operationDescription: "全部通知标记已读"
+        ) {
+            try await sessionStore.markAllNotificationsRead()
+        }
     }
 
     // MARK: - Search helpers
@@ -1318,25 +1411,74 @@ final class FireAppViewModel: ObservableObject {
     }
 
     func performWriteWithCloudflareRetry<T>(
-        operation: () async throws -> T
+        operationDescription: String = "执行当前操作",
+        operation: @escaping () async throws -> T
     ) async throws -> T {
         do {
-            return try await operation()
+            return try await performWithCloudflareRecovery(
+                operation: operationDescription,
+                work: operation
+            )
+        } catch is FireCloudflareRecoveryError {
+            throw FireTopicInteractionError.requiresCloudflareVerification
+        }
+    }
+
+    func performWithCloudflareRecovery<T>(
+        operation: String,
+        work: @escaping () async throws -> T
+    ) async throws -> T {
+        do {
+            return try await work()
         } catch {
             guard case FireUniFfiError.CloudflareChallenge = error else {
                 throw error
             }
+        }
 
-            try? await syncPlatformCookiesFromWebViewStore()
+        try? await syncPlatformCookiesFromWebViewStore()
 
-            do {
-                return try await operation()
-            } catch {
-                guard case FireUniFfiError.CloudflareChallenge = error else {
-                    throw error
+        do {
+            return try await work()
+        } catch {
+            guard case FireUniFfiError.CloudflareChallenge = error else {
+                throw error
+            }
+        }
+
+        try await beginCloudflareRecoveryAndWait(operation: operation)
+        try Task.checkCancellation()
+        return try await work()
+    }
+
+    private func beginCloudflareRecoveryAndWait(operation: String) async throws {
+        if pendingCloudflareRecovery == nil {
+            let context = FireCloudflareChallengeContext(
+                id: UUID(),
+                operation: operation,
+                preferredURL: challengeRecoveryURL(),
+                message: "\(operation) 需要先完成 Cloudflare 验证。完成后会自动重试。"
+            )
+            pendingCloudflareRecovery = PendingCloudflareRecovery(context: context)
+            errorMessage = nil
+            canSyncLoginSession = false
+            setAuthPresentationState(.cloudflareRecovery(context))
+        }
+
+        let waiterID = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation {
+                (continuation: CheckedContinuation<Void, Error>) in
+                guard var pendingCloudflareRecovery else {
+                    continuation.resume(throwing: FireCloudflareRecoveryError.cancelled)
+                    return
                 }
-                isPresentingLogin = true
-                throw FireTopicInteractionError.requiresCloudflareVerification
+                pendingCloudflareRecovery.waiters[waiterID] = continuation
+                self.pendingCloudflareRecovery = pendingCloudflareRecovery
+            }
+        } onCancel: { [weak self] in
+            Task { @MainActor [weak self] in
+                self?.cancelPendingCloudflareRecoveryWaiter(waiterID)
             }
         }
     }
@@ -1382,13 +1524,32 @@ final class FireAppViewModel: ObservableObject {
             return false
         }
 
-        await resetSessionAndPresentLogin(
-            message: message ?? error.localizedDescription
-        )
+        let operation = message ?? "当前请求"
+        if pendingCloudflareRecovery == nil {
+            let context = FireCloudflareChallengeContext(
+                id: UUID(),
+                operation: operation,
+                preferredURL: challengeRecoveryURL(),
+                message: message ?? error.localizedDescription
+            )
+            pendingCloudflareRecovery = PendingCloudflareRecovery(context: context)
+            errorMessage = nil
+            canSyncLoginSession = false
+            setAuthPresentationState(.cloudflareRecovery(context))
+        } else if case let .cloudflareRecovery(context)? = authPresentationState {
+            setAuthPresentationState(.cloudflareRecovery(context))
+        }
         return true
     }
 
+    private func challengeRecoveryURL() -> URL {
+        session.baseURL.appendingPathComponent("challenge", isDirectory: false)
+    }
+
     private func resetSessionAndPresentLogin(message: String) async {
+        resolvePendingCloudflareRecovery(
+            with: .failure(FireCloudflareRecoveryError.cancelled)
+        )
         stopMessageBus()
 
         do {
@@ -1405,7 +1566,7 @@ final class FireAppViewModel: ObservableObject {
         notificationStore?.reset()
         canSyncLoginSession = false
         errorMessage = message
-        isPresentingLogin = true
+        presentLoginAuthFlow()
     }
 
     private func logLoginInvalidationDiagnostics(message: String) async {
@@ -1525,6 +1686,59 @@ final class FireAppViewModel: ObservableObject {
         let loginCoordinator = try await loginCoordinatorValue()
         let session = try await loginCoordinator.refreshPlatformCookies()
         await applySession(session)
+    }
+
+    private func syncCookiesForCloudflareRecovery() async throws -> SessionState {
+        if let cloudflareRecoveryCookieSync {
+            return try await cloudflareRecoveryCookieSync()
+        }
+
+        let loginCoordinator = try await loginCoordinatorValue()
+        return try await loginCoordinator.refreshPlatformCookies()
+    }
+
+    private func presentLoginAuthFlow() {
+        resolvePendingCloudflareRecovery(
+            with: .failure(FireCloudflareRecoveryError.cancelled)
+        )
+        canSyncLoginSession = false
+        setAuthPresentationState(.login)
+    }
+
+    private func setAuthPresentationState(_ state: FireAuthPresentationState?) {
+        authPresentationState = state
+        let isInteractiveRecoveryActive: Bool
+        switch state {
+        case .cloudflareRecovery:
+            isInteractiveRecoveryActive = true
+        case .login, .none:
+            isInteractiveRecoveryActive = false
+        }
+        FireCfClearanceRefreshService.shared.setInteractiveRecoveryActive(
+            isInteractiveRecoveryActive
+        )
+    }
+
+    private func resolvePendingCloudflareRecovery(with result: Result<Void, Error>) {
+        guard let pendingCloudflareRecovery else {
+            return
+        }
+
+        let waiters = Array(pendingCloudflareRecovery.waiters.values)
+        self.pendingCloudflareRecovery = nil
+        waiters.forEach { $0.resume(with: result) }
+    }
+
+    private func cancelPendingCloudflareRecoveryWaiter(_ waiterID: UUID) {
+        guard var pendingCloudflareRecovery else {
+            return
+        }
+        guard let waiter = pendingCloudflareRecovery.waiters.removeValue(forKey: waiterID) else {
+            return
+        }
+
+        self.pendingCloudflareRecovery = pendingCloudflareRecovery
+        waiter.resume(throwing: CancellationError())
     }
 
     func topicDetailLogger() -> FireHostLogger? {

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -943,7 +943,7 @@ final class FireAppViewModel: ObservableObject {
             )
             return accepted
         } catch {
-            _ = await handleLoginRequiredIfNeeded(error)
+            _ = await handleRecoverableSessionErrorIfNeeded(error)
             return false
         }
     }
@@ -1488,6 +1488,9 @@ final class FireAppViewModel: ObservableObject {
         if await handleLoginRequiredIfNeeded(error) {
             return true
         }
+        if await handleStaleSessionResponseIfNeeded(error) {
+            return true
+        }
         return await handleCloudflareChallengeIfNeeded(error)
     }
 
@@ -1502,6 +1505,19 @@ final class FireAppViewModel: ObservableObject {
         )
         await resetSessionAndPresentLogin(
             message: message.isEmpty ? Self.loginRequiredMessage : message
+        )
+        return true
+    }
+
+    @discardableResult
+    func handleStaleSessionResponseIfNeeded(_ error: Error) async -> Bool {
+        guard case let FireUniFfiError.StaleSessionResponse(operation) = error else {
+            return false
+        }
+
+        FireAPMManager.shared.recordBreadcrumb(
+            target: Self.authDiagnosticsLogTarget,
+            message: "discarded stale session response operation=\(operation)"
         )
         return true
     }

--- a/native/ios-app/App/FireLoginWebView.swift
+++ b/native/ios-app/App/FireLoginWebView.swift
@@ -223,11 +223,38 @@ struct FireLoginWebView: UIViewRepresentable {
     }
 }
 
-struct FireLoginScreen: View {
-    @Environment(\.dismiss) private var dismiss
+struct FireAuthScreen: View {
     @Environment(\.scenePhase) private var scenePhase
     @ObservedObject var viewModel: FireAppViewModel
+    let presentationState: FireAuthPresentationState
     @StateObject private var webViewBox = FireWebViewBox()
+
+    private var title: String {
+        switch presentationState {
+        case .login:
+            return "登录 LinuxDo"
+        case .cloudflareRecovery:
+            return "完成安全验证"
+        }
+    }
+
+    private var url: URL {
+        switch presentationState {
+        case .login:
+            return URL(string: "https://linux.do")!
+        case let .cloudflareRecovery(context):
+            return context.preferredURL
+        }
+    }
+
+    private var route: String {
+        switch presentationState {
+        case .login:
+            return "auth.login"
+        case .cloudflareRecovery:
+            return "auth.cloudflare"
+        }
+    }
 
     var body: some View {
         NavigationStack {
@@ -247,21 +274,28 @@ struct FireLoginScreen: View {
                     )
                 }
 
+                if case let .cloudflareRecovery(context) = presentationState {
+                    FireAuthInfoBanner(message: context.message)
+                }
+
                 FireLoginWebView(
-                    url: URL(string: "https://linux.do")!,
+                    url: url,
                     webViewBox: webViewBox,
                     onNavigationStateChange: { webView in
+                        guard case .login = presentationState else {
+                            return
+                        }
                         viewModel.refreshLoginSyncReadiness(from: webView)
                     }
                 )
                 .frame(maxHeight: .infinity)
             }
             .background(Color(.systemBackground))
-            .navigationTitle("登录 LinuxDo")
+            .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
-                    Button("关闭") { dismiss() }
+                    Button("关闭") { viewModel.dismissAuthPresentation() }
                 }
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {
@@ -272,20 +306,27 @@ struct FireLoginScreen: View {
                 }
             }
             .safeAreaInset(edge: .bottom) {
-                FireLoginBottomBar(
+                FireAuthBottomBar(
                     viewModel: viewModel,
+                    presentationState: presentationState,
                     webViewBox: webViewBox,
-                    onSync: {
+                    onLoginSync: {
                         guard let webView = webViewBox.webView else { return }
                         viewModel.completeLogin(from: webView)
+                    },
+                    onCloudflareRecoveryComplete: {
+                        viewModel.completeCloudflareRecovery()
                     }
                 )
             }
             .onAppear {
-                viewModel.setAPMRoute("auth.login")
+                viewModel.setAPMRoute(route)
             }
             .onChange(of: scenePhase) { _, phase in
                 guard phase == .active, let webView = webViewBox.webView else {
+                    return
+                }
+                guard case .login = presentationState else {
                     return
                 }
                 viewModel.refreshLoginSyncReadiness(from: webView)
@@ -318,10 +359,49 @@ private struct FireLoginAddressBar: View {
     }
 }
 
-private struct FireLoginBottomBar: View {
+private struct FireAuthBottomBar: View {
     @ObservedObject var viewModel: FireAppViewModel
+    let presentationState: FireAuthPresentationState
     @ObservedObject var webViewBox: FireWebViewBox
-    let onSync: () -> Void
+    let onLoginSync: () -> Void
+    let onCloudflareRecoveryComplete: () -> Void
+
+    private var isRunningAction: Bool {
+        switch presentationState {
+        case .login:
+            return viewModel.isSyncingLoginSession
+        case .cloudflareRecovery:
+            return viewModel.isCompletingCloudflareChallenge
+        }
+    }
+
+    private var actionTitle: String {
+        switch presentationState {
+        case .login:
+            return viewModel.isSyncingLoginSession ? "同步中…" : "完成登录"
+        case .cloudflareRecovery:
+            return viewModel.isCompletingCloudflareChallenge ? "重试中…" : "完成验证并重试"
+        }
+    }
+
+    private var isActionEnabled: Bool {
+        guard webViewBox.webView != nil else {
+            return false
+        }
+        guard !webViewBox.isLoading else {
+            return false
+        }
+        guard !isRunningAction else {
+            return false
+        }
+
+        switch presentationState {
+        case .login:
+            return viewModel.canSyncLoginSession
+        case .cloudflareRecovery:
+            return true
+        }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -345,27 +425,31 @@ private struct FireLoginBottomBar: View {
 
                 Spacer()
 
-                Button(action: onSync) {
+                Button(action: performPrimaryAction) {
                     HStack(spacing: 6) {
-                        if viewModel.isSyncingLoginSession {
+                        if isRunningAction {
                             ProgressView()
                                 .tint(.white)
                                 .controlSize(.small)
                         }
-                        Text(viewModel.isSyncingLoginSession ? "同步中…" : "完成登录")
+                        Text(actionTitle)
                     }
                 }
                 .buttonStyle(FirePrimaryButtonStyle())
-                .disabled(
-                    webViewBox.webView == nil
-                        || webViewBox.isLoading
-                        || viewModel.isSyncingLoginSession
-                        || !viewModel.canSyncLoginSession
-                )
+                .disabled(!isActionEnabled)
             }
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
             .background(.bar)
+        }
+    }
+
+    private func performPrimaryAction() {
+        switch presentationState {
+        case .login:
+            onLoginSync()
+        case .cloudflareRecovery:
+            onCloudflareRecoveryComplete()
         }
     }
 }
@@ -393,6 +477,28 @@ private struct FireLoginErrorBanner: View {
                     .foregroundStyle(.tertiary)
             }
             .buttonStyle(.plain)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color(.secondarySystemBackground))
+    }
+}
+
+private struct FireAuthInfoBanner: View {
+    let message: String
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "shield.lefthalf.filled")
+                .foregroundStyle(FireTheme.accent)
+                .font(.caption)
+
+            Text(message)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(3)
+
+            Spacer(minLength: 0)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/native/ios-app/App/FireTabRoot.swift
+++ b/native/ios-app/App/FireTabRoot.swift
@@ -68,8 +68,11 @@ struct FireTabRoot: View {
             }
         }
         .animation(.easeInOut(duration: 0.3), value: isAuthenticated)
-        .fullScreenCover(isPresented: $viewModel.isPresentingLogin) {
-            FireLoginScreen(viewModel: viewModel)
+        .fullScreenCover(item: $viewModel.authPresentationState) { presentationState in
+            FireAuthScreen(
+                viewModel: viewModel,
+                presentationState: presentationState
+            )
         }
         .task {
             viewModel.loadInitialState()

--- a/native/ios-app/App/SessionState+Helpers.swift
+++ b/native/ios-app/App/SessionState+Helpers.swift
@@ -49,7 +49,7 @@ enum MirroredCookieStoreFactory {
 }
 
 extension SessionState {
-    private static let mirroredCookieNames: Set<String> = ["_t", "_forum_session", "cf_clearance"]
+    private static let scalarFallbackCookieNames: Set<String> = ["_t", "_forum_session", "cf_clearance"]
 
     static func placeholder(baseUrl: String = "https://linux.do") -> SessionState {
         SessionState(
@@ -115,18 +115,26 @@ extension SessionState {
     @MainActor
     func mirrorCookiesToNativeStorage() async {
         let host = baseURL.host ?? "linux.do"
-        let cookies = bridgedCookies(host: host)
+        let batch = bridgedCookieBatch(host: host)
 
-        mirrorCookiesToSharedStorage(cookies, host: host)
-        await mirrorCookiesToWebKitStorage(cookies, host: host)
+        mirrorCookiesToSharedStorage(batch.cookies, host: host, fullSameSiteScope: batch.usesFullSameSiteScope)
+        await mirrorCookiesToWebKitStorage(
+            batch.cookies,
+            host: host,
+            fullSameSiteScope: batch.usesFullSameSiteScope
+        )
     }
 
     @MainActor
-    private func mirrorCookiesToSharedStorage(_ cookies: [HTTPCookie], host: String) {
+    private func mirrorCookiesToSharedStorage(
+        _ cookies: [HTTPCookie],
+        host: String,
+        fullSameSiteScope: Bool
+    ) {
         let cookieStorage = HTTPCookieStorage.shared
 
         for existingCookie in cookieStorage.cookies ?? [] {
-            guard Self.shouldMirror(existingCookie, host: host) else {
+            guard Self.shouldMirror(existingCookie, host: host, fullSameSiteScope: fullSameSiteScope) else {
                 continue
             }
             cookieStorage.deleteCookie(existingCookie)
@@ -138,9 +146,17 @@ extension SessionState {
     }
 
     @MainActor
-    private func mirrorCookiesToWebKitStorage(_ cookies: [HTTPCookie], host: String) async {
+    private func mirrorCookiesToWebKitStorage(
+        _ cookies: [HTTPCookie],
+        host: String,
+        fullSameSiteScope: Bool
+    ) async {
         let store = MirroredCookieStoreFactory.makeWebKitStore()
-        let existingCookies = await currentWebKitMirroredCookies(host: host, from: store)
+        let existingCookies = await currentWebKitMirroredCookies(
+            host: host,
+            fullSameSiteScope: fullSameSiteScope,
+            from: store
+        )
         if Self.cookieDescriptors(existingCookies) == Self.cookieDescriptors(cookies) {
             return
         }
@@ -157,15 +173,18 @@ extension SessionState {
     @MainActor
     private func currentWebKitMirroredCookies(
         host: String,
+        fullSameSiteScope: Bool,
         from store: any MirroredCookieStore
     ) async -> [HTTPCookie] {
-        await store.getAllCookies().filter { Self.shouldMirror($0, host: host) }
+        await store.getAllCookies().filter {
+            Self.shouldMirror($0, host: host, fullSameSiteScope: fullSameSiteScope)
+        }
     }
 
-    private func bridgedCookies(host: String) -> [HTTPCookie] {
+    private func bridgedCookieBatch(host: String) -> MirroredCookieBatch {
         let secure = baseURL.scheme?.lowercased() == "https"
         let platformCookies = cookies.platformCookies
-            .filter { Self.mirroredCookieNames.contains($0.name) && !$0.value.isEmpty }
+            .filter { Self.shouldBridgePlatformCookie($0, host: host) }
             .compactMap { cookie in
                 Self.makeCookie(
                     name: cookie.name,
@@ -177,6 +196,7 @@ extension SessionState {
                     originURL: baseURL
                 )
             }
+        let usesFullSameSiteScope = !platformCookies.isEmpty
 
         let mirroredNames = Set(platformCookies.map(\.name))
         let scalarFallbackCandidates: [(String, String?)] = [
@@ -201,22 +221,54 @@ extension SessionState {
             )
         }
 
-        return (platformCookies + scalarFallback).sorted {
+        let sortedCookies = (platformCookies + scalarFallback).sorted {
             let lhs = Self.cookieDescriptor($0)
             let rhs = Self.cookieDescriptor($1)
             return lhs < rhs
         }
+
+        return MirroredCookieBatch(
+            cookies: sortedCookies,
+            usesFullSameSiteScope: usesFullSameSiteScope
+        )
     }
 
-    private static func shouldMirror(_ cookie: HTTPCookie, host: String) -> Bool {
-        guard mirroredCookieNames.contains(cookie.name) else {
+    private static func shouldBridgePlatformCookie(
+        _ cookie: PlatformCookieState,
+        host: String
+    ) -> Bool {
+        let normalizedValue = cookie.value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedValue.isEmpty else {
+            return false
+        }
+        if let expiresAtUnixMs = cookie.expiresAtUnixMs, expiresAtUnixMs <= currentUnixMs() {
             return false
         }
 
+        return sameSiteDomainMatches(cookie.domain ?? host, host: host)
+    }
+
+    private static func shouldMirror(
+        _ cookie: HTTPCookie,
+        host: String,
+        fullSameSiteScope: Bool
+    ) -> Bool {
+        if !fullSameSiteScope && !scalarFallbackCookieNames.contains(cookie.name) {
+            return false
+        }
+
+        return sameSiteDomainMatches(cookie.domain, host: host)
+    }
+
+    private static func sameSiteDomainMatches(_ domain: String, host: String) -> Bool {
         let normalizedHost = normalizeDomain(host)
-        let normalizedDomain = normalizeDomain(cookie.domain)
+        let normalizedDomain = normalizeDomain(domain)
         return normalizedDomain == normalizedHost
             || normalizedDomain.hasSuffix(".\(normalizedHost)")
+    }
+
+    private static func currentUnixMs() -> Int64 {
+        Int64(Date().timeIntervalSince1970 * 1000)
     }
 
     private static func normalizeDomain(_ domain: String) -> String {
@@ -271,6 +323,11 @@ extension SessionState {
     private func deleteCookie(_ cookie: HTTPCookie, from store: any MirroredCookieStore) async {
         await store.deleteCookie(cookie)
     }
+}
+
+private struct MirroredCookieBatch {
+    let cookies: [HTTPCookie]
+    let usesFullSameSiteScope: Bool
 }
 
 extension TopicListKindState {

--- a/native/ios-app/App/Stores/FireHomeFeedStore.swift
+++ b/native/ios-app/App/Stores/FireHomeFeedStore.swift
@@ -286,6 +286,15 @@ final class FireHomeFeedStore: ObservableObject {
                     )
                 )
             }
+            let operationDescription = (page == nil && reset)
+                ? "刷新首页话题列表"
+                : "加载更多首页话题"
+            let fetchWithRecovery: () async throws -> TopicListState = {
+                try await self.appViewModel.performWithCloudflareRecovery(
+                    operation: operationDescription,
+                    work: fetch
+                )
+            }
 
             let response: TopicListState
             if reset && page == nil && requestedKind == .latest {
@@ -296,10 +305,10 @@ final class FireHomeFeedStore: ObservableObject {
                         "tag": primaryTag ?? "none",
                         "incremental": usesIncrementalRefresh ? "true" : "false"
                     ],
-                    operation: fetch
+                    operation: fetchWithRecovery
                 )
             } else {
-                response = try await fetch()
+                response = try await fetchWithRecovery()
             }
 
             guard requestedScope == currentTopicListRefreshScope else {

--- a/native/ios-app/App/Stores/FireTopicDetailStore.swift
+++ b/native/ios-app/App/Stores/FireTopicDetailStore.swift
@@ -93,16 +93,20 @@ final class FireTopicDetailStore: ObservableObject {
                 .topicDetailInitialLoad,
                 metadata: ["topic_id": String(topicId)]
             ) {
-                try await sessionStore.fetchTopicDetailInitial(
-                    query: TopicDetailQueryState(
-                        topicId: topicId,
-                        postNumber: targetPostNumber,
-                        trackVisit: true,
-                        filter: nil,
-                        usernameFilters: nil,
-                        filterTopLevelReplies: false
+                try await appViewModel.performWithCloudflareRecovery(
+                    operation: "加载话题详情"
+                ) {
+                    try await sessionStore.fetchTopicDetailInitial(
+                        query: TopicDetailQueryState(
+                            topicId: topicId,
+                            postNumber: targetPostNumber,
+                            trackVisit: true,
+                            filter: nil,
+                            usernameFilters: nil,
+                            filterTopLevelReplies: false
+                        )
                     )
-                )
+                }
             }
             applyTopicDetail(detail, topicId: topicId)
             appViewModel.topicDetailLogger()?.debug(
@@ -503,16 +507,20 @@ final class FireTopicDetailStore: ObservableObject {
         topicId: UInt64,
         sessionStore: FireSessionStore
     ) async throws {
-        let detail = try await sessionStore.fetchTopicDetailInitial(
-            query: TopicDetailQueryState(
-                topicId: topicId,
-                postNumber: nil,
-                trackVisit: false,
-                filter: nil,
-                usernameFilters: nil,
-                filterTopLevelReplies: false
+        let detail = try await appViewModel.performWithCloudflareRecovery(
+            operation: "刷新话题详情"
+        ) {
+            try await sessionStore.fetchTopicDetailInitial(
+                query: TopicDetailQueryState(
+                    topicId: topicId,
+                    postNumber: nil,
+                    trackVisit: false,
+                    filter: nil,
+                    usernameFilters: nil,
+                    filterTopLevelReplies: false
+                )
             )
-        )
+        }
         applyTopicDetail(detail, topicId: topicId)
     }
 
@@ -525,16 +533,20 @@ final class FireTopicDetailStore: ObservableObject {
             guard self.topicDetails[topicId] != nil else { return }
             let anchorPostNumber = self.topicDetailTargetPostNumbers[topicId]
             do {
-                let detail = try await store.fetchTopicDetailInitial(
-                    query: TopicDetailQueryState(
-                        topicId: topicId,
-                        postNumber: anchorPostNumber,
-                        trackVisit: false,
-                        filter: nil,
-                        usernameFilters: nil,
-                        filterTopLevelReplies: false
+                let detail = try await self.appViewModel.performWithCloudflareRecovery(
+                    operation: "刷新话题详情"
+                ) {
+                    try await store.fetchTopicDetailInitial(
+                        query: TopicDetailQueryState(
+                            topicId: topicId,
+                            postNumber: anchorPostNumber,
+                            trackVisit: false,
+                            filter: nil,
+                            usernameFilters: nil,
+                            filterTopLevelReplies: false
+                        )
                     )
-                )
+                }
                 self.applyTopicDetail(detail, topicId: topicId)
             } catch {
                 _ = await self.appViewModel.handleRecoverableSessionErrorIfNeeded(error)
@@ -791,10 +803,14 @@ final class FireTopicDetailStore: ObservableObject {
             let batchPostIDs = Array(missingPostIDs.prefix(Self.topicPostPageSize))
 
             do {
-                let fetchedPosts = try await sessionStore.fetchTopicPosts(
-                    topicID: topicId,
-                    postIDs: batchPostIDs
-                )
+                let fetchedPosts = try await appViewModel.performWithCloudflareRecovery(
+                    operation: "加载更多帖子"
+                ) {
+                    try await sessionStore.fetchTopicPosts(
+                        topicID: topicId,
+                        postIDs: batchPostIDs
+                    )
+                }
                 let returnedPostIDs = Set(fetchedPosts.map(\.id))
                 exhaustedPostIDs.formUnion(
                     batchPostIDs.filter { !returnedPostIDs.contains($0) }

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -50,11 +50,12 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
 - `FireCfClearanceRefreshService.swift`
   - owns an offscreen `WKWebView` that periodically reloads `https://linux.do/` once the shared session is authenticated, scene-active, and bootstrap has exposed a Turnstile sitekey
   - re-syncs WebKit cookies back into Rust after each refresh cycle so host-owned `cf_clearance` state stays warm without forcing the foreground login WebView open
-  - starts/stops automatically from session and scene-phase changes, and records APM breadcrumbs for refresh lifecycle and failures
+  - pauses that background refresh loop while an interactive `/challenge` recovery WebView is on-screen, then resumes automatically after the recovery flow is dismissed
+  - starts/stops automatically from session, scene-phase, and interactive-recovery changes, and records APM breadcrumbs for refresh lifecycle and failures
 - `App/FireLoginWebView.swift`
-  - presents the login browser as a full-screen flow
+  - presents the host-owned auth browser as a full-screen flow for both initial login and interactive Cloudflare recovery
   - now wraps the embedded `WKWebView` in a full-screen native browser shell with adaptive light/dark chrome, a compact top bar, and a bottom command dock
-  - exposes back, forward, home, reload, and session sync controls so OAuth hops can return to LinuxDo without closing the flow
+  - exposes back, forward, home, reload, and context-aware primary actions so OAuth hops can return to LinuxDo without closing the flow and challenge recovery can finish with an explicit `完成验证并重试`
   - enables back/forward swipe gestures on the embedded `WKWebView`
   - avoids mutating observed browser state from `UIViewRepresentable.updateUIView`, so SwiftUI updates do not loop back into `WKWebView` host state and freeze the login entry flow
 - `App/FireApp.swift`
@@ -71,7 +72,7 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - now also owns native private-message inbox/sent loading plus private-message creation on top of the shared Rust mailbox and `/posts.json` PM surfaces
   - now acts as a session/runtime facade for feature stores instead of also owning every screen's transient state directly
   - now owns the foreground MessageBus transport lifecycle on iOS and forwards runtime refresh work into the bound feature stores instead of publishing home/topic-detail state itself
-  - now treats Rust-owned `CloudflareChallenge` errors as the signal to clear the local authenticated snapshot, return the shell to onboarding, and auto-present the login WebView so challenge recovery stays inside the browser flow
+  - now treats Rust-owned `CloudflareChallenge` errors as the signal to present an interactive `/challenge` recovery WebView, re-sync the browser cookie batch back into Rust, and automatically retry the blocked read/write flow without tearing down the current authenticated snapshot
   - now also treats Rust-owned `LoginRequired` invalidation the same way, clearing host-side auth cookies while preserving `cf_clearance` so passive session loss, explicit logout, and bootstrap-challenged recovery all converge on one reset path
   - now probes login sync readiness from the embedded `WKWebView` and keeps the `完成登录` button disabled until the shared login prerequisites are actually satisfied
   - now also emits host-owned APM spans for cold-start restore, login sync, bootstrap refresh, latest-feed load, topic-detail load, reply submit, notification refresh, and MessageBus start

--- a/native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift
+++ b/native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift
@@ -11,6 +11,7 @@ final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate {
     private weak var loginCoordinator: FireWebViewLoginCoordinator?
     private var session: SessionState = .placeholder()
     private var sceneActive = false
+    private var interactiveRecoveryActive = false
     private var refreshTask: Task<Void, Never>?
     private var webView: WKWebView?
     private var loadContinuation: CheckedContinuation<Void, Error>?
@@ -29,18 +30,29 @@ final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate {
         reconfigureLoop(reason: active ? "scene_active" : "scene_inactive")
     }
 
+    func setInteractiveRecoveryActive(_ active: Bool) {
+        interactiveRecoveryActive = active
+        reconfigureLoop(reason: active ? "interactive_recovery_started" : "interactive_recovery_ended")
+    }
+
     nonisolated static func shouldAutoRefresh(
         session: SessionState,
-        sceneActive: Bool
+        sceneActive: Bool,
+        interactiveRecoveryActive: Bool = false
     ) -> Bool {
         sceneActive
+            && !interactiveRecoveryActive
             && session.readiness.canReadAuthenticatedApi
             && session.readiness.hasCloudflareClearance
             && !(session.bootstrap.turnstileSitekey?.isEmpty ?? true)
     }
 
     private var shouldRun: Bool {
-        Self.shouldAutoRefresh(session: session, sceneActive: sceneActive)
+        Self.shouldAutoRefresh(
+            session: session,
+            sceneActive: sceneActive,
+            interactiveRecoveryActive: interactiveRecoveryActive
+        )
     }
 
     private func reconfigureLoop(reason: String) {

--- a/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
+++ b/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
@@ -229,14 +229,14 @@ public final class FireWebViewLoginCoordinator {
             // refresh is still challenged. The WebView login flow remains open so
             // the user can complete the challenge and retry Sync.
             _ = try? await sessionStore.logoutLocal(preserveCfClearance: true)
-            try? await clearPlatformLoginCookies(preserveCfClearance: true)
+            try? await clearChallengeRecoveryCookies()
             throw error
         }
     }
 
     public func logout() async throws -> SessionState {
         let state = try await sessionStore.logout()
-        try await clearPlatformLoginCookies(preserveCfClearance: true)
+        try await clearSameSitePlatformCookies(preserving: ["cf_clearance"])
         return state
     }
 
@@ -343,7 +343,9 @@ public final class FireWebViewLoginCoordinator {
         preserveCfClearance: Bool = true
     ) async throws -> SessionState {
         let state = try await sessionStore.logoutLocal(preserveCfClearance: preserveCfClearance)
-        try await clearPlatformLoginCookies(preserveCfClearance: preserveCfClearance)
+        try await clearSameSitePlatformCookies(
+            preserving: preserveCfClearance ? ["cf_clearance"] : []
+        )
         return state
     }
 
@@ -403,25 +405,37 @@ public final class FireWebViewLoginCoordinator {
         }
     }
 
-    private func clearPlatformLoginCookies(preserveCfClearance: Bool) async throws {
-        let store = WKWebsiteDataStore.default().httpCookieStore
-        let cookies = try await httpCookies(from: store)
-
-        for cookie in cookies where shouldDelete(cookie, preserveCfClearance: preserveCfClearance) {
-            await deleteCookie(cookie, from: store)
+    private func clearSameSitePlatformCookies(
+        preserving preservedCookieNames: Set<String> = []
+    ) async throws {
+        try await clearPlatformCookies { cookie in
+            isSameSiteCookie(cookie) && !preservedCookieNames.contains(cookie.name)
         }
     }
 
-    private func shouldDelete(_ cookie: HTTPCookie, preserveCfClearance: Bool) -> Bool {
-        guard cookie.domain.range(of: "linux.do", options: .caseInsensitive) != nil else {
-            return false
+    private func clearChallengeRecoveryCookies() async throws {
+        let targetedNames: Set<String> = ["_t", "_forum_session"]
+        try await clearPlatformCookies { cookie in
+            isSameSiteCookie(cookie) && targetedNames.contains(cookie.name)
+        }
+    }
+
+    private func clearPlatformCookies(
+        matching shouldDelete: (HTTPCookie) -> Bool
+    ) async throws {
+        let webKitStore = WKWebsiteDataStore.default().httpCookieStore
+        let webKitCookies = try await httpCookies(from: webKitStore)
+        for cookie in webKitCookies where shouldDelete(cookie) {
+            await deleteCookie(cookie, from: webKitStore)
         }
 
-        if preserveCfClearance && cookie.name == "cf_clearance" {
-            return false
+        for cookie in HTTPCookieStorage.shared.cookies ?? [] where shouldDelete(cookie) {
+            HTTPCookieStorage.shared.deleteCookie(cookie)
         }
+    }
 
-        return ["_t", "_forum_session", "cf_clearance"].contains(cookie.name)
+    private func isSameSiteCookie(_ cookie: HTTPCookie) -> Bool {
+        cookie.domain.range(of: "linux.do", options: .caseInsensitive) != nil
     }
 
     private func deleteCookie(_ cookie: HTTPCookie, from store: WKHTTPCookieStore) async {

--- a/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
+++ b/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
@@ -643,6 +643,13 @@ final class FireSessionSecurityTests: XCTestCase {
                 sceneActive: true
             )
         )
+        XCTAssertFalse(
+            FireCfClearanceRefreshService.shouldAutoRefresh(
+                session: authenticatedSession(turnstileSitekey: "sitekey"),
+                sceneActive: true,
+                interactiveRecoveryActive: true
+            )
+        )
     }
 
     @MainActor
@@ -692,14 +699,8 @@ final class FireSessionSecurityTests: XCTestCase {
     }
 
     @MainActor
-    func testChallengeRecoveryClearsLocalSessionAndPresentsLogin() async {
-        let recoveryStore = MockChallengeRecoveryStore(
-            result: .success(challengedLoggedOutSession())
-        )
-        let viewModel = FireAppViewModel(
-            initialSession: authenticatedSession(),
-            challengeRecoveryStore: recoveryStore
-        )
+    func testChallengeRecoveryPresentsInteractiveRecoveryWithoutClearingSession() async {
+        let viewModel = FireAppViewModel(initialSession: authenticatedSession())
 
         let recovered = await viewModel.handleCloudflareChallengeIfNeeded(
             FireUniFfiError.CloudflareChallenge
@@ -707,15 +708,18 @@ final class FireSessionSecurityTests: XCTestCase {
 
         XCTAssertTrue(recovered)
         XCTAssertTrue(viewModel.isPresentingLogin)
+        guard case let .cloudflareRecovery(context)? = viewModel.authPresentationState else {
+            return XCTFail("expected interactive Cloudflare recovery presentation")
+        }
+        XCTAssertEqual(context.preferredURL.absoluteString, "https://linux.do/challenge")
         XCTAssertEqual(
-            viewModel.errorMessage,
-            "需要先完成 Cloudflare 验证。请在登录页完成验证后点 Sync，再重试。"
+            context.message,
+            "需要先完成 Cloudflare 验证。请在验证页完成后重试。"
         )
-        XCTAssertFalse(viewModel.session.hasLoginSession)
-        XCTAssertFalse(viewModel.session.readiness.canReadAuthenticatedApi)
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertTrue(viewModel.session.hasLoginSession)
+        XCTAssertTrue(viewModel.session.readiness.canReadAuthenticatedApi)
         XCTAssertTrue(viewModel.session.readiness.hasCloudflareClearance)
-        let calls = await recoveryStore.recordedCalls()
-        XCTAssertEqual(calls, [true])
     }
 
     @MainActor
@@ -763,6 +767,99 @@ final class FireSessionSecurityTests: XCTestCase {
         XCTAssertTrue(viewModel.session.readiness.canReadAuthenticatedApi)
         let calls = await recoveryStore.recordedCalls()
         XCTAssertTrue(calls.isEmpty)
+    }
+
+    @MainActor
+    func testPerformWithCloudflareRecoveryWaitsForInteractiveRecoveryAndRetries() async throws {
+        let viewModel = FireAppViewModel(
+            initialSession: authenticatedSession(),
+            cloudflareRecoveryCookieSync: {
+                self.authenticatedSession(turnstileSitekey: "sitekey")
+            }
+        )
+        var attempts = 0
+
+        let task = Task {
+            try await viewModel.performWithCloudflareRecovery(operation: "刷新首页话题列表") {
+                attempts += 1
+                if attempts < 3 {
+                    throw FireUniFfiError.CloudflareChallenge
+                }
+                return "ok"
+            }
+        }
+
+        let presentedRecovery = await waitUntil {
+            if case .cloudflareRecovery? = viewModel.authPresentationState {
+                return true
+            }
+            return false
+        }
+
+        XCTAssertTrue(presentedRecovery)
+        XCTAssertEqual(attempts, 2)
+
+        viewModel.completeCloudflareRecovery()
+
+        let dismissedRecovery = await waitUntil { viewModel.authPresentationState == nil }
+        XCTAssertTrue(dismissedRecovery)
+        let result = try await task.value
+        XCTAssertEqual(result, "ok")
+        XCTAssertEqual(attempts, 3)
+    }
+
+    @MainActor
+    func testPerformWithCloudflareRecoveryCancellationStopsWaitingTaskFromRetrying() async {
+        let viewModel = FireAppViewModel(
+            initialSession: authenticatedSession(),
+            cloudflareRecoveryCookieSync: {
+                self.authenticatedSession(turnstileSitekey: "sitekey")
+            }
+        )
+        var attempts = 0
+
+        let task = Task {
+            try await viewModel.performWithCloudflareRecovery(operation: "刷新首页话题列表") {
+                attempts += 1
+                if attempts < 3 {
+                    throw FireUniFfiError.CloudflareChallenge
+                }
+                return "ok"
+            }
+        }
+
+        let presentedRecovery = await waitUntil {
+            if case .cloudflareRecovery? = viewModel.authPresentationState {
+                return true
+            }
+            return false
+        }
+
+        XCTAssertTrue(presentedRecovery)
+        XCTAssertEqual(attempts, 2)
+
+        task.cancel()
+
+        let finished = expectation(description: "cancelled recovery task finished")
+        var completionError: Error?
+        Task { @MainActor in
+            do {
+                _ = try await task.value
+                XCTFail("Expected task cancellation while waiting for Cloudflare recovery")
+            } catch {
+                completionError = error
+            }
+            finished.fulfill()
+        }
+
+        await fulfillment(of: [finished], timeout: 1.0)
+        XCTAssertTrue(completionError is CancellationError)
+        XCTAssertEqual(attempts, 2)
+
+        viewModel.completeCloudflareRecovery()
+        let dismissedRecovery = await waitUntil { viewModel.authPresentationState == nil }
+        XCTAssertTrue(dismissedRecovery)
+        XCTAssertEqual(attempts, 2)
     }
 
     @MainActor

--- a/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
+++ b/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
@@ -32,6 +32,13 @@ final class FireSessionSecurityTests: XCTestCase {
                         domain: ".linux.do",
                         expiresAtUnixMs: freshExpiry
                     ),
+                    makePlatformCookie(
+                        name: "__cf_bm",
+                        value: "browser-context",
+                        domain: ".linux.do",
+                        path: "/cdn-cgi",
+                        expiresAtUnixMs: freshExpiry
+                    ),
                 ]
             ),
             bootstrap: BootstrapState(
@@ -95,19 +102,27 @@ final class FireSessionSecurityTests: XCTestCase {
         await session.mirrorCookiesToNativeStorage()
 
         let sharedCookies = mirroredSharedCookies()
-        XCTAssertEqual(sharedCookies.count, 3)
+        XCTAssertEqual(sharedCookies.count, 4)
         XCTAssertEqual(sharedCookies.first(where: { $0.name == "_t" })?.value, "fresh-token")
         XCTAssertEqual(
             sharedCookies.first(where: { $0.name == "cf_clearance" })?.value,
             "fresh-clearance"
         )
+        XCTAssertEqual(
+            sharedCookies.first(where: { $0.name == "__cf_bm" })?.value,
+            "browser-context"
+        )
 
         let webKitCookies = await mirroredWebKitCookies(store)
-        XCTAssertEqual(webKitCookies.count, 3)
+        XCTAssertEqual(webKitCookies.count, 4)
         XCTAssertEqual(webKitCookies.first(where: { $0.name == "_t" })?.value, "fresh-token")
         XCTAssertEqual(
             webKitCookies.first(where: { $0.name == "cf_clearance" })?.value,
             "fresh-clearance"
+        )
+        XCTAssertEqual(
+            webKitCookies.first(where: { $0.name == "__cf_bm" })?.value,
+            "browser-context"
         )
         XCTAssertFalse(webKitCookies.contains(where: { $0.value == "stale-token" }))
 
@@ -723,6 +738,22 @@ final class FireSessionSecurityTests: XCTestCase {
     }
 
     @MainActor
+    func testStaleSessionResponseIsConsumedWithoutPresentingRecovery() async {
+        let viewModel = FireAppViewModel(initialSession: authenticatedSession())
+
+        let recovered = await viewModel.handleRecoverableSessionErrorIfNeeded(
+            FireUniFfiError.StaleSessionResponse(operation: "fetch topic list")
+        )
+
+        XCTAssertTrue(recovered)
+        XCTAssertFalse(viewModel.isPresentingLogin)
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertTrue(viewModel.session.hasLoginSession)
+        XCTAssertTrue(viewModel.session.readiness.canReadAuthenticatedApi)
+        XCTAssertTrue(viewModel.session.readiness.hasCloudflareClearance)
+    }
+
+    @MainActor
     func testLoginRequiredRecoveryClearsLocalSessionAndPresentsLogin() async {
         let recoveryStore = MockChallengeRecoveryStore(
             result: .success(challengedLoggedOutSession())
@@ -959,7 +990,6 @@ final class FireSessionSecurityTests: XCTestCase {
     private func mirroredSharedCookies() -> [HTTPCookie] {
         let host = "linux.do"
         return (HTTPCookieStorage.shared.cookies ?? [])
-            .filter { mirroredCookieNames.contains($0.name) }
             .filter {
                 let normalizedDomain = normalizeCookieDomain($0.domain)
                 return normalizedDomain == host || normalizedDomain.hasSuffix(".\(host)")
@@ -982,7 +1012,6 @@ final class FireSessionSecurityTests: XCTestCase {
         let host = "linux.do"
         let cookies = await store.getAllCookies()
         return cookies
-            .filter { mirroredCookieNames.contains($0.name) }
             .filter {
                 let normalizedDomain = normalizeCookieDomain($0.domain)
                 return normalizedDomain == host || normalizedDomain.hasSuffix(".\(host)")
@@ -999,10 +1028,6 @@ final class FireSessionSecurityTests: XCTestCase {
         for cookie in await mirroredWebKitCookies(store) {
             await store.deleteCookie(cookie)
         }
-    }
-
-    private var mirroredCookieNames: Set<String> {
-        ["_t", "_forum_session", "cf_clearance"]
     }
 
     private func normalizeCookieDomain(_ domain: String) -> String {

--- a/rust/crates/fire-core/src/cookies.rs
+++ b/rust/crates/fire-core/src/cookies.rs
@@ -32,8 +32,12 @@ impl CookieJar for FireSessionCookieJar {
             return;
         }
 
-        let mut patch = CookieSnapshot::default();
         let request_epoch = FIRE_REQUEST_EPOCH.try_with(|epoch| *epoch).ok();
+        if is_stale_request_epoch(&self.session, request_epoch) {
+            return;
+        }
+
+        let mut patch = CookieSnapshot::default();
         for header in cookie_headers {
             let Ok(value) = header.to_str() else {
                 continue;
@@ -41,10 +45,6 @@ impl CookieJar for FireSessionCookieJar {
             let Some(cookie) = parse_set_cookie(value, url) else {
                 continue;
             };
-            let is_auth_cookie = matches!(cookie.name.as_str(), "_t" | "_forum_session");
-            if is_auth_cookie && is_stale_request_epoch(&self.session, request_epoch) {
-                continue;
-            }
 
             match cookie.name.as_str() {
                 "_t" => patch.t_token = Some(cookie.value.clone()),

--- a/rust/crates/fire-core/src/core/messagebus.rs
+++ b/rust/crates/fire-core/src/core/messagebus.rs
@@ -567,7 +567,11 @@ fn build_message_bus_poll_request_for_snapshot(
         .insert(FireRequestProfile::MessageBusPoll);
     request.extensions_mut().insert(FireRequestEpoch(epoch));
     let trace_id = diagnostics.prepare_request_trace(MESSAGE_BUS_OPERATION, &mut request);
-    Ok(TracedRequest { trace_id, request })
+    Ok(TracedRequest {
+        trace_id,
+        operation: MESSAGE_BUS_OPERATION,
+        request,
+    })
 }
 
 async fn read_message_bus_error_response(

--- a/rust/crates/fire-core/src/core/mod.rs
+++ b/rust/crates/fire-core/src/core/mod.rs
@@ -169,6 +169,10 @@ impl FireCore {
         (state.snapshot.clone(), state.epoch)
     }
 
+    pub(crate) fn current_session_epoch(&self) -> u64 {
+        read_rwlock(&self.session, "session").epoch
+    }
+
     pub fn shared_client(&self) -> Client {
         self.network.client()
     }

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -93,10 +93,17 @@ pub(crate) enum FireCallProfile {
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct FireRequestEpoch(pub(crate) u64);
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct FireResponseEpochContext {
+    pub(crate) request_epoch: u64,
+    pub(crate) operation: &'static str,
+}
+
 #[derive(Clone)]
 pub(crate) struct FireNetworkLayer {
     client: Client,
     diagnostics: Arc<FireDiagnosticsStore>,
+    session: Arc<RwLock<super::FireSessionRuntimeState>>,
 }
 
 #[derive(Clone)]
@@ -180,6 +187,7 @@ impl Interceptor for FireTraceSnapshotInterceptor {
 
 pub(crate) struct TracedRequest {
     pub(crate) trace_id: u64,
+    pub(crate) operation: &'static str,
     pub(crate) request: Request<RequestBody>,
 }
 
@@ -192,7 +200,10 @@ impl FireNetworkLayer {
     ) -> Result<Self, FireCoreError> {
         let builder = Client::builder()
             .cookie_jar(cookie_jar)
-            .application_interceptor(FireCommonHeaderInterceptor::new(base_url.clone(), session))
+            .application_interceptor(FireCommonHeaderInterceptor::new(
+                base_url.clone(),
+                Arc::clone(&session),
+            ))
             .network_interceptor(FireTraceSnapshotInterceptor::new(Arc::clone(&diagnostics)))
             .connect_timeout(NETWORK_CONNECT_TIMEOUT)
             .call_timeout(NETWORK_CALL_TIMEOUT)
@@ -211,6 +222,7 @@ impl FireNetworkLayer {
         Ok(Self {
             client,
             diagnostics,
+            session,
         })
     }
 
@@ -224,6 +236,7 @@ impl FireNetworkLayer {
         profile: FireCallProfile,
     ) -> Result<(u64, Response<ResponseBody>), FireCoreError> {
         let trace_id = traced.trace_id;
+        let operation = traced.operation;
         let request_epoch = traced
             .request
             .extensions()
@@ -257,7 +270,22 @@ impl FireNetworkLayer {
                 return Err(FireCoreError::Network { source });
             }
         };
+        let current_epoch = self.current_epoch();
+        if current_epoch != request_epoch.0 {
+            trace_guard.cancel(
+                "Session superseded",
+                format!(
+                    "Discarded `{operation}` response after session epoch advanced from {} to {}",
+                    request_epoch.0, current_epoch
+                ),
+            );
+            return Err(FireCoreError::StaleSessionResponse { operation });
+        }
         response.extensions_mut().insert(trace_guard);
+        response.extensions_mut().insert(FireResponseEpochContext {
+            request_epoch: request_epoch.0,
+            operation,
+        });
         debug!(
             trace_id,
             status = response.status().as_u16(),
@@ -265,6 +293,10 @@ impl FireNetworkLayer {
             "HTTP response received"
         );
         Ok((trace_id, response))
+    }
+
+    fn current_epoch(&self) -> u64 {
+        read_rwlock(&self.session, "session").epoch
     }
 }
 
@@ -274,6 +306,37 @@ pub(crate) fn take_trace_cancellation_guard(
     response
         .extensions_mut()
         .remove::<FireNetworkTraceCancellationGuard>()
+}
+
+fn response_epoch_context(response: &Response<ResponseBody>) -> Option<FireResponseEpochContext> {
+    response
+        .extensions()
+        .get::<FireResponseEpochContext>()
+        .copied()
+}
+
+fn stale_response_error(
+    core: &FireCore,
+    diagnostics: &Arc<FireDiagnosticsStore>,
+    trace_id: u64,
+    context: FireResponseEpochContext,
+) -> Option<FireCoreError> {
+    let current_epoch = core.current_session_epoch();
+    if current_epoch == context.request_epoch {
+        return None;
+    }
+
+    diagnostics.record_cancelled_if_in_progress(
+        trace_id,
+        "Session superseded",
+        Some(&format!(
+            "Discarded `{}` response after session epoch advanced from {} to {}",
+            context.operation, context.request_epoch, current_epoch
+        )),
+    );
+    Some(FireCoreError::StaleSessionResponse {
+        operation: context.operation,
+    })
 }
 
 fn apply_call_profile(call: Call, profile: FireCallProfile) -> Call {
@@ -309,7 +372,11 @@ impl FireCore {
         let trace_id = self
             .diagnostics
             .prepare_request_trace(operation, &mut request);
-        Ok(TracedRequest { trace_id, request })
+        Ok(TracedRequest {
+            trace_id,
+            operation,
+            request,
+        })
     }
 
     pub(crate) fn build_json_get_request(
@@ -345,7 +412,11 @@ impl FireCore {
         let trace_id = self
             .diagnostics
             .prepare_request_trace(operation, &mut request);
-        Ok(TracedRequest { trace_id, request })
+        Ok(TracedRequest {
+            trace_id,
+            operation,
+            request,
+        })
     }
 
     pub(crate) fn build_api_request(
@@ -432,7 +503,11 @@ impl FireCore {
         let trace_id = self
             .diagnostics
             .prepare_request_trace(operation, &mut request);
-        Ok(TracedRequest { trace_id, request })
+        Ok(TracedRequest {
+            trace_id,
+            operation,
+            request,
+        })
     }
 
     pub(crate) fn build_api_request_with_body(
@@ -470,7 +545,11 @@ impl FireCore {
         let trace_id = self
             .diagnostics
             .prepare_request_trace(operation, &mut request);
-        Ok(TracedRequest { trace_id, request })
+        Ok(TracedRequest {
+            trace_id,
+            operation,
+            request,
+        })
     }
 
     pub(crate) async fn execute_request(
@@ -488,6 +567,7 @@ impl FireCore {
         response: Response<ResponseBody>,
     ) -> Result<String, FireCoreError> {
         let mut response = response;
+        let response_epoch = response_epoch_context(&response);
         let _trace_guard = take_trace_cancellation_guard(&mut response).unwrap_or_else(|| {
             self.diagnostics.cancellation_guard(
                 trace_id,
@@ -503,6 +583,11 @@ impl FireCore {
                 return Err(FireCoreError::Network { source });
             }
         };
+        if let Some(error) = response_epoch
+            .and_then(|context| stale_response_error(self, &self.diagnostics, trace_id, context))
+        {
+            return Err(error);
+        }
         self.diagnostics
             .record_response_body_text(trace_id, &text, content_type.as_deref());
         Ok(text)
@@ -644,6 +729,7 @@ pub(crate) async fn expect_success(
     let response_status = response.status();
     let status = response_status.as_u16();
     let invalidation = response_login_invalidation_signal(response.headers());
+    let response_epoch = response_epoch_context(&response);
     let _trace_guard = take_trace_cancellation_guard(&mut response).unwrap_or_else(|| {
         core.diagnostics.cancellation_guard(
             trace_id,
@@ -656,6 +742,11 @@ pub(crate) async fn expect_success(
         .text()
         .await
         .unwrap_or_else(|error| format!("<failed to read error body: {error}>"));
+    if let Some(error) = response_epoch
+        .and_then(|context| stale_response_error(core, &core.diagnostics, trace_id, context))
+    {
+        return Err(error);
+    }
     warn!(
         operation,
         trace_id,

--- a/rust/crates/fire-core/src/diagnostics.rs
+++ b/rust/crates/fire-core/src/diagnostics.rs
@@ -341,6 +341,22 @@ impl Clone for FireNetworkTraceCancellationGuard {
     }
 }
 
+impl FireNetworkTraceCancellationGuard {
+    pub(crate) fn cancel(self, summary: impl Into<String>, details: impl Into<String>) {
+        let summary = summary.into();
+        let details = details.into();
+        if !self.inner.armed.swap(false, Ordering::AcqRel) {
+            return;
+        }
+
+        self.inner.diagnostics.record_cancelled_if_in_progress(
+            self.inner.trace_id,
+            &summary,
+            Some(&details),
+        );
+    }
+}
+
 impl Default for FireDiagnosticsStore {
     fn default() -> Self {
         Self::new()

--- a/rust/crates/fire-core/src/error.rs
+++ b/rust/crates/fire-core/src/error.rs
@@ -27,6 +27,8 @@ pub enum FireCoreError {
         operation: &'static str,
         message: String,
     },
+    #[error("{operation} response was discarded because the session changed")]
+    StaleSessionResponse { operation: &'static str },
     #[error("{operation} requires Cloudflare challenge verification")]
     CloudflareChallenge { operation: &'static str },
     #[error("failed to parse {operation} response: {source}")]

--- a/rust/crates/fire-core/tests/network.rs
+++ b/rust/crates/fire-core/tests/network.rs
@@ -535,10 +535,10 @@ async fn fetch_topic_list_surfaces_login_required_and_clears_local_state_for_not
 }
 
 #[tokio::test]
-async fn stale_response_auth_cookies_do_not_restore_logged_out_session() {
+async fn stale_response_is_discarded_after_local_logout() {
     let body = sample_latest_json();
     let response = format!(
-        "HTTP/1.1 200 TEST\r\nContent-Type: application/json\r\nContent-Length: {}\r\nSet-Cookie: _t=stale-token; path=/; SameSite=Lax\r\nSet-Cookie: _forum_session=stale-forum; path=/; SameSite=Lax\r\nConnection: close\r\n\r\n{body}",
+        "HTTP/1.1 200 TEST\r\nContent-Type: application/json\r\nContent-Length: {}\r\nSet-Cookie: _t=stale-token; path=/; SameSite=Lax\r\nSet-Cookie: _forum_session=stale-forum; path=/; SameSite=Lax\r\nSet-Cookie: __cf_bm=stale-browser-context; path=/; SameSite=Lax\r\nConnection: close\r\n\r\n{body}",
         body.len()
     );
     let server = TestServer::spawn_scripted(vec![TestServerStep::delayed(
@@ -591,21 +591,34 @@ async fn stale_response_auth_cookies_do_not_restore_logged_out_session() {
     let cleared = core.logout_local(true);
     assert!(!cleared.cookies.has_login_session());
 
-    let result = task.await.expect("task join").expect("topic list");
+    let error = task
+        .await
+        .expect("task join")
+        .expect_err("stale response should be discarded");
     let _ = server.shutdown().await;
 
-    assert_eq!(result.topics.len(), 1);
+    assert!(matches!(
+        error,
+        FireCoreError::StaleSessionResponse {
+            operation: "fetch topic list"
+        }
+    ));
     let snapshot = core.snapshot();
     assert_eq!(snapshot.cookies.t_token, None);
     assert_eq!(snapshot.cookies.forum_session, None);
     assert_eq!(snapshot.cookies.cf_clearance, None);
+    assert!(!snapshot
+        .cookies
+        .platform_cookies
+        .iter()
+        .any(|cookie| cookie.name == "__cf_bm"));
 }
 
 #[tokio::test]
-async fn stale_response_auth_cookies_do_not_override_rotated_session() {
+async fn stale_response_is_discarded_after_session_rotation() {
     let body = sample_latest_json();
     let response = format!(
-        "HTTP/1.1 200 TEST\r\nContent-Type: application/json\r\nContent-Length: {}\r\nSet-Cookie: _t=stale-token; path=/; SameSite=Lax\r\nSet-Cookie: _forum_session=stale-forum; path=/; SameSite=Lax\r\nConnection: close\r\n\r\n{body}",
+        "HTTP/1.1 200 TEST\r\nContent-Type: application/json\r\nContent-Length: {}\r\nSet-Cookie: _t=stale-token; path=/; SameSite=Lax\r\nSet-Cookie: _forum_session=stale-forum; path=/; SameSite=Lax\r\nSet-Cookie: __cf_bm=stale-browser-context; path=/; SameSite=Lax\r\nConnection: close\r\n\r\n{body}",
         body.len()
     );
     let server = TestServer::spawn_scripted(vec![TestServerStep::delayed(
@@ -680,16 +693,29 @@ async fn stale_response_auth_cookies_do_not_override_rotated_session() {
     });
     assert_eq!(rotated.cookies.t_token.as_deref(), Some("fresh-token"));
 
-    let result = task.await.expect("task join").expect("topic list");
+    let error = task
+        .await
+        .expect("task join")
+        .expect_err("stale response should be discarded");
     let _ = server.shutdown().await;
 
-    assert_eq!(result.topics.len(), 1);
+    assert!(matches!(
+        error,
+        FireCoreError::StaleSessionResponse {
+            operation: "fetch topic list"
+        }
+    ));
     let snapshot = core.snapshot();
     assert_eq!(snapshot.cookies.t_token.as_deref(), Some("fresh-token"));
     assert_eq!(
         snapshot.cookies.forum_session.as_deref(),
         Some("fresh-forum")
     );
+    assert!(!snapshot
+        .cookies
+        .platform_cookies
+        .iter()
+        .any(|cookie| cookie.name == "__cf_bm"));
 }
 
 #[tokio::test]

--- a/rust/crates/fire-uniffi/src/lib.rs
+++ b/rust/crates/fire-uniffi/src/lib.rs
@@ -2859,6 +2859,8 @@ pub enum FireUniFfiError {
     Authentication { details: String },
     #[error("login required: {details}")]
     LoginRequired { details: String },
+    #[error("stale session response discarded: {operation}")]
+    StaleSessionResponse { operation: String },
     #[error("network error: {details}")]
     Network { details: String },
     #[error("request requires Cloudflare challenge verification")]
@@ -2899,6 +2901,9 @@ impl From<FireCoreError> for FireUniFfiError {
             FireCoreError::LoginRequired { message, .. } => {
                 Self::LoginRequired { details: message }
             }
+            FireCoreError::StaleSessionResponse { operation } => Self::StaleSessionResponse {
+                operation: operation.to_string(),
+            },
             FireCoreError::CloudflareChallenge { .. } => Self::CloudflareChallenge,
             FireCoreError::HttpStatus {
                 operation,
@@ -4187,6 +4192,19 @@ mod tests {
             error,
             FireUniFfiError::LoginRequired { details }
                 if details == "您需要登录才能执行此操作。"
+        ));
+    }
+
+    #[test]
+    fn maps_stale_session_response_errors_to_dedicated_variant() {
+        let error = FireUniFfiError::from(FireCoreError::StaleSessionResponse {
+            operation: "fetch topic list",
+        });
+
+        assert!(matches!(
+            error,
+            FireUniFfiError::StaleSessionResponse { operation }
+                if operation == "fetch topic list"
         ));
     }
 


### PR DESCRIPTION
## Summary
- add the iOS auth alignment implementation plan plus the final workspace/backend doc sync
- fence stale Rust responses by session epoch, drop stale cookie batches wholesale, and expose a dedicated UniFFI stale-session error
- finish the iOS auth recovery flow with full same-site cookie mirroring, interactive Cloudflare recovery/retry, and stale-session host handling across home/topic/notification surfaces

## Testing
- cargo test -p fire-core stale_response -- --nocapture
- cargo test -p fire-uniffi maps_ -- --nocapture
- cargo test -p fire-core -p fire-uniffi --quiet
- bash native/ios-app/scripts/sync_uniffi_bindings.sh
- xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'id=D733CCB1-7B2A-49B5-B3F8-36CB6D0CB2BF' -only-testing:FireTests/FireSessionSecurityTests test
