### PR TITLE
feat(ios): zip and streamline full APM exports

### DIFF
--- a/docs/architecture/ios-apm-beta-foundation.md
+++ b/docs/architecture/ios-apm-beta-foundation.md
@@ -17,9 +17,10 @@ This document describes the iOS-only crash and APM runtime added for the beta ph
   - `events/` daily NDJSON event files
   - `crashes/` raw `.plcrash` payloads
   - `metrickit/` raw MetricKit JSON payloads
-  - `exports/` shareable `.firesupportbundle` directories
-  - `tmp/` PLCrashReporter temporary files
-  - `runtime-state.json` last durable route / scene / breadcrumb snapshot
+  - `runtime-states/` per-launch route / scene / breadcrumb snapshots
+  - `tmp/` PLCrashReporter and full-export staging files
+- Shareable full-export artifacts live under `Application Support/Fire/ios-apm-exports/` as `.zip` archives.
+- The app keeps at most the latest 3 full-export archives and expires archives older than 24 hours.
 
 ## Correlation model
 
@@ -31,12 +32,13 @@ This document describes the iOS-only crash and APM runtime added for the beta ph
 ## Export and release workflow
 
 - Standard diagnostics export still comes from Rust via `export_support_bundle`.
-- Full iOS APM export creates a `.firesupportbundle` package containing:
+- Full iOS APM export creates a `.zip` archive whose root folder preserves the `.firesupportbundle` layout and contains:
   - Rust support bundle copy, when available
   - iOS APM events
   - raw crash payloads
   - raw MetricKit payloads
   - APM manifest with build metadata
+- Export staging directories are removed immediately after zipping so only the final archive remains in `ios-apm-exports/`.
 - Release artifact generation is handled by `scripts/ios/archive_release.sh`.
 - CI/manual archive artifact generation is handled by `.github/workflows/ios-release-artifacts.yml`.
 - The archive script injects `FIRE_GIT_SHA`, archives the app, copies `dSYMs/`, and emits `build-metadata.json`.

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -1164,6 +1164,11 @@ final class FireAppViewModel: ObservableObject {
         } else {
             rustBundleURL = nil
         }
+        defer {
+            if let rustBundleURL {
+                try? FileManager.default.removeItem(at: rustBundleURL)
+            }
+        }
         return try await FireAPMManager.shared.exportSupportBundle(
             rustSupportBundleURL: rustBundleURL,
             scenePhase: scenePhase

--- a/native/ios-app/App/FireDiagnosticsView.swift
+++ b/native/ios-app/App/FireDiagnosticsView.swift
@@ -131,6 +131,12 @@ struct FireDiagnosticsPagedTextDocument: Equatable {
     }
 }
 
+struct FireDiagnosticsShareRequest: Identifiable, Equatable {
+    let id = UUID()
+    let title: String
+    let url: URL
+}
+
 @MainActor
 final class FireDiagnosticsViewModel: ObservableObject {
     private static let traceAutoRefreshInterval: Duration = .seconds(1)
@@ -150,6 +156,7 @@ final class FireDiagnosticsViewModel: ObservableObject {
     @Published private(set) var isExportingFullAPMSupportBundle = false
     @Published private(set) var isLoading = false
     @Published var errorMessage: String?
+    @Published var shareRequest: FireDiagnosticsShareRequest?
 
     private let appViewModel: FireAppViewModel
     private var traceAutoRefreshTask: Task<Void, Never>?
@@ -387,6 +394,16 @@ final class FireDiagnosticsViewModel: ObservableObject {
         latestSupportBundle.map { URL(fileURLWithPath: $0.absolutePath) }
     }
 
+    func presentSupportBundleShare() {
+        guard let url = supportBundleURL() else {
+            return
+        }
+        shareRequest = FireDiagnosticsShareRequest(
+            title: "Fire Rust Diagnostics",
+            url: url
+        )
+    }
+
     func exportFullAPMSupportBundle(scenePhase: String) {
         guard !isExportingFullAPMSupportBundle else {
             return
@@ -397,8 +414,13 @@ final class FireDiagnosticsViewModel: ObservableObject {
             defer { isExportingFullAPMSupportBundle = false }
             do {
                 errorMessage = nil
-                latestFullAPMSupportBundle = try await appViewModel.exportFullAPMSupportBundle(
+                let export = try await appViewModel.exportFullAPMSupportBundle(
                     scenePhase: scenePhase
+                )
+                latestFullAPMSupportBundle = export
+                shareRequest = FireDiagnosticsShareRequest(
+                    title: "Fire Full APM Export",
+                    url: export.absoluteURL
                 )
             } catch {
                 errorMessage = error.localizedDescription
@@ -408,6 +430,20 @@ final class FireDiagnosticsViewModel: ObservableObject {
 
     func fullAPMSupportBundleURL() -> URL? {
         latestFullAPMSupportBundle?.absoluteURL
+    }
+
+    func presentFullAPMSupportBundleShare() {
+        guard let url = fullAPMSupportBundleURL() else {
+            return
+        }
+        shareRequest = FireDiagnosticsShareRequest(
+            title: "Fire Full APM Export",
+            url: url
+        )
+    }
+
+    func clearShareRequest() {
+        shareRequest = nil
     }
 
     private func loadTraceBodyPage(
@@ -613,6 +649,12 @@ struct FireDiagnosticsView: View {
         }
         .listStyle(.plain)
         .navigationTitle("诊断工具")
+        .sheet(item: $diagnosticsViewModel.shareRequest) { request in
+            FireActivityShareSheet(
+                activityItems: [request.url],
+                subject: request.title
+            )
+        }
         .onAppear {
             diagnosticsViewModel.startTraceAutoRefresh()
             Task {
@@ -711,13 +753,21 @@ struct FireDiagnosticsView: View {
     }
 
     private var supportBundleCard: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Label("诊断包", systemImage: "square.and.arrow.up")
-                .font(.headline)
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Label("导出与分享", systemImage: "square.and.arrow.up")
+                        .font(.headline)
 
-            Text("导出 Rust 诊断包，或附带本地 crash / MetricKit / route / span 工件的完整 APM 包，便于留档或分享排障。")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+                    Text("Rust 诊断快照保持轻量；完整 APM 采集会把本地 crash、MetricKit 和 runtime 工件整理成单个 ZIP，生成后可直接分享。")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 8)
+
+                exportFormatBadge("APM ZIP", color: .teal)
+            }
 
             if let diagnosticSessionID = diagnosticsViewModel.diagnosticSessionID {
                 VStack(alignment: .leading, spacing: 4) {
@@ -732,93 +782,105 @@ struct FireDiagnosticsView: View {
                 }
             }
 
-            HStack(spacing: 10) {
-                Button {
+            exportActionTile(
+                title: "Rust 诊断快照",
+                subtitle: "JSON，包含当前会话、最近日志和网络请求摘要，适合快速留档或单独转交。",
+                formatLabel: "JSON",
+                accent: .gray,
+                primaryProminent: false,
+                isBusy: diagnosticsViewModel.isExportingSupportBundle,
+                primaryTitle: diagnosticsViewModel.isExportingSupportBundle ? "导出中…" : "导出 JSON",
+                primarySystemImage: "doc.badge.arrow.up",
+                onPrimaryTap: {
                     diagnosticsViewModel.exportSupportBundle(
                         scenePhase: scenePhaseLabel(scenePhase)
                     )
-                } label: {
-                    Label(
-                        diagnosticsViewModel.isExportingSupportBundle ? "导出中…" : "导出诊断包",
-                        systemImage: "tray.and.arrow.down"
-                    )
+                },
+                secondaryTitle: diagnosticsViewModel.supportBundleURL() == nil ? nil : "分享上次导出",
+                onSecondaryTap: {
+                    diagnosticsViewModel.presentSupportBundleShare()
                 }
-                .buttonStyle(.borderedProminent)
-                .disabled(diagnosticsViewModel.isExportingSupportBundle)
-
-                if let bundleURL = diagnosticsViewModel.supportBundleURL() {
-                    ShareLink(item: bundleURL) {
-                        Label("分享", systemImage: "square.and.arrow.up")
-                    }
-                    .buttonStyle(.bordered)
-                }
-
-                if diagnosticsViewModel.isExportingSupportBundle {
-                    ProgressView()
-                        .controlSize(.small)
-                }
+            ) {
+                supportBundleMetadata
             }
 
-            HStack(spacing: 10) {
-                Button {
+            exportActionTile(
+                title: "完整 APM 采集包",
+                subtitle: "ZIP，附带 crash、MetricKit、runtime breadcrumbs 以及临时生成的 Rust 诊断快照，适合完整排障。",
+                formatLabel: "ZIP",
+                accent: .teal,
+                primaryProminent: true,
+                isBusy: diagnosticsViewModel.isExportingFullAPMSupportBundle,
+                primaryTitle: diagnosticsViewModel.isExportingFullAPMSupportBundle ? "生成中…" : "生成并分享 ZIP",
+                primarySystemImage: "archivebox",
+                onPrimaryTap: {
                     diagnosticsViewModel.exportFullAPMSupportBundle(
                         scenePhase: scenePhaseLabel(scenePhase)
                     )
-                } label: {
-                    Label(
-                        diagnosticsViewModel.isExportingFullAPMSupportBundle ? "导出中…" : "导出完整 APM 包",
-                        systemImage: "archivebox"
-                    )
+                },
+                secondaryTitle: diagnosticsViewModel.fullAPMSupportBundleURL() == nil ? nil : "再次分享",
+                onSecondaryTap: {
+                    diagnosticsViewModel.presentFullAPMSupportBundleShare()
                 }
-                .buttonStyle(.bordered)
-                .disabled(diagnosticsViewModel.isExportingFullAPMSupportBundle)
-
-                if let bundleURL = diagnosticsViewModel.fullAPMSupportBundleURL() {
-                    ShareLink(item: bundleURL) {
-                        Label("分享 APM 包", systemImage: "square.and.arrow.up")
-                    }
-                    .buttonStyle(.bordered)
-                }
-
-                if diagnosticsViewModel.isExportingFullAPMSupportBundle {
-                    ProgressView()
-                        .controlSize(.small)
-                }
+            ) {
+                fullAPMSupportBundleMetadata
             }
 
-            if let export = diagnosticsViewModel.latestSupportBundle {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("\(export.fileName) · \(FireDiagnosticsPresentation.byteSize(export.sizeBytes))")
-                        .font(.caption.monospaced())
-                    Text(FireDiagnosticsPresentation.timestamp(export.createdAtUnixMs))
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                    Text(export.relativePath)
-                        .font(.caption2.monospaced())
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                }
-            }
-
-            if let export = diagnosticsViewModel.latestFullAPMSupportBundle {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("\(export.fileName) · \(FireDiagnosticsPresentation.byteSize(export.sizeBytes))")
-                        .font(.caption.monospaced())
-                    Text(FireDiagnosticsPresentation.timestamp(export.createdAtUnixMs))
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                    Text(export.absoluteURL.path)
-                        .font(.caption2.monospaced())
-                        .foregroundStyle(.secondary)
-                        .textSelection(.enabled)
-                }
-            }
+            Label("完整 APM ZIP 最多保留最近 3 份，并在 24 小时后自动过期清理；打包临时目录会在导出结束后立即删除。", systemImage: "trash.slash")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
         }
         .padding(14)
         .background(
             RoundedRectangle(cornerRadius: 12, style: .continuous)
                 .fill(Color(.secondarySystemGroupedBackground))
         )
+    }
+
+    @ViewBuilder
+    private var supportBundleMetadata: some View {
+        if let export = diagnosticsViewModel.latestSupportBundle {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("最近导出：\(FireDiagnosticsPresentation.timestamp(export.createdAtUnixMs)) · \(FireDiagnosticsPresentation.byteSize(export.sizeBytes))")
+                    .font(.caption.weight(.medium))
+                Text(export.fileName)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.primary)
+                Text(export.relativePath)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        } else {
+            Text("输出单个 JSON 文件，不会触发额外的目录打包。")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var fullAPMSupportBundleMetadata: some View {
+        if diagnosticsViewModel.isExportingFullAPMSupportBundle {
+            Text("正在汇总采集目录并生成 ZIP，完成后会直接拉起系统分享。")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        } else if let export = diagnosticsViewModel.latestFullAPMSupportBundle {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("ZIP 已就绪：\(FireDiagnosticsPresentation.timestamp(export.createdAtUnixMs)) · \(FireDiagnosticsPresentation.byteSize(export.sizeBytes))")
+                    .font(.caption.weight(.medium))
+                Text(export.fileName)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.primary)
+                Text(export.absoluteURL.path)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        } else {
+            Text("导出时会先临时组包，再写入单个 ZIP 文件；中间目录不会长期留在本地。")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+        }
     }
 
     private var apmCard: some View {
@@ -972,6 +1034,88 @@ struct FireDiagnosticsView: View {
                 .foregroundStyle(.secondary)
         }
         .frame(maxWidth: .infinity)
+    }
+
+    private func exportFormatBadge(_ text: String, color: Color) -> some View {
+        Text(text)
+            .font(.caption2.weight(.semibold))
+            .foregroundStyle(color)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 5)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(color.opacity(0.12))
+            )
+    }
+
+    private func exportActionTile<Metadata: View>(
+        title: String,
+        subtitle: String,
+        formatLabel: String,
+        accent: Color,
+        primaryProminent: Bool,
+        isBusy: Bool,
+        primaryTitle: String,
+        primarySystemImage: String,
+        onPrimaryTap: @escaping () -> Void,
+        secondaryTitle: String?,
+        onSecondaryTap: @escaping () -> Void = {},
+        @ViewBuilder metadata: () -> Metadata
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 10) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(title)
+                        .font(.subheadline.weight(.semibold))
+                    Text(subtitle)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 8)
+
+                exportFormatBadge(formatLabel, color: accent)
+            }
+
+            HStack(spacing: 10) {
+                if primaryProminent {
+                    Button(action: onPrimaryTap) {
+                        Label(primaryTitle, systemImage: primarySystemImage)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isBusy)
+                } else {
+                    Button(action: onPrimaryTap) {
+                        Label(primaryTitle, systemImage: primarySystemImage)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(isBusy)
+                }
+
+                if let secondaryTitle {
+                    Button(action: onSecondaryTap) {
+                        Label(secondaryTitle, systemImage: "square.and.arrow.up")
+                    }
+                    .buttonStyle(.bordered)
+                }
+
+                if isBusy {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            metadata()
+        }
+        .padding(14)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(accent.opacity(0.08))
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .stroke(accent.opacity(0.18), lineWidth: 1)
+        )
     }
 
     private func pushActionTitle(for diagnostics: FirePushRegistrationDiagnostics) -> String {
@@ -1869,4 +2013,20 @@ private enum FireDiagnosticsPresentation {
             return "已取消"
         }
     }
+}
+
+private struct FireActivityShareSheet: UIViewControllerRepresentable {
+    let activityItems: [Any]
+    let subject: String
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let controller = UIActivityViewController(
+            activityItems: activityItems,
+            applicationActivities: nil
+        )
+        controller.setValue(subject, forKey: "subject")
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: UIActivityViewController, context: Context) {}
 }

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -33,7 +33,7 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - owns the beta-phase iOS crash/APM runtime
   - installs `PLCrashReporter` at launch, harvests pending crash reports on next cold start, and persists raw `.plcrash` payloads under `Application Support/Fire/ios-apm/crashes`
   - registers `MetricKit`, stores raw metric/diagnostic payload JSON under `Application Support/Fire/ios-apm/metrickit`, and keeps per-launch runtime-state snapshots under `Application Support/Fire/ios-apm/runtime-states` for route / scene / breadcrumb recovery
-  - samples foreground CPU / memory / thermal state, detects main-thread stalls, tracks host-owned route/span breadcrumbs, and exports shareable `.firesupportbundle` packages under `Application Support/Fire/ios-apm-exports`
+  - samples foreground CPU / memory / thermal state, detects main-thread stalls, tracks host-owned route/span breadcrumbs, and exports shareable `.zip` archives under `Application Support/Fire/ios-apm-exports`
 - `FireAuthCookieKeychainStore.swift`
   - stores the full same-site LinuxDo browser cookie batch in Keychain using a host-scoped generic-password entry, preserving domain variants and cookie expiry
   - preserves non-login browser context cookies, including `cf_clearance`, across explicit logout so Cloudflare challenge state stays aligned with the host shell
@@ -120,7 +120,7 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - lists workspace log files plus reverse-chronological network request traces
   - opens tail-first log pages, preview-first network body viewers, and per-request execution chains without pushing full diagnostic text across the UniFFI boundary by default
   - exposes host-owned notification permission / APNs registration state and the locally cached device token for production-readiness checks
-  - exports both the Rust-owned diagnostics bundle and a host-owned full APM `.firesupportbundle` package containing local crash / MetricKit / route / span artifacts for share-sheet based escalation during beta
+  - exports both the Rust-owned diagnostics bundle and a host-owned full APM `.zip` archive containing local crash / MetricKit / route / span artifacts for share-sheet based escalation during beta, auto-presenting the share sheet after full APM export completes
 - `App/FireTabRoot.swift`
   - instantiates the authenticated-shell store graph (`FireHomeFeedStore`, `FireSearchStore`, `FireNotificationStore`, `FireTopicDetailStore`, `FireProfileViewModel`) around one shared `FireAppViewModel`
   - injects home/topic-detail stores through the SwiftUI environment so those screens observe scoped feature state instead of the app-wide root object
@@ -207,7 +207,8 @@ Workspace note:
 - Rust can resolve relative paths inside that workspace for shared file ownership such as logs, caches, or exports.
 - The current persisted session file remains `Application Support/Fire/session.json`, and iOS currently writes the full session snapshot there during the active diagnostics-heavy development phase.
 - iOS keeps the full same-site LinuxDo browser cookie batch in Keychain, including expiry metadata and distinct host/domain variants, re-injects it into Rust during cold start before any authenticated refresh path runs, and refreshes the Keychain copy when Rust receives newer auth cookies from the network.
-- iOS now also keeps host-owned beta crash/APM runtime state under `Application Support/Fire/ios-apm/` plus exported full APM bundles under `Application Support/Fire/ios-apm-exports/`. Those trees are not Rust-owned and should be treated as native-only operational state.
+- iOS now also keeps host-owned beta crash/APM runtime state under `Application Support/Fire/ios-apm/` plus exported full APM zip archives under `Application Support/Fire/ios-apm-exports/`. Those trees are not Rust-owned and should be treated as native-only operational state.
+- Full APM zip exports are auto-cleaned: the app keeps at most the latest 3 archives and expires older exports after 24 hours. Any temporary staging directory used during zipping is removed immediately after export.
 
 Current UX note:
 

--- a/native/ios-app/Sources/FireAppSession/APM/FireAPMEventStore.swift
+++ b/native/ios-app/Sources/FireAppSession/APM/FireAPMEventStore.swift
@@ -4,6 +4,9 @@ actor FireAPMEventStore {
     private enum Constants {
         static let maxTotalBytes: UInt64 = 32 * 1024 * 1024
         static let retentionWindow: TimeInterval = 7 * 24 * 60 * 60
+        static let exportRetentionWindow: TimeInterval = 24 * 60 * 60
+        static let maxExportArchiveCount = 3
+        static let staleTemporaryExportWindow: TimeInterval = 6 * 60 * 60
     }
 
     private let baseURL: URL
@@ -29,6 +32,7 @@ actor FireAPMEventStore {
         self.encoder = encoder
         self.decoder = JSONDecoder()
         try ensureDirectories()
+        try pruneIfNeeded()
     }
 
     static func defaultBaseURL(fileManager: FileManager = .default) throws -> URL {
@@ -164,26 +168,36 @@ actor FireAPMEventStore {
         scenePhase: String?
     ) throws -> FireAPMSupportBundleExport {
         let timestamp = FireAPMClock.nowUnixMs()
-        let fileName = "fire-ios-apm-\(timestamp).firesupportbundle"
+        let archiveRootName = "fire-ios-apm-\(timestamp).firesupportbundle"
+        let fileName = "fire-ios-apm-\(timestamp).zip"
         let exportURL = exportBaseURL
-            .appendingPathComponent(fileName, isDirectory: true)
+            .appendingPathComponent(fileName, isDirectory: false)
+        let stagingURL = temporaryExportDirectoryURL(rootName: archiveRootName)
+
+        try pruneIfNeeded()
 
         if fileManager.fileExists(atPath: exportURL.path) {
             try fileManager.removeItem(at: exportURL)
         }
-        try fileManager.createDirectory(at: exportURL, withIntermediateDirectories: true)
+        if fileManager.fileExists(atPath: stagingURL.path) {
+            try fileManager.removeItem(at: stagingURL)
+        }
+        try fileManager.createDirectory(at: stagingURL, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: stagingURL)
+        }
 
         for component in ["events", "crashes", "metrickit"] {
             let source = baseURL.appendingPathComponent(component, isDirectory: true)
             guard fileManager.fileExists(atPath: source.path) else { continue }
-            let destination = exportURL.appendingPathComponent(component, isDirectory: true)
+            let destination = stagingURL.appendingPathComponent(component, isDirectory: true)
             try fileManager.copyItem(at: source, to: destination)
         }
 
         if let rustSupportBundleURL, fileManager.fileExists(atPath: rustSupportBundleURL.path) {
             try fileManager.copyItem(
                 at: rustSupportBundleURL,
-                to: exportURL.appendingPathComponent(rustSupportBundleURL.lastPathComponent)
+                to: stagingURL.appendingPathComponent(rustSupportBundleURL.lastPathComponent)
             )
         }
 
@@ -196,11 +210,24 @@ actor FireAPMEventStore {
         )
         let manifestData = try encoder.encode(manifest)
         try manifestData.write(
-            to: exportURL.appendingPathComponent("manifest.json"),
+            to: stagingURL.appendingPathComponent("manifest.json"),
             options: .atomic
         )
 
-        let sizeBytes = try Self.directorySize(at: exportURL, fileManager: fileManager)
+        try FireZipArchiveWriter.createArchive(
+            from: stagingURL,
+            to: exportURL,
+            fileManager: fileManager
+        )
+        if fileManager.fileExists(atPath: stagingURL.path) {
+            try? fileManager.removeItem(at: stagingURL)
+        }
+        try pruneExportArchivesIfNeeded(
+            at: exportBaseURL,
+            preserving: [exportURL.standardizedFileURL]
+        )
+        try pruneExportArchivesIfNeeded(at: legacyExportsDirectoryURL())
+        let sizeBytes = try Self.fileSize(at: exportURL, fileManager: fileManager)
         return FireAPMSupportBundleExport(
             fileName: fileName,
             absoluteURL: exportURL,
@@ -261,7 +288,17 @@ actor FireAPMEventStore {
         return events
     }
 
-    private func pruneIfNeeded() throws {
+    private func pruneIfNeeded(preservingExportURLs: Set<URL> = []) throws {
+        try pruneCapturedArtifactsIfNeeded()
+        try pruneTemporaryExportsIfNeeded()
+        try pruneExportArchivesIfNeeded(
+            at: exportBaseURL,
+            preserving: preservingExportURLs
+        )
+        try pruneExportArchivesIfNeeded(at: legacyExportsDirectoryURL())
+    }
+
+    private func pruneCapturedArtifactsIfNeeded() throws {
         let expirationCutoff = Date().addingTimeInterval(-Constants.retentionWindow)
         let legacyExportsURL = legacyExportsDirectoryURL().standardizedFileURL
         let enumerator = fileManager.enumerator(
@@ -313,6 +350,74 @@ actor FireAPMEventStore {
         }
     }
 
+    private func pruneTemporaryExportsIfNeeded() throws {
+        let tmpURL = baseURL.appendingPathComponent("tmp", isDirectory: true)
+        let expirationCutoff = Date().addingTimeInterval(-Constants.staleTemporaryExportWindow)
+        for item in try directoryContents(at: tmpURL) {
+            guard item.lastPathComponent.hasPrefix("fire-ios-apm-") else {
+                continue
+            }
+            let modifiedAt = try item.resourceValues(forKeys: [.contentModificationDateKey])
+                .contentModificationDate ?? .distantPast
+            if modifiedAt < expirationCutoff {
+                try? fileManager.removeItem(at: item)
+            }
+        }
+    }
+
+    private func pruneExportArchivesIfNeeded(
+        at directoryURL: URL,
+        preserving preservedURLs: Set<URL> = []
+    ) throws {
+        let preservedURLs = Set(preservedURLs.map(\.standardizedFileURL))
+        let expirationCutoff = Date().addingTimeInterval(-Constants.exportRetentionWindow)
+        let contents = try directoryContents(at: directoryURL)
+        if contents.isEmpty {
+            return
+        }
+
+        var candidates: [(url: URL, modifiedAt: Date)] = []
+        for item in contents {
+            let values = try item.resourceValues(
+                forKeys: [.contentModificationDateKey, .isRegularFileKey, .isDirectoryKey]
+            )
+            guard values.isRegularFile == true || values.isDirectory == true else {
+                continue
+            }
+
+            let standardizedURL = item.standardizedFileURL
+            let modifiedAt = values.contentModificationDate ?? .distantPast
+            if !preservedURLs.contains(standardizedURL), modifiedAt < expirationCutoff {
+                try? fileManager.removeItem(at: item)
+                continue
+            }
+
+            candidates.append((standardizedURL, modifiedAt))
+        }
+
+        let sorted = candidates.sorted { lhs, rhs in
+            if lhs.modifiedAt != rhs.modifiedAt {
+                return lhs.modifiedAt > rhs.modifiedAt
+            }
+            return lhs.url.lastPathComponent > rhs.url.lastPathComponent
+        }
+
+        var allowedURLs = preservedURLs
+        for candidate in sorted {
+            if allowedURLs.contains(candidate.url) {
+                continue
+            }
+            if allowedURLs.count >= Constants.maxExportArchiveCount {
+                break
+            }
+            allowedURLs.insert(candidate.url)
+        }
+
+        for candidate in sorted where !allowedURLs.contains(candidate.url) {
+            try? fileManager.removeItem(at: candidate.url)
+        }
+    }
+
     private func ensureDirectories() throws {
         try fileManager.createDirectory(at: baseURL, withIntermediateDirectories: true)
         for component in ["events", "crashes", "metrickit", "runtime-states", "tmp"] {
@@ -340,6 +445,12 @@ actor FireAPMEventStore {
 
     private func legacyExportsDirectoryURL() -> URL {
         baseURL.appendingPathComponent("exports", isDirectory: true)
+    }
+
+    private func temporaryExportDirectoryURL(rootName: String) -> URL {
+        baseURL
+            .appendingPathComponent("tmp", isDirectory: true)
+            .appendingPathComponent(rootName, isDirectory: true)
     }
 
     private func todayEventsURL() -> URL {
@@ -371,6 +482,18 @@ actor FireAPMEventStore {
     private static func fileSize(at url: URL, fileManager: FileManager) throws -> UInt64 {
         let values = try url.resourceValues(forKeys: [.fileSizeKey])
         return UInt64(values.fileSize ?? 0)
+    }
+
+    private func directoryContents(at url: URL) throws -> [URL] {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return []
+        }
+
+        return try fileManager.contentsOfDirectory(
+            at: url,
+            includingPropertiesForKeys: [.contentModificationDateKey, .isRegularFileKey, .isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        )
     }
 
     private func loadRuntimeState(forLaunchID launchID: String) throws -> FireAPMRuntimeState? {
@@ -445,4 +568,212 @@ private struct FireAPMSupportBundleManifest: Codable {
     let buildInfo: FireAPMBuildInfo
     let runtimeState: FireAPMRuntimeState?
     let rustSupportBundleFileName: String?
+}
+
+private struct FireZipArchiveWriter {
+    private struct Entry {
+        let relativePath: String
+        let contents: Data
+        let modifiedAt: Date
+        let crc32: UInt32
+
+        var sizeBytes: UInt32 {
+            UInt32(contents.count)
+        }
+    }
+
+    private struct DOSTimestamp {
+        let time: UInt16
+        let date: UInt16
+    }
+
+    private enum ZipArchiveError: Error {
+        case unsupportedEntrySize(String)
+        case unsupportedEntryCount(Int)
+        case unsupportedArchiveSize
+    }
+
+    private static let utf8Flag: UInt16 = 1 << 11
+    private static let calendar = Calendar(identifier: .gregorian)
+    private static let crc32Table: [UInt32] = (0..<256).map { index in
+        var value = UInt32(index)
+        for _ in 0..<8 {
+            if value & 1 == 1 {
+                value = 0xEDB88320 ^ (value >> 1)
+            } else {
+                value >>= 1
+            }
+        }
+        return value
+    }
+
+    static func createArchive(
+        from directoryURL: URL,
+        to archiveURL: URL,
+        fileManager: FileManager
+    ) throws {
+        let entries = try makeEntries(from: directoryURL, fileManager: fileManager)
+        guard entries.count <= Int(UInt16.max) else {
+            throw ZipArchiveError.unsupportedEntryCount(entries.count)
+        }
+
+        if fileManager.fileExists(atPath: archiveURL.path) {
+            try fileManager.removeItem(at: archiveURL)
+        }
+        _ = fileManager.createFile(atPath: archiveURL.path, contents: nil)
+        guard let handle = try? FileHandle(forWritingTo: archiveURL) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        defer { try? handle.close() }
+
+        var centralDirectory = Data()
+        var localHeaderOffset: UInt64 = 0
+
+        for entry in entries {
+            let fileNameData = Data(entry.relativePath.utf8)
+            let timestamp = dosTimestamp(for: entry.modifiedAt)
+
+            var localHeader = Data()
+            localHeader.appendLittleEndian(UInt32(0x04034B50))
+            localHeader.appendLittleEndian(UInt16(20))
+            localHeader.appendLittleEndian(utf8Flag)
+            localHeader.appendLittleEndian(UInt16(0))
+            localHeader.appendLittleEndian(timestamp.time)
+            localHeader.appendLittleEndian(timestamp.date)
+            localHeader.appendLittleEndian(entry.crc32)
+            localHeader.appendLittleEndian(entry.sizeBytes)
+            localHeader.appendLittleEndian(entry.sizeBytes)
+            localHeader.appendLittleEndian(UInt16(fileNameData.count))
+            localHeader.appendLittleEndian(UInt16(0))
+            localHeader.append(fileNameData)
+
+            try handle.write(contentsOf: localHeader)
+            try handle.write(contentsOf: entry.contents)
+
+            guard let storedOffset = UInt32(exactly: localHeaderOffset) else {
+                throw ZipArchiveError.unsupportedArchiveSize
+            }
+
+            var centralHeader = Data()
+            centralHeader.appendLittleEndian(UInt32(0x02014B50))
+            centralHeader.appendLittleEndian(UInt16(20))
+            centralHeader.appendLittleEndian(UInt16(20))
+            centralHeader.appendLittleEndian(utf8Flag)
+            centralHeader.appendLittleEndian(UInt16(0))
+            centralHeader.appendLittleEndian(timestamp.time)
+            centralHeader.appendLittleEndian(timestamp.date)
+            centralHeader.appendLittleEndian(entry.crc32)
+            centralHeader.appendLittleEndian(entry.sizeBytes)
+            centralHeader.appendLittleEndian(entry.sizeBytes)
+            centralHeader.appendLittleEndian(UInt16(fileNameData.count))
+            centralHeader.appendLittleEndian(UInt16(0))
+            centralHeader.appendLittleEndian(UInt16(0))
+            centralHeader.appendLittleEndian(UInt16(0))
+            centralHeader.appendLittleEndian(UInt16(0))
+            centralHeader.appendLittleEndian(UInt32(0))
+            centralHeader.appendLittleEndian(storedOffset)
+            centralHeader.append(fileNameData)
+            centralDirectory.append(centralHeader)
+
+            localHeaderOffset += UInt64(localHeader.count + entry.contents.count)
+        }
+
+        guard
+            let centralDirectoryOffset = UInt32(exactly: localHeaderOffset),
+            let centralDirectorySize = UInt32(exactly: centralDirectory.count)
+        else {
+            throw ZipArchiveError.unsupportedArchiveSize
+        }
+
+        try handle.write(contentsOf: centralDirectory)
+
+        var endOfCentralDirectory = Data()
+        endOfCentralDirectory.appendLittleEndian(UInt32(0x06054B50))
+        endOfCentralDirectory.appendLittleEndian(UInt16(0))
+        endOfCentralDirectory.appendLittleEndian(UInt16(0))
+        endOfCentralDirectory.appendLittleEndian(UInt16(entries.count))
+        endOfCentralDirectory.appendLittleEndian(UInt16(entries.count))
+        endOfCentralDirectory.appendLittleEndian(centralDirectorySize)
+        endOfCentralDirectory.appendLittleEndian(centralDirectoryOffset)
+        endOfCentralDirectory.appendLittleEndian(UInt16(0))
+        try handle.write(contentsOf: endOfCentralDirectory)
+    }
+
+    private static func makeEntries(
+        from directoryURL: URL,
+        fileManager: FileManager
+    ) throws -> [Entry] {
+        let rootName = directoryURL.lastPathComponent
+        let enumerator = fileManager.enumerator(
+            at: directoryURL,
+            includingPropertiesForKeys: [.isRegularFileKey, .contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        )
+
+        var entries: [Entry] = []
+        while let item = enumerator?.nextObject() as? URL {
+            let values = try item.resourceValues(
+                forKeys: [.isRegularFileKey, .contentModificationDateKey]
+            )
+            guard values.isRegularFile == true else {
+                continue
+            }
+
+            let relativeComponent = item.path.replacingOccurrences(
+                of: directoryURL.path + "/",
+                with: ""
+            )
+            let relativePath = "\(rootName)/\(relativeComponent)"
+            let contents = try Data(contentsOf: item)
+            guard UInt32(exactly: contents.count) != nil else {
+                throw ZipArchiveError.unsupportedEntrySize(relativePath)
+            }
+
+            entries.append(
+                Entry(
+                    relativePath: relativePath,
+                    contents: contents,
+                    modifiedAt: values.contentModificationDate ?? Date(),
+                    crc32: crc32(contents)
+                )
+            )
+        }
+
+        return entries.sorted { $0.relativePath < $1.relativePath }
+    }
+
+    private static func crc32(_ data: Data) -> UInt32 {
+        var crc: UInt32 = 0xFFFF_FFFF
+        for byte in data {
+            let index = Int((crc ^ UInt32(byte)) & 0xFF)
+            crc = crc32Table[index] ^ (crc >> 8)
+        }
+        return crc ^ 0xFFFF_FFFF
+    }
+
+    private static func dosTimestamp(for date: Date) -> DOSTimestamp {
+        let components = calendar.dateComponents(
+            in: TimeZone(secondsFromGMT: 0) ?? .current,
+            from: date
+        )
+        let year = max(1980, min(components.year ?? 1980, 2107))
+        let month = max(1, min(components.month ?? 1, 12))
+        let day = max(1, min(components.day ?? 1, 31))
+        let hour = max(0, min(components.hour ?? 0, 23))
+        let minute = max(0, min(components.minute ?? 0, 59))
+        let second = max(0, min(components.second ?? 0, 59))
+
+        let dosTime = UInt16((hour << 11) | (minute << 5) | (second / 2))
+        let dosDate = UInt16(((year - 1980) << 9) | (month << 5) | day)
+        return DOSTimestamp(time: dosTime, date: dosDate)
+    }
+}
+
+private extension Data {
+    mutating func appendLittleEndian<T: FixedWidthInteger>(_ value: T) {
+        var littleEndianValue = value.littleEndian
+        Swift.withUnsafeBytes(of: &littleEndianValue) { buffer in
+            append(contentsOf: buffer)
+        }
+    }
 }

--- a/native/ios-app/Tests/Unit/FireAPMEventStoreTests.swift
+++ b/native/ios-app/Tests/Unit/FireAPMEventStoreTests.swift
@@ -64,7 +64,7 @@ final class FireAPMEventStoreTests: XCTestCase {
         XCTAssertEqual(summary.currentSample?.physicalFootprintBytes, 2_048)
     }
 
-    func testEventStoreRoundTripsRuntimeStateAndExportsBundle() async throws {
+    func testEventStoreRoundTripsRuntimeStateAndExportsZipBundle() async throws {
         let fileManager = FileManager.default
         let sandboxURL = fileManager.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -104,6 +104,10 @@ final class FireAPMEventStoreTests: XCTestCase {
         XCTAssertGreaterThan(export.sizeBytes, 0)
         XCTAssertTrue(export.absoluteURL.path.hasPrefix(exportBaseURL.path + "/"))
         XCTAssertFalse(export.absoluteURL.path.hasPrefix(rootURL.path + "/"))
+        XCTAssertEqual(export.absoluteURL.pathExtension, "zip")
+
+        let entryNames = try zipEntryNames(at: export.absoluteURL)
+        XCTAssertTrue(entryNames.contains { $0.hasSuffix("/manifest.json") })
     }
 
     func testPreviousRuntimeStateSkipsCurrentLaunchState() async throws {
@@ -149,7 +153,7 @@ final class FireAPMEventStoreTests: XCTestCase {
         XCTAssertEqual(restoredPrevious.currentRoute, "tab.profile")
     }
 
-    func testExportBundleDoesNotPruneLiveDiagnosticsOrReturnedBundle() async throws {
+    func testExportBundleDoesNotPruneLiveDiagnosticsAndPackagesArtifactsIntoZip() async throws {
         let fileManager = FileManager.default
         let sandboxURL = fileManager.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -199,26 +203,76 @@ final class FireAPMEventStoreTests: XCTestCase {
 
         XCTAssertTrue(fileManager.fileExists(atPath: rootURL.appendingPathComponent("crashes/crash.plcrash").path))
         XCTAssertTrue(fileManager.fileExists(atPath: rootURL.appendingPathComponent("metrickit/metric.json").path))
-        XCTAssertTrue(
-            fileManager.fileExists(
-                atPath: export.absoluteURL.appendingPathComponent("crashes/crash.plcrash").path
-            )
+        XCTAssertEqual(export.absoluteURL.pathExtension, "zip")
+
+        let entryNames = try zipEntryNames(at: export.absoluteURL)
+        XCTAssertTrue(entryNames.contains { $0.hasSuffix("/crashes/crash.plcrash") })
+        XCTAssertTrue(entryNames.contains { $0.hasSuffix("/metrickit/metric.json") })
+        XCTAssertTrue(entryNames.contains { $0.hasSuffix("/\(rustBundleURL.lastPathComponent)") })
+        XCTAssertTrue(entryNames.contains { $0.hasSuffix("/manifest.json") })
+    }
+
+    func testExportBundlePrunesExpiredAndExcessArchives() async throws {
+        let fileManager = FileManager.default
+        let sandboxURL = fileManager.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        defer { try? fileManager.removeItem(at: sandboxURL) }
+        let rootURL = sandboxURL.appendingPathComponent("ios-apm", isDirectory: true)
+        let exportBaseURL = sandboxURL.appendingPathComponent("ios-apm-exports", isDirectory: true)
+
+        let store = try await makeStore(
+            fileManager: fileManager,
+            baseURL: rootURL,
+            exportBaseURL: exportBaseURL
         )
-        XCTAssertTrue(
-            fileManager.fileExists(
-                atPath: export.absoluteURL.appendingPathComponent("metrickit/metric.json").path
+
+        let now = Date()
+        for index in 0..<4 {
+            let archiveURL = exportBaseURL.appendingPathComponent("recent-\(index).zip", isDirectory: false)
+            try Data("recent-\(index)".utf8).write(to: archiveURL, options: .atomic)
+            try fileManager.setAttributes(
+                [.modificationDate: now.addingTimeInterval(TimeInterval(-(index + 1) * 60))],
+                ofItemAtPath: archiveURL.path
             )
+        }
+
+        let expiredArchiveURL = exportBaseURL.appendingPathComponent("expired.zip", isDirectory: false)
+        try Data("expired".utf8).write(to: expiredArchiveURL, options: .atomic)
+        try fileManager.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-(26 * 60 * 60))],
+            ofItemAtPath: expiredArchiveURL.path
         )
-        XCTAssertTrue(
-            fileManager.fileExists(
-                atPath: export.absoluteURL.appendingPathComponent(rustBundleURL.lastPathComponent).path
-            )
+
+        let legacyArchiveURL = rootURL
+            .appendingPathComponent("exports", isDirectory: true)
+            .appendingPathComponent("legacy.firesupportbundle", isDirectory: true)
+        try fileManager.createDirectory(at: legacyArchiveURL, withIntermediateDirectories: true)
+        let legacyManifestURL = legacyArchiveURL.appendingPathComponent("manifest.json", isDirectory: false)
+        try Data("{}".utf8).write(to: legacyManifestURL, options: .atomic)
+        try fileManager.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-(26 * 60 * 60))],
+            ofItemAtPath: legacyArchiveURL.path
         )
-        XCTAssertTrue(
-            fileManager.fileExists(
-                atPath: export.absoluteURL.appendingPathComponent("manifest.json").path
-            )
+        try fileManager.setAttributes(
+            [.modificationDate: now.addingTimeInterval(-(26 * 60 * 60))],
+            ofItemAtPath: legacyManifestURL.path
         )
+
+        let export = try await store.exportBundle(
+            rustSupportBundleURL: nil,
+            runtimeState: nil,
+            scenePhase: "active"
+        )
+
+        let remainingExports = try fileManager.contentsOfDirectory(
+            at: exportBaseURL,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        )
+        XCTAssertEqual(remainingExports.count, 3)
+        XCTAssertTrue(remainingExports.contains(export.absoluteURL))
+        XCTAssertFalse(fileManager.fileExists(atPath: expiredArchiveURL.path))
+        XCTAssertFalse(fileManager.fileExists(atPath: legacyArchiveURL.path))
     }
 
     private func makeStore(
@@ -232,5 +286,49 @@ final class FireAPMEventStoreTests: XCTestCase {
             exportBaseURL: exportBaseURL,
             fileManager: fileManager
         )
+    }
+
+    private func zipEntryNames(at url: URL) throws -> [String] {
+        let data = try Data(contentsOf: url)
+        let endOfCentralDirectorySignature = Data([0x50, 0x4B, 0x05, 0x06])
+        guard let endRecordRange = data.range(
+            of: endOfCentralDirectorySignature,
+            options: .backwards
+        ) else {
+            XCTFail("Missing end of central directory record")
+            return []
+        }
+
+        let endRecordOffset = endRecordRange.lowerBound
+        let entryCount = Int(readUInt16LE(data, at: endRecordOffset + 10))
+        let centralDirectoryOffset = Int(readUInt32LE(data, at: endRecordOffset + 16))
+
+        var cursor = centralDirectoryOffset
+        var entryNames: [String] = []
+
+        for _ in 0..<entryCount {
+            XCTAssertEqual(readUInt32LE(data, at: cursor), 0x02014B50)
+            let nameLength = Int(readUInt16LE(data, at: cursor + 28))
+            let extraLength = Int(readUInt16LE(data, at: cursor + 30))
+            let commentLength = Int(readUInt16LE(data, at: cursor + 32))
+            let nameStart = cursor + 46
+            let nameEnd = nameStart + nameLength
+            let nameData = data.subdata(in: nameStart..<nameEnd)
+            entryNames.append(String(decoding: nameData, as: UTF8.self))
+            cursor = nameEnd + extraLength + commentLength
+        }
+
+        return entryNames
+    }
+
+    private func readUInt16LE(_ data: Data, at offset: Int) -> UInt16 {
+        UInt16(data[offset]) | (UInt16(data[offset + 1]) << 8)
+    }
+
+    private func readUInt32LE(_ data: Data, at offset: Int) -> UInt32 {
+        UInt32(data[offset])
+            | (UInt32(data[offset + 1]) << 8)
+            | (UInt32(data[offset + 2]) << 16)
+            | (UInt32(data[offset + 3]) << 24)
     }
 }


### PR DESCRIPTION
## Summary
- redesign the diagnostics export card so full APM export is clearly presented as a ZIP flow and auto-opens the share sheet after export
- switch full iOS APM exports from a directory package to a single zip archive while preserving the internal `.firesupportbundle` layout
- add archive retention and stale staging cleanup so local full-export artifacts do not accumulate, and remove the temporary Rust support bundle generated for full-export packaging
- refresh the iOS APM docs and add unit coverage for zip export contents and export pruning

## Verification
- xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' -derivedDataPath /tmp/fire-ios-apm-export-zip CODE_SIGNING_ALLOWED=NO -only-testing:FireTests/FireAPMEventStoreTests test