### PR TITLE
ci: scope iOS validation by event

### DIFF
--- a/.github/workflows/native.yml
+++ b/.github/workflows/native.yml
@@ -92,8 +92,9 @@ jobs:
         run: ./gradlew assembleRelease
 
   ios:
-    name: iOS Build And Unit Test
+    name: iOS Validation
     runs-on: macos-15
+    timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v5
@@ -135,7 +136,7 @@ jobs:
       - name: Verify generated Xcode project is up to date
         run: git diff --exit-code -- native/ios-app/Fire.xcodeproj
 
-      - name: Run iOS unit tests
+      - name: Run iOS tests
         shell: bash
         run: |
           set -euo pipefail
@@ -150,15 +151,27 @@ jobs:
           trap 'xcrun simctl delete "$sim_id"' EXIT
           xcrun simctl boot "$sim_id" || true
           xcrun simctl bootstatus "$sim_id" -b
-          xcodebuild \
-            -project native/ios-app/Fire.xcodeproj \
-            -scheme Fire \
-            -destination "id=$sim_id" \
-            -derivedDataPath /tmp/fire-ios-tests \
-            CODE_SIGNING_ALLOWED=NO \
-            test
+          run_tests() {
+            local test_identifier="$1"
+
+            xcodebuild \
+              -project native/ios-app/Fire.xcodeproj \
+              -scheme Fire \
+              -destination "id=$sim_id" \
+              -derivedDataPath /tmp/fire-ios-tests \
+              CODE_SIGNING_ALLOWED=NO \
+              -only-testing:"$test_identifier" \
+              test
+          }
+
+          run_tests FireTests
+
+          if [[ "${GITHUB_EVENT_NAME}" == "push" ]]; then
+            run_tests "FireUITests/FireSmokeUITests/testAppLaunches"
+          fi
 
       - name: Build iOS app for device
+        if: github.event_name == 'push'
         run: |
           xcodebuild \
             -project native/ios-app/Fire.xcodeproj \

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -78,9 +78,35 @@ private enum FireCloudflareRecoveryError: LocalizedError {
     }
 }
 
+private final class PendingCloudflareRecoveryWaiters: @unchecked Sendable {
+    private let lock = NSLock()
+    private var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+
+    func add(_ waiter: CheckedContinuation<Void, Error>, for id: UUID) {
+        lock.lock()
+        waiters[id] = waiter
+        lock.unlock()
+    }
+
+    func remove(_ id: UUID) -> CheckedContinuation<Void, Error>? {
+        lock.lock()
+        defer { lock.unlock() }
+        return waiters.removeValue(forKey: id)
+    }
+
+    func removeAll() -> [CheckedContinuation<Void, Error>] {
+        lock.lock()
+        defer {
+            waiters.removeAll()
+            lock.unlock()
+        }
+        return Array(waiters.values)
+    }
+}
+
 private struct PendingCloudflareRecovery {
     let context: FireCloudflareChallengeContext
-    var waiters: [UUID: CheckedContinuation<Void, Error>] = [:]
+    let waiters = PendingCloudflareRecoveryWaiters()
 }
 
 struct FireTopicPostPaginationState {
@@ -1465,20 +1491,23 @@ final class FireAppViewModel: ObservableObject {
             setAuthPresentationState(.cloudflareRecovery(context))
         }
 
+        guard let pendingCloudflareRecovery else {
+            throw FireCloudflareRecoveryError.cancelled
+        }
+
+        let waiters = pendingCloudflareRecovery.waiters
         let waiterID = UUID()
         try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation {
                 (continuation: CheckedContinuation<Void, Error>) in
-                guard var pendingCloudflareRecovery else {
-                    continuation.resume(throwing: FireCloudflareRecoveryError.cancelled)
-                    return
+                waiters.add(continuation, for: waiterID)
+                if Task.isCancelled, let waiter = waiters.remove(waiterID) {
+                    waiter.resume(throwing: CancellationError())
                 }
-                pendingCloudflareRecovery.waiters[waiterID] = continuation
-                self.pendingCloudflareRecovery = pendingCloudflareRecovery
             }
-        } onCancel: { [weak self] in
-            Task { @MainActor [weak self] in
-                self?.cancelPendingCloudflareRecoveryWaiter(waiterID)
+        } onCancel: {
+            if let waiter = waiters.remove(waiterID) {
+                waiter.resume(throwing: CancellationError())
             }
         }
     }
@@ -1740,21 +1769,9 @@ final class FireAppViewModel: ObservableObject {
             return
         }
 
-        let waiters = Array(pendingCloudflareRecovery.waiters.values)
+        let waiters = pendingCloudflareRecovery.waiters.removeAll()
         self.pendingCloudflareRecovery = nil
         waiters.forEach { $0.resume(with: result) }
-    }
-
-    private func cancelPendingCloudflareRecoveryWaiter(_ waiterID: UUID) {
-        guard var pendingCloudflareRecovery else {
-            return
-        }
-        guard let waiter = pendingCloudflareRecovery.waiters.removeValue(forKey: waiterID) else {
-            return
-        }
-
-        self.pendingCloudflareRecovery = pendingCloudflareRecovery
-        waiter.resume(throwing: CancellationError())
     }
 
     func topicDetailLogger() -> FireHostLogger? {

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -138,7 +138,7 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
 - `Tests/Unit/FireEntityStateTests.swift`
   - covers `FireEntityIndex` upsert behavior plus `FireOrderedIDList` deduplication and stable ordering for the W2 home-feed list state
 - `Tests/UI/FireSmokeUITests.swift`
-  - backs the new `FireUITests` target with a minimal launch smoke test so the W3 UI-test lane is present before deeper end-to-end coverage lands
+  - keeps a minimal launch smoke test available for the dedicated `FireUITests` target; default PR CI runs only `FireTests`, while the smoke case stays on the slower main-branch validation path until deeper end-to-end coverage lands
 - `Tests/Unit/FireRouteParserTests.swift`
   - covers supported custom URL forms, LinuxDo route parsing, and notification-payload route mapping
 - `App/FireRootView.swift`
@@ -252,7 +252,8 @@ Verified local commands:
 - `./scripts/check_clean_submodules.sh`
 - `xcodegen generate --spec native/ios-app/project.yml`
 - `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'generic/platform=iOS Simulator' build`
-- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' -derivedDataPath /tmp/fire-ios-ui CODE_SIGNING_ALLOWED=NO test`
+- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' -derivedDataPath /tmp/fire-ios-ui CODE_SIGNING_ALLOWED=NO -only-testing:FireTests test`
+- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' -derivedDataPath /tmp/fire-ios-ui CODE_SIGNING_ALLOWED=NO -only-testing:FireUITests/FireSmokeUITests/testAppLaunches test`
 
 Operational archive command:
 

--- a/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
+++ b/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
@@ -190,14 +190,20 @@ extension FireSessionStore: FireLoginSessionStoring {}
 @MainActor
 public final class FireWebViewLoginCoordinator {
     private let sessionStore: any FireLoginSessionStoring
+    private let challengeRecoveryCookieCleaner: (@Sendable () async throws -> Void)?
     private var probeHomeFallbackCache: FireLoginProbeHomeFallbackCache?
 
     public init(sessionStore: FireSessionStore) {
         self.sessionStore = sessionStore
+        self.challengeRecoveryCookieCleaner = nil
     }
 
-    init(loginSessionStore: any FireLoginSessionStoring) {
+    init(
+        loginSessionStore: any FireLoginSessionStoring,
+        challengeRecoveryCookieCleaner: (@Sendable () async throws -> Void)? = nil
+    ) {
         self.sessionStore = loginSessionStore
+        self.challengeRecoveryCookieCleaner = challengeRecoveryCookieCleaner
     }
 
     public func restorePersistedSessionIfAvailable() async throws -> SessionState? {
@@ -229,7 +235,11 @@ public final class FireWebViewLoginCoordinator {
             // refresh is still challenged. The WebView login flow remains open so
             // the user can complete the challenge and retry Sync.
             _ = try? await sessionStore.logoutLocal(preserveCfClearance: true)
-            try? await clearChallengeRecoveryCookies()
+            if let challengeRecoveryCookieCleaner {
+                try? await challengeRecoveryCookieCleaner()
+            } else {
+                try? await clearChallengeRecoveryCookies()
+            }
             throw error
         }
     }

--- a/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
+++ b/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
@@ -462,7 +462,15 @@ final class FireSessionSecurityTests: XCTestCase {
             refreshResult: .failure(FireUniFfiError.CloudflareChallenge),
             logoutLocalResult: SessionState.placeholder()
         )
-        let coordinator = FireWebViewLoginCoordinator(loginSessionStore: store)
+        let clearedChallengeCookies = expectation(
+            description: "challenge recovery cookies cleared"
+        )
+        let coordinator = FireWebViewLoginCoordinator(
+            loginSessionStore: store,
+            challengeRecoveryCookieCleaner: {
+                clearedChallengeCookies.fulfill()
+            }
+        )
 
         do {
             _ = try await coordinator.completeLogin(sampleCapturedLoginState())
@@ -473,6 +481,7 @@ final class FireSessionSecurityTests: XCTestCase {
             XCTFail("unexpected error: \(error)")
         }
 
+        await fulfillment(of: [clearedChallengeCookies], timeout: 1.0)
         let calls = await store.calls()
         XCTAssertEqual(calls.syncLoginContextCount, 1)
         XCTAssertEqual(calls.refreshBootstrapIfNeededCount, 1)


### PR DESCRIPTION
## Summary
- add a timeout to the iOS validation job
- run only FireTests on pull requests and keep the UI smoke test on push-to-main validation
- skip the unsigned device release build on pull requests and document the split test commands

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/native.yml"); puts "native.yml OK"'