### PR TITLE
fix(core): avoid false login invalidation on auth cookie deletes

### DIFF
--- a/docs/architecture/ios-auth-alignment-plan.md
+++ b/docs/architecture/ios-auth-alignment-plan.md
@@ -147,7 +147,7 @@ if current_epoch != request_epoch.0 {
 **File: `rust/crates/fire-core/src/cookies.rs`**
 
 - Drop the entire `Set-Cookie` batch when the request epoch is stale.
-- Do not special-case only auth cookies anymore.
+- Post-implementation follow-up: stale-request batches are still dropped wholesale, but current-response `_t` / `_forum_session` delete directives are now treated as non-authoritative until a stronger invalidation signal arrives. See `docs/architecture/ios-auth-cookie-invalidation-fix.md`.
 
 **File: `rust/crates/fire-core/src/core/messagebus.rs`**
 

--- a/docs/architecture/ios-auth-cookie-invalidation-fix.md
+++ b/docs/architecture/ios-auth-cookie-invalidation-fix.md
@@ -12,6 +12,8 @@ This change is fully achievable inside the current Fire architecture. The false-
 - `rust/crates/fire-core/src/core/network.rs::expect_success` -- converts successful responses into `LoginRequired` when the invalidation classifier says the response is authoritative.
 - `rust/crates/fire-core/src/core/network.rs::response_login_invalidation_error` -- performs local logout while preserving `cf_clearance`.
 - `rust/crates/fire-core/tests/network.rs` -- end-to-end coverage for successful invalidation, `not_logged_in`, and stale-response session races.
+- `native/ios-app/App/FireAppViewModel.swift` -- owns `LoginRequired` handling, login presentation, session application, and the host-side cookie mirroring path.
+- `native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift` -- owns background `cf_clearance` maintenance and the offscreen WebKit runtime that keeps Cloudflare clearance warm.
 - `docs/architecture/ios-auth-alignment-plan.md` -- prior architecture plan that documents the stale-response guard and now needs a follow-up note for the current-response auth-cookie fix.
 
 ## Design
@@ -35,6 +37,9 @@ This change is fully achievable inside the current Fire architecture. The false-
 - A `200` response that only sends `Set-Cookie: _t=; Max-Age=0` or `Set-Cookie: _forum_session=; Max-Age=0` does not clear local login state and does not become `LoginRequired` on its own.
 - A response with `discourse-logged-out` still forces `logout_local(true)` and returns `LoginRequired`.
 - A `401` or `403` response whose body parses as `error_type: "not_logged_in"` still forces `logout_local(true)` and returns `LoginRequired`.
+- Multiple concurrent `LoginRequired` errors only clear/present the native login flow once on iOS.
+- Background `cf_clearance` refresh on iOS actively solves Turnstile refreshes by replaying `/cdn-cgi/challenge-platform/.../rc/...` through native networking instead of passively reloading the forum homepage.
+- A successful background Cloudflare refresh flows back through `FireAppViewModel.applySession`, so the refreshed cookie batch is mirrored back into `HTTPCookieStorage` and the shared `WKHTTPCookieStore`.
 - `cf_clearance` preservation and stale-response epoch invalidation remain unchanged.
 
 ## Phased Implementation
@@ -87,18 +92,49 @@ This change is fully achievable inside the current Fire architecture. The false-
 - Run `cargo test -p fire-core fetch_topic_list_surfaces_login_required -- --nocapture`.
 - Keep stale-response tests unchanged because this patch must not alter epoch behavior.
 
+## Follow-up Host Fixes On The Same Worktree
+
+## Phase 6: Deduplicate native login reset presentation
+
+**File: `native/ios-app/App/FireAppViewModel.swift`**
+
+- Add an `isResettingSession` guard around `resetSessionAndPresentLogin(message:)`.
+- Keep the implementation on `@MainActor` so concurrent `LoginRequired` surfaces serialize naturally without extra locks.
+- Rationale: Rust already avoids duplicate `logout_local(true)` side effects once the first logout clears auth cookies; the remaining duplicate behavior lives in Swift UI reset/presentation.
+
+## Phase 7: Replace passive Cloudflare refresh with Turnstile rc replay
+
+**File: `native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift`**
+
+- Replace the timer-driven homepage reload loop with a long-lived offscreen `WKWebView` that hosts a Turnstile widget configured with `refresh-expired: 'auto'`.
+- Inject a `fetch` interceptor before `api.js` loads, capture `/cdn-cgi/challenge-platform/.../rc/...` calls, replay them through native `URLSession`, and return the real response to JavaScript through `window._resolveRc(...)`.
+- Keep the existing scene-active and interactive-recovery gating, and add runtime generation tokens, first-intercept timeout handling, and bounded retry/failure tracking so stale callbacks and repeated failures self-quiesce.
+
+## Phase 8: Push refreshed sessions back through the host cookie mirror
+
+**Files: `native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift`, `native/ios-app/App/FireAppViewModel.swift`**
+
+- After a successful rc replay, call `loginCoordinator.refreshPlatformCookies()` to pull the refreshed cookie batch into Rust.
+- Feed that refreshed `SessionState` back into `FireAppViewModel.applySession` through a service callback.
+- Rationale: the WebKit cookie store is only fully reconciled when `applySession` runs and re-mirrors the updated platform cookie batch into host-owned storage.
+
 ## Architectural Notes
 
 - Semver impact: none; all changes are internal to `fire-core` behavior.
 - Cross-crate dependencies: none added or removed.
 - Side effects: auth-cookie delete headers are still visible in diagnostics, but they no longer clear local state or trigger `LoginRequired` by themselves.
-- Explicitly not changed: iOS `cf_clearance` auto-refresh, `WKHTTPCookieStoreObserver` debounce timing, platform-side logout de-duplication, and stale-response epoch invalidation.
+- Host follow-ups now implemented on the same worktree: iOS `LoginRequired` presentation deduplication, Turnstile-driven `cf_clearance` auto-refresh, and host-side reapplication of refreshed cookie batches.
+- Explicitly still not changed: `WKHTTPCookieStoreObserver` debounce timing and stale-response epoch invalidation.
 - The host can still clear auth state by supplying a full replacement platform-cookie batch through `apply_platform_cookies`; this fix only changes network `Set-Cookie` handling.
 
 ## File Change Summary
 
 - `docs/architecture/ios-auth-alignment-plan.md` -- annotate the earlier auth-alignment plan with the current-response auth-cookie invalidation follow-up.
-- `docs/architecture/ios-auth-cookie-invalidation-fix.md` -- capture the verified design and phased implementation for the false-positive login invalidation fix.
+- `docs/architecture/ios-auth-cookie-invalidation-fix.md` -- capture the verified design, the Rust-side fix, and the follow-up iOS host remediation that landed on the same worktree.
+- `docs/backend-api/03-bootstrap-and-site.md` -- document that Fire iOS now replays Cloudflare's internal `rc` refresh flow from an offscreen WebView runtime.
+- `native/ios-app/README.md` -- document the Turnstile-based offscreen refresh runtime and the apply-session callback used to mirror refreshed cookies back into native storage.
+- `native/ios-app/App/FireAppViewModel.swift` -- deduplicate concurrent login reset presentation and reapply refreshed Cloudflare sessions through the existing session mirror path.
+- `native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift` -- replace the passive homepage reload loop with the Turnstile rc interception runtime.
 - `rust/crates/fire-core/src/core/network.rs` -- keep auth-cookie deletion signals for diagnostics while limiting strong invalidation to explicit server logout evidence.
 - `rust/crates/fire-core/src/cookies.rs` -- ignore network `_t` and `_forum_session` delete directives until a stronger invalidation path clears local auth state.
 - `rust/crates/fire-core/tests/network.rs` -- add an end-to-end regression test for successful responses that only clear auth cookies.

--- a/docs/architecture/ios-auth-cookie-invalidation-fix.md
+++ b/docs/architecture/ios-auth-cookie-invalidation-fix.md
@@ -1,0 +1,104 @@
+# Fix iOS Auth Cookie Invalidation
+
+## Feasibility Assessment
+
+This change is fully achievable inside the current Fire architecture. The false-positive logout behavior is controlled by a small shared Rust surface: `rust/crates/fire-core/src/cookies.rs` decides whether network `Set-Cookie` headers mutate the session snapshot, and `rust/crates/fire-core/src/core/network.rs` decides whether a response should become `LoginRequired`. The existing strong signals (`discourse-logged-out` and `error_type: "not_logged_in"`) already exist and remain valid, while the stale-response epoch guard already protects the separate in-flight race. No platform API changes or new dependencies are required. Fully feasible.
+
+## Current Surface Inventory
+
+- `rust/crates/fire-core/src/cookies.rs::FireSessionCookieJar::set_cookies` -- applies network `Set-Cookie` batches into the in-memory session snapshot.
+- `rust/crates/fire-core/src/core/network.rs::LoginInvalidationSignal` -- carries per-response login invalidation evidence.
+- `rust/crates/fire-core/src/core/network.rs::response_login_invalidation_signal` -- extracts `discourse-logged-out` and auth-cookie deletion hints from response headers.
+- `rust/crates/fire-core/src/core/network.rs::expect_success` -- converts successful responses into `LoginRequired` when the invalidation classifier says the response is authoritative.
+- `rust/crates/fire-core/src/core/network.rs::response_login_invalidation_error` -- performs local logout while preserving `cf_clearance`.
+- `rust/crates/fire-core/tests/network.rs` -- end-to-end coverage for successful invalidation, `not_logged_in`, and stale-response session races.
+- `docs/architecture/ios-auth-alignment-plan.md` -- prior architecture plan that documents the stale-response guard and now needs a follow-up note for the current-response auth-cookie fix.
+
+## Design
+
+### Key design decisions
+
+1. Treat network `_t` and `_forum_session` deletions as non-authoritative until a stronger invalidation signal arrives.
+   Rejected alternative: continue applying the delete to the session snapshot immediately and rely on later recovery. That leaves a race where `expect_success` sees an already-cleared session and either produces a false `LoginRequired` or skips the intended `logout_local(true)` cleanup path.
+
+2. Keep auth-cookie deletion detection as diagnostic metadata, but stop using it as a standalone logout trigger.
+   Rejected alternative: delete the cleared-cookie fields entirely. Keeping them preserves traceability in warnings without letting them drive control flow.
+
+3. Preserve `discourse-logged-out` and `not_logged_in` as the only strong invalidation signals for this fix.
+   Rejected alternative: redesign Cloudflare refresh, WebView cookie probing, or host-side logout serialization in the same patch. Those are separate concerns and would dilute the P0 fix.
+
+4. Leave the session epoch guard unchanged.
+   Rejected alternative: repurpose the epoch guard to solve current-response auth-cookie deletion. The epoch guard only covers stale in-flight responses after the session epoch changes; it does not protect the active response being classified right now.
+
+### Target behavior
+
+- A `200` response that only sends `Set-Cookie: _t=; Max-Age=0` or `Set-Cookie: _forum_session=; Max-Age=0` does not clear local login state and does not become `LoginRequired` on its own.
+- A response with `discourse-logged-out` still forces `logout_local(true)` and returns `LoginRequired`.
+- A `401` or `403` response whose body parses as `error_type: "not_logged_in"` still forces `logout_local(true)` and returns `LoginRequired`.
+- `cf_clearance` preservation and stale-response epoch invalidation remain unchanged.
+
+## Phased Implementation
+
+## Phase 1: Ignore non-authoritative network auth-cookie deletions
+
+**File: `rust/crates/fire-core/src/cookies.rs`**
+
+- Add a small helper that identifies network `_t` and `_forum_session` deletes after `parse_set_cookie` normalizes them to an empty string.
+- Skip writing those delete cookies into `CookieSnapshot` and `platform_cookies` inside `FireSessionCookieJar::set_cookies`.
+- Keep normal auth-cookie updates and all `cf_clearance` mutations untouched.
+- Rationale: the shared session snapshot should only lose auth cookies when the server also emits a strong invalidation signal or when the host supplies a full replacement cookie set.
+
+## Phase 2: Downgrade cleared auth cookies to diagnostics in the invalidation classifier
+
+**File: `rust/crates/fire-core/src/core/network.rs`**
+
+- Keep parsing `Set-Cookie` deletes into `cleared_t_cookie` and `cleared_forum_session` so warning logs still show what happened on the wire.
+- Change `LoginInvalidationSignal::any()` so only `discourse_logged_out` is authoritative for success-response invalidation.
+- Leave `response_login_invalidation_error` unchanged aside from relying on the updated `any()` behavior, so `not_logged_in_message()` still forces logout on `401` and `403`.
+- Rationale: this preserves observability while aligning behavior with Fluxdo's stronger business-layer logout criteria.
+
+## Phase 3: Add focused regression coverage
+
+**File: `rust/crates/fire-core/tests/network.rs`**
+
+- Add an end-to-end regression test that logs in, receives a successful `200` response whose only auth-related effect is deleting `_t` and `_forum_session`, and asserts that:
+  - the request succeeds,
+  - auth cookies remain present,
+  - `csrf_token`, `cf_clearance`, and bootstrap identity stay intact.
+- Keep the existing successful `discourse-logged-out` test and `not_logged_in` test as the preserved strong-signal coverage.
+- Rationale: the regression is only fixed when both the cookie write path and the invalidation classifier change together.
+
+## Phase 4: Sync architecture documentation
+
+**File: `docs/architecture/ios-auth-alignment-plan.md`**
+
+- Amend the stale-response phase note so it no longer implies that auth-cookie deletes should never be special-cased.
+- Point readers at this follow-up document for the current-response false-positive logout fix.
+
+**File: `docs/architecture/ios-auth-cookie-invalidation-fix.md`**
+
+- Record the verified root cause, the narrowed implementation scope, and the validation plan for future readers.
+
+## Phase 5: Verification
+
+**File: `rust/crates/fire-core/tests/network.rs`**
+
+- Run `cargo test -p fire-core fetch_topic_list_keeps_local_login_when_success_response_only_clears_auth_cookies -- --nocapture`.
+- Run `cargo test -p fire-core fetch_topic_list_surfaces_login_required -- --nocapture`.
+- Keep stale-response tests unchanged because this patch must not alter epoch behavior.
+
+## Architectural Notes
+
+- Semver impact: none; all changes are internal to `fire-core` behavior.
+- Cross-crate dependencies: none added or removed.
+- Side effects: auth-cookie delete headers are still visible in diagnostics, but they no longer clear local state or trigger `LoginRequired` by themselves.
+- Explicitly not changed: iOS `cf_clearance` auto-refresh, `WKHTTPCookieStoreObserver` debounce timing, platform-side logout de-duplication, and stale-response epoch invalidation.
+- The host can still clear auth state by supplying a full replacement platform-cookie batch through `apply_platform_cookies`; this fix only changes network `Set-Cookie` handling.
+
+## File Change Summary
+
+- `docs/architecture/ios-auth-alignment-plan.md` -- annotate the earlier auth-alignment plan with the current-response auth-cookie invalidation follow-up.
+- `docs/architecture/ios-auth-cookie-invalidation-fix.md` -- capture the verified design and phased implementation for the false-positive login invalidation fix.
+- `rust/crates/fire-core/src/core/network.rs` -- keep auth-cookie deletion signals for diagnostics while limiting strong invalidation to explicit server logout evidence.
+- `rust/crates/fire-core/src/cookies.rs` -- ignore network `_t` and `_forum_session` delete directives until a stronger invalidation path clears local auth state.
+- `rust/crates/fire-core/tests/network.rs` -- add an end-to-end regression test for successful responses that only clear auth cookies.

--- a/docs/backend-api/03-bootstrap-and-site.md
+++ b/docs/backend-api/03-bootstrap-and-site.md
@@ -127,7 +127,7 @@
 - 备注：
   - 当前客户端没有把这一步当成独立业务接口暴露，而是视为 Cloudflare 内部续期流程
   - 当前客户端回放请求时未显式固定 `Content-Type` 为 `application/x-www-form-urlencoded`；拦截到的原始运行时请求体更接近 JSON 形态
-  - 当前 Fire iOS 一期没有直接在宿主里回放这条 `rc` 内部接口；iOS 改为在会话已连接、已有 `cf_clearance`、且首页 bootstrap 已暴露 Turnstile `sitekey` 时，启动一个离屏 `WKWebView` 定时加载首页，并把浏览器里更新后的 Cookie 再次同步回共享层
+  - 当前 Fire iOS 会在会话已连接、已有 `cf_clearance`、且首页 bootstrap 已暴露 Turnstile `sitekey` 时，启动一个离屏 `WKWebView` 承载 Turnstile widget；宿主在 `api.js` 加载前注入 `fetch` 拦截脚本，捕获 `/cdn-cgi/challenge-platform/.../rc/...` 请求后由 `URLSession` 代发，再把真实响应回注到页面，最后把更新后的 Cookie 同步回共享层
   - 共享层仍会保留并发送 `cf_clearance`；挑战完成、平台 Cookie 读取、离屏 WebView 续期都仍属于宿主职责
 
 ## 站点信息、分类、标签、表情

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -187,6 +187,7 @@ final class FireAppViewModel: ObservableObject {
     private var initialStateLoadGeneration: UInt64 = 0
     private var loginSyncReadinessTask: Task<Void, Never>?
     private var pendingCloudflareRecovery: PendingCloudflareRecovery?
+    private var isResettingSession = false
     private let loginURL = URL(string: "https://linux.do")!
     private let challengeRecoveryStore: (any FireChallengeSessionRecovering)?
     private let loginCoordinatorPreloader: LoginCoordinatorPreloader?
@@ -1390,9 +1391,17 @@ final class FireAppViewModel: ObservableObject {
         if let coordinator = try? await loginCoordinatorValue() {
             FireCfClearanceRefreshService.shared.updateSession(
                 session,
-                loginCoordinator: coordinator
+                loginCoordinator: coordinator,
+                onSessionRefreshed: { [weak self] updatedSession in
+                    guard let self else { return }
+                    await self.cfClearanceDidRefresh(updatedSession)
+                }
             )
         }
+    }
+
+    func cfClearanceDidRefresh(_ updatedSession: SessionState) async {
+        await applySession(updatedSession)
     }
 
     func refreshLoginSyncReadiness(from webView: WKWebView) {
@@ -1601,6 +1610,13 @@ final class FireAppViewModel: ObservableObject {
     }
 
     private func resetSessionAndPresentLogin(message: String) async {
+        guard !isResettingSession else {
+            return
+        }
+
+        isResettingSession = true
+        defer { isResettingSession = false }
+
         resolvePendingCloudflareRecovery(
             with: .failure(FireCloudflareRecoveryError.cancelled)
         )

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -48,10 +48,10 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - if the follow-up Rust bootstrap refresh is challenged by Cloudflare again, it clears the partial native session and keeps the WebView login flow open so the user can finish the challenge and sync again
   - clears host-side LinuxDo auth cookies after a successful explicit logout while preserving `cf_clearance`
 - `FireCfClearanceRefreshService.swift`
-  - owns an offscreen `WKWebView` that periodically reloads `https://linux.do/` once the shared session is authenticated, scene-active, and bootstrap has exposed a Turnstile sitekey
-  - re-syncs WebKit cookies back into Rust after each refresh cycle so host-owned `cf_clearance` state stays warm without forcing the foreground login WebView open
-  - pauses that background refresh loop while an interactive `/challenge` recovery WebView is on-screen, then resumes automatically after the recovery flow is dismissed
-  - starts/stops automatically from session, scene-phase, and interactive-recovery changes, and records APM breadcrumbs for refresh lifecycle and failures
+  - owns an offscreen `WKWebView` that keeps a Turnstile widget alive once the shared session is authenticated, scene-active, and bootstrap has exposed a Turnstile sitekey
+  - injects a fetch interceptor before `api.js` loads, replays `/cdn-cgi/challenge-platform/.../rc/...` through native `URLSession`, and feeds the real response back into the page so `cf_clearance` can auto-renew without foreground UI
+  - re-syncs refreshed WebKit cookies back into Rust and then pushes the updated session back through `FireAppViewModel.applySession`, which mirrors the latest cookie batch into both `HTTPCookieStorage` and the shared `WKHTTPCookieStore`
+  - pauses that background Turnstile runtime while an interactive `/challenge` recovery WebView is on-screen, resumes automatically after recovery, and records APM breadcrumbs plus bounded retry failures
 - `App/FireLoginWebView.swift`
   - presents the host-owned auth browser as a full-screen flow for both initial login and interactive Cloudflare recovery
   - now wraps the embedded `WKWebView` in a full-screen native browser shell with adaptive light/dark chrome, a compact top bar, and a bottom command dock
@@ -242,7 +242,7 @@ Current UX note:
 - The app now keeps the in-app notification list synchronized from Rust-owned notification runtime state when MessageBus notification events arrive, instead of only updating the unread badge count.
 - iOS now schedules background refresh work for `/notification-alert/{userId}` and presents host-owned local notifications from a dedicated one-shot Rust MessageBus poll path.
 - The authenticated shell now also requests APNs registration, caches the resulting device token locally, and exposes host-side registration diagnostics without attempting backend token upload yet.
-- iOS now also runs a default-on offscreen Cloudflare cookie refresh loop for authenticated sessions that still expose a Turnstile sitekey in bootstrap, re-syncing refreshed WebKit cookies back into Rust while the scene stays active.
+- iOS now also runs a default-on offscreen Cloudflare Turnstile runtime for authenticated sessions that still expose a Turnstile sitekey in bootstrap, replaying the internal `/rc` refresh requests through native networking and re-syncing the refreshed cookie batch back into Rust and WebKit while the scene stays active.
 - The app now exposes a diagnostics screen for tail-first log inspection, preview-first request-trace body paging, and local support-bundle export.
 - The profile screen now consumes Rust-derived session display labels, so authenticated recovery states are described consistently across hosts instead of being inferred separately in Swift.
 - The profile area now includes a native private-message mailbox, and public profile headers can open a pre-addressed private-message composer when the viewed user allows PMs.

--- a/native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift
+++ b/native/ios-app/Sources/FireAppSession/FireCfClearanceRefreshService.swift
@@ -2,37 +2,154 @@ import Foundation
 import WebKit
 
 @MainActor
-final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate {
+final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
     static let shared = FireCfClearanceRefreshService()
 
-    private static let refreshInterval: Duration = .seconds(240)
-    private static let refreshURL = URL(string: "https://linux.do/")!
+    nonisolated static let logTarget = "cf.refresh"
+    nonisolated static let rcInterceptHandlerName = "onRcIntercepted"
+    nonisolated static let turnstileErrorHandlerName = "onTurnstileError"
+    nonisolated static let initialSolveTimeout: Duration = .seconds(30)
+    nonisolated static let retryDelay: Duration = .seconds(2)
+    nonisolated static let cookiePropagationDelay: Duration = .milliseconds(500)
+    nonisolated static let maxConsecutiveFailures = 3
+    nonisolated static let fetchInterceptionUserScriptSource = #"""
+(function() {
+  if (window.__fireCfFetchInstalled) {
+    return;
+  }
+  window.__fireCfFetchInstalled = true;
+
+  var originalFetch = window.fetch ? window.fetch.bind(window) : null;
+  var pendingRc = Object.create(null);
+  var rcId = 0;
+
+  function postRcIntercept(payload) {
+    if (!window.webkit ||
+        !window.webkit.messageHandlers ||
+        !window.webkit.messageHandlers.onRcIntercepted) {
+      throw new Error('fire_cf_refresh_bridge_missing');
+    }
+    window.webkit.messageHandlers.onRcIntercepted.postMessage(payload);
+  }
+
+  function parseBody(body) {
+    if (!body) {
+      return {};
+    }
+    if (typeof body === 'string') {
+      try {
+        return JSON.parse(body);
+      } catch (error) {
+        return {};
+      }
+    }
+    if (typeof URLSearchParams !== 'undefined' && body instanceof URLSearchParams) {
+      var result = {};
+      body.forEach(function(value, key) {
+        result[key] = value;
+      });
+      return result;
+    }
+    return {};
+  }
+
+  window._resolveRc = function(id, status, body) {
+    var resolve = pendingRc[id];
+    if (!resolve) {
+      return;
+    }
+    delete pendingRc[id];
+    resolve(new Response(body || '{}', {
+      status: status,
+      headers: { 'Content-Type': 'application/json' }
+    }));
+  };
+
+  if (!originalFetch) {
+    return;
+  }
+
+  window.fetch = function(input, init) {
+    var requestURL = typeof input === 'string' ? input : (input && input.url) || '';
+    if (requestURL.indexOf('/cdn-cgi/challenge-platform/') !== -1 &&
+        requestURL.indexOf('/rc/') !== -1) {
+      var id = 'rc_' + (++rcId);
+      var challengeID = '';
+      var parts = requestURL.split('/rc/');
+      if (parts.length > 1) {
+        challengeID = parts[1].split(/[?#]/)[0];
+      }
+      var parsedBody = parseBody(init && init.body);
+      postRcIntercept({
+        id: id,
+        chlId: challengeID,
+        secondaryToken: parsedBody.secondaryToken || '',
+        sitekey: parsedBody.sitekey || '',
+        runtimeToken: window.__fireCfRuntimeToken || ''
+      });
+      return new Promise(function(resolve) {
+        pendingRc[id] = resolve;
+      });
+    }
+
+    return originalFetch(input, init);
+  };
+})();
+"""#
 
     private weak var loginCoordinator: FireWebViewLoginCoordinator?
+    private var onSessionRefreshed: ((SessionState) async -> Void)?
     private var session: SessionState = .placeholder()
     private var sceneActive = false
     private var interactiveRecoveryActive = false
-    private var refreshTask: Task<Void, Never>?
+    private var startupTask: Task<Void, Never>?
+    private var retryTask: Task<Void, Never>?
+    private var initialSolveTimeoutTask: Task<Void, Never>?
     private var webView: WKWebView?
     private var loadContinuation: CheckedContinuation<Void, Error>?
+    private var generation: UInt64 = 0
+    private var consecutiveFailureCount = 0
+    private var hasInterceptedInitialRc = false
+    private var isCallingRc = false
+    private var activeSitekey: String?
+    private var activeBaseURL: String?
+    private var activeRuntimeToken: String?
+    private lazy var urlSession: URLSession = {
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = .reloadIgnoringLocalCacheData
+        configuration.httpShouldSetCookies = true
+        configuration.httpCookieAcceptPolicy = .always
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 30
+        return URLSession(configuration: configuration)
+    }()
 
     func updateSession(
         _ session: SessionState,
-        loginCoordinator: FireWebViewLoginCoordinator
+        loginCoordinator: FireWebViewLoginCoordinator,
+        onSessionRefreshed: ((SessionState) async -> Void)? = nil
     ) {
         self.session = session
         self.loginCoordinator = loginCoordinator
-        reconfigureLoop(reason: "session_update")
+        if let onSessionRefreshed {
+            self.onSessionRefreshed = onSessionRefreshed
+        }
+
+        if needsRuntimeRebuild {
+            restartRuntime(reason: "session_update")
+        } else {
+            reconfigureRuntime(reason: "session_update")
+        }
     }
 
     func setSceneActive(_ active: Bool) {
         sceneActive = active
-        reconfigureLoop(reason: active ? "scene_active" : "scene_inactive")
+        reconfigureRuntime(reason: active ? "scene_active" : "scene_inactive")
     }
 
     func setInteractiveRecoveryActive(_ active: Bool) {
         interactiveRecoveryActive = active
-        reconfigureLoop(reason: active ? "interactive_recovery_started" : "interactive_recovery_ended")
+        reconfigureRuntime(reason: active ? "interactive_recovery_started" : "interactive_recovery_ended")
     }
 
     nonisolated static func shouldAutoRefresh(
@@ -47,6 +164,85 @@ final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate {
             && !(session.bootstrap.turnstileSitekey?.isEmpty ?? true)
     }
 
+    nonisolated static func turnstileHTML(
+        sitekey: String,
+        runtimeToken: String = "runtime-token"
+    ) -> String {
+        let sitekeyLiteral = javaScriptStringLiteral(sitekey)
+        let runtimeTokenLiteral = javaScriptStringLiteral(runtimeToken)
+
+        return """
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    html, body {
+      margin: 0;
+      padding: 0;
+      background: transparent;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+
+    #fire-turnstile {
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+  </style>
+  <script>
+    window.__fireCfRuntimeToken = \(runtimeTokenLiteral);
+
+    function fireReportTurnstileError(error) {
+      var message = '';
+      try {
+        message = String(error || 'turnstile_error');
+      } catch (stringifyError) {
+        message = 'turnstile_error';
+      }
+      if (window.webkit &&
+          window.webkit.messageHandlers &&
+          window.webkit.messageHandlers.onTurnstileError) {
+        window.webkit.messageHandlers.onTurnstileError.postMessage({
+          runtimeToken: window.__fireCfRuntimeToken || '',
+          message: message
+        });
+      }
+    }
+  </script>
+  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=fireTurnstileOnLoad" async defer></script>
+</head>
+<body>
+  <div id="fire-turnstile"></div>
+  <script>
+    function fireTurnstileOnLoad() {
+      try {
+        turnstile.render('#fire-turnstile', {
+          sitekey: \(sitekeyLiteral),
+          appearance: 'interaction-only',
+          'refresh-expired': 'auto',
+          'error-callback': fireReportTurnstileError
+        });
+      } catch (error) {
+        fireReportTurnstileError(error);
+      }
+    }
+  </script>
+</body>
+</html>
+"""
+    }
+
+    nonisolated static func rcEndpointURL(baseURL: URL, challengeID: String) -> URL? {
+        let base = baseURL.absoluteString.hasSuffix("/")
+            ? String(baseURL.absoluteString.dropLast())
+            : baseURL.absoluteString
+        return URL(string: "\(base)/cdn-cgi/challenge-platform/h/g/rc/\(challengeID)")
+    }
+
     private var shouldRun: Bool {
         Self.shouldAutoRefresh(
             session: session,
@@ -55,63 +251,141 @@ final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate {
         )
     }
 
-    private func reconfigureLoop(reason: String) {
+    private var normalizedTurnstileSitekey: String? {
+        guard
+            let sitekey = session.bootstrap.turnstileSitekey?
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+            !sitekey.isEmpty
+        else {
+            return nil
+        }
+        return sitekey
+    }
+
+    private var needsRuntimeRebuild: Bool {
+        guard webView != nil || startupTask != nil || retryTask != nil else {
+            return false
+        }
+
+        return activeSitekey != normalizedTurnstileSitekey
+            || activeBaseURL != session.bootstrap.baseUrl
+    }
+
+    private func reconfigureRuntime(reason: String) {
         if shouldRun {
-            guard refreshTask == nil else { return }
-            FireAPMManager.shared.recordBreadcrumb(
-                target: "cf.refresh",
-                message: "cf clearance refresh started reason=\(reason)"
-            )
-            refreshTask = Task { [weak self] in
-                await self?.runRefreshLoop()
-            }
+            startRuntimeIfNeeded(reason: reason)
         } else {
-            refreshTask?.cancel()
-            refreshTask = nil
-            tearDownWebView()
-            FireAPMManager.shared.recordBreadcrumb(
-                target: "cf.refresh",
-                message: "cf clearance refresh stopped reason=\(reason)"
+            stopRuntime(reason: reason)
+        }
+    }
+
+    private func startRuntimeIfNeeded(reason: String) {
+        guard shouldRun else { return }
+        guard startupTask == nil, retryTask == nil, webView == nil else { return }
+        guard let sitekey = normalizedTurnstileSitekey else { return }
+
+        activeSitekey = sitekey
+        activeBaseURL = session.bootstrap.baseUrl
+        activeRuntimeToken = UUID().uuidString
+
+        let generation = advanceGeneration()
+        let runtimeToken = activeRuntimeToken ?? UUID().uuidString
+
+        FireAPMManager.shared.recordBreadcrumb(
+            target: Self.logTarget,
+            message: "cf clearance refresh starting reason=\(reason)"
+        )
+
+        startupTask = Task { [weak self] in
+            await self?.bootstrapRuntime(
+                sitekey: sitekey,
+                runtimeToken: runtimeToken,
+                generation: generation,
+                reason: reason
             )
         }
     }
 
-    private func runRefreshLoop() async {
-        defer {
-            refreshTask = nil
-            if !shouldRun {
-                tearDownWebView()
-            }
-        }
-
-        while !Task.isCancelled && shouldRun {
-            await performRefreshCycle()
-            do {
-                try await Task.sleep(for: Self.refreshInterval)
-            } catch {
-                break
-            }
-        }
-    }
-
-    private func performRefreshCycle() async {
-        guard shouldRun, let loginCoordinator else {
+    private func restartRuntime(reason: String) {
+        if shouldRun {
+            _ = cancelRuntime(resetFailures: false)
+            reconfigureRuntime(reason: reason)
             return
         }
 
+        stopRuntime(reason: reason)
+    }
+
+    private func stopRuntime(reason: String) {
+        guard hasRuntimeState else { return }
+
+        _ = cancelRuntime(resetFailures: true)
+        FireAPMManager.shared.recordBreadcrumb(
+            target: Self.logTarget,
+            message: "cf clearance refresh stopped reason=\(reason)"
+        )
+    }
+
+    private var hasRuntimeState: Bool {
+        webView != nil || startupTask != nil || retryTask != nil || loadContinuation != nil
+    }
+
+    @discardableResult
+    private func cancelRuntime(resetFailures: Bool) -> UInt64 {
+        let generation = advanceGeneration()
+        startupTask?.cancel()
+        startupTask = nil
+        retryTask?.cancel()
+        retryTask = nil
+        cancelInitialSolveTimeout()
+        tearDownWebView()
+
+        if resetFailures {
+            consecutiveFailureCount = 0
+        }
+
+        return generation
+    }
+
+    private func advanceGeneration() -> UInt64 {
+        generation &+= 1
+        return generation
+    }
+
+    private func bootstrapRuntime(
+        sitekey: String,
+        runtimeToken: String,
+        generation: UInt64,
+        reason: String
+    ) async {
+        defer {
+            if self.generation == generation {
+                self.startupTask = nil
+            }
+        }
+
         do {
-            try await loadRefreshPage()
-            let refreshed = try await loginCoordinator.refreshPlatformCookies()
-            session = refreshed
-            FireAPMManager.shared.recordBreadcrumb(
-                target: "cf.refresh",
-                message: "cf clearance refresh cycle succeeded"
+            try await loadTurnstilePage(
+                sitekey: sitekey,
+                runtimeToken: runtimeToken,
+                generation: generation
             )
-        } catch {
+            guard isCurrentRuntime(generation: generation, runtimeToken: runtimeToken) else {
+                return
+            }
+
+            scheduleInitialSolveTimeout(generation: generation, runtimeToken: runtimeToken)
             FireAPMManager.shared.recordBreadcrumb(
-                level: "warning",
-                target: "cf.refresh",
-                message: "cf clearance refresh cycle failed: \(error.localizedDescription)"
+                target: Self.logTarget,
+                message: "cf clearance refresh runtime ready reason=\(reason)"
+            )
+        } catch is CancellationError {
+            return
+        } catch {
+            await handleRuntimeFailure(
+                message: "cf clearance refresh startup failed: \(error.localizedDescription)",
+                generation: generation,
+                runtimeToken: runtimeToken
             )
         }
     }
@@ -121,8 +395,21 @@ final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate {
             return webView
         }
 
+        let userContentController = WKUserContentController()
+        userContentController.addUserScript(
+            WKUserScript(
+                source: Self.fetchInterceptionUserScriptSource,
+                injectionTime: .atDocumentStart,
+                forMainFrameOnly: true
+            )
+        )
+        userContentController.add(self, name: Self.rcInterceptHandlerName)
+        userContentController.add(self, name: Self.turnstileErrorHandlerName)
+
         let configuration = WKWebViewConfiguration()
+        configuration.userContentController = userContentController
         configuration.websiteDataStore = .default()
+
         let webView = WKWebView(frame: .zero, configuration: configuration)
         webView.isHidden = true
         webView.navigationDelegate = self
@@ -133,24 +420,48 @@ final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate {
     private func tearDownWebView() {
         loadContinuation?.resume(throwing: CancellationError())
         loadContinuation = nil
-        webView?.stopLoading()
-        webView?.navigationDelegate = nil
-        webView = nil
+
+        guard let webView else {
+            activeSitekey = nil
+            activeBaseURL = nil
+            activeRuntimeToken = nil
+            hasInterceptedInitialRc = false
+            isCallingRc = false
+            return
+        }
+
+        webView.stopLoading()
+        let userContentController = webView.configuration.userContentController
+        userContentController.removeScriptMessageHandler(forName: Self.rcInterceptHandlerName)
+        userContentController.removeScriptMessageHandler(forName: Self.turnstileErrorHandlerName)
+        userContentController.removeAllUserScripts()
+        webView.navigationDelegate = nil
+        self.webView = nil
+        activeSitekey = nil
+        activeBaseURL = nil
+        activeRuntimeToken = nil
+        hasInterceptedInitialRc = false
+        isCallingRc = false
     }
 
-    private func loadRefreshPage() async throws {
+    private func loadTurnstilePage(
+        sitekey: String,
+        runtimeToken: String,
+        generation: UInt64
+    ) async throws {
+        guard isCurrentRuntime(generation: generation, runtimeToken: runtimeToken) else {
+            throw CancellationError()
+        }
+
         let webView = ensureWebView()
-        let request = URLRequest(
-            url: Self.refreshURL,
-            cachePolicy: .reloadIgnoringLocalCacheData,
-            timeoutInterval: 30
-        )
+        let html = Self.turnstileHTML(sitekey: sitekey, runtimeToken: runtimeToken)
+
         try await withCheckedThrowingContinuation { continuation in
             if let loadContinuation {
                 loadContinuation.resume(throwing: CancellationError())
             }
             loadContinuation = continuation
-            webView.load(request)
+            webView.loadHTMLString(html, baseURL: session.baseURL)
         }
     }
 
@@ -158,6 +469,337 @@ final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate {
         guard let loadContinuation else { return }
         loadContinuation.resume(with: result)
         self.loadContinuation = nil
+    }
+
+    private func scheduleInitialSolveTimeout(generation: UInt64, runtimeToken: String) {
+        cancelInitialSolveTimeout()
+        hasInterceptedInitialRc = false
+
+        initialSolveTimeoutTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: Self.initialSolveTimeout)
+            } catch {
+                return
+            }
+
+            await self?.handleInitialSolveTimeout(
+                generation: generation,
+                runtimeToken: runtimeToken
+            )
+        }
+    }
+
+    private func cancelInitialSolveTimeout() {
+        initialSolveTimeoutTask?.cancel()
+        initialSolveTimeoutTask = nil
+    }
+
+    private func handleInitialSolveTimeout(generation: UInt64, runtimeToken: String) async {
+        guard isCurrentRuntime(generation: generation, runtimeToken: runtimeToken) else {
+            return
+        }
+        guard !hasInterceptedInitialRc else {
+            return
+        }
+
+        await handleRuntimeFailure(
+            message: "cf clearance refresh timed out waiting for Turnstile rc intercept",
+            generation: generation,
+            runtimeToken: runtimeToken
+        )
+    }
+
+    private func scheduleRetry(reason: String, expectedGeneration: UInt64) {
+        retryTask?.cancel()
+        retryTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: Self.retryDelay)
+            } catch {
+                return
+            }
+
+            guard let self else { return }
+            guard self.generation == expectedGeneration else { return }
+            self.retryTask = nil
+            self.reconfigureRuntime(reason: reason)
+        }
+    }
+
+    private func handleRuntimeFailure(
+        message: String,
+        generation: UInt64,
+        runtimeToken: String
+    ) async {
+        guard isCurrentRuntime(generation: generation, runtimeToken: runtimeToken) else {
+            return
+        }
+
+        consecutiveFailureCount += 1
+        FireAPMManager.shared.recordBreadcrumb(
+            level: "warning",
+            target: Self.logTarget,
+            message: "\(message) failures=\(consecutiveFailureCount)"
+        )
+
+        let invalidatedGeneration = cancelRuntime(resetFailures: false)
+        guard shouldRun else { return }
+
+        guard consecutiveFailureCount < Self.maxConsecutiveFailures else {
+            FireAPMManager.shared.recordBreadcrumb(
+                level: "warning",
+                target: Self.logTarget,
+                message: "cf clearance refresh stopped after \(consecutiveFailureCount) consecutive failures"
+            )
+            return
+        }
+
+        scheduleRetry(reason: "retry_after_failure", expectedGeneration: invalidatedGeneration)
+    }
+
+    private func isCurrentRuntime(generation: UInt64, runtimeToken: String) -> Bool {
+        generation == self.generation && runtimeToken == activeRuntimeToken
+    }
+
+    private func normalizedNonEmpty(_ value: String?) -> String? {
+        guard let value = value?.trimmingCharacters(in: .whitespacesAndNewlines), !value.isEmpty else {
+            return nil
+        }
+        return value
+    }
+
+    func userContentController(
+        _ userContentController: WKUserContentController,
+        didReceive message: WKScriptMessage
+    ) {
+        switch message.name {
+        case Self.rcInterceptHandlerName:
+            guard let payload = message.body as? [String: Any] else { return }
+            let id = payload["id"] as? String ?? UUID().uuidString
+            let challengeID = payload["chlId"] as? String
+            let secondaryToken = payload["secondaryToken"] as? String
+            let sitekey = payload["sitekey"] as? String
+            let runtimeToken = payload["runtimeToken"] as? String ?? ""
+            let generation = self.generation
+
+            hasInterceptedInitialRc = true
+            cancelInitialSolveTimeout()
+
+            Task { [weak self] in
+                await self?.handleRcIntercepted(
+                    id: id,
+                    challengeID: challengeID,
+                    secondaryToken: secondaryToken,
+                    sitekey: sitekey,
+                    generation: generation,
+                    runtimeToken: runtimeToken
+                )
+            }
+
+        case Self.turnstileErrorHandlerName:
+            guard let payload = message.body as? [String: Any] else { return }
+            let runtimeToken = payload["runtimeToken"] as? String ?? ""
+            let errorMessage = normalizedNonEmpty(payload["message"] as? String)
+                ?? "turnstile_error"
+            let generation = self.generation
+
+            Task { [weak self] in
+                await self?.handleRuntimeFailure(
+                    message: "cf clearance refresh turnstile error: \(errorMessage)",
+                    generation: generation,
+                    runtimeToken: runtimeToken
+                )
+            }
+
+        default:
+            return
+        }
+    }
+
+    private func handleRcIntercepted(
+        id: String,
+        challengeID: String?,
+        secondaryToken: String?,
+        sitekey: String?,
+        generation: UInt64,
+        runtimeToken: String
+    ) async {
+        guard isCurrentRuntime(generation: generation, runtimeToken: runtimeToken) else {
+            return
+        }
+
+        guard !isCallingRc else {
+            try? await resolveRc(id: id, statusCode: 503, body: "{}")
+            return
+        }
+
+        guard
+            let challengeID = normalizedNonEmpty(challengeID),
+            let rcURL = Self.rcEndpointURL(baseURL: session.baseURL, challengeID: challengeID)
+        else {
+            FireAPMManager.shared.recordBreadcrumb(
+                level: "warning",
+                target: Self.logTarget,
+                message: "cf clearance refresh intercepted rc without challenge id"
+            )
+            try? await resolveRc(id: id, statusCode: 400, body: "{}")
+            return
+        }
+
+        guard let effectiveSitekey = normalizedNonEmpty(sitekey) ?? normalizedTurnstileSitekey else {
+            FireAPMManager.shared.recordBreadcrumb(
+                level: "warning",
+                target: Self.logTarget,
+                message: "cf clearance refresh intercepted rc without sitekey"
+            )
+            try? await resolveRc(id: id, statusCode: 400, body: "{}")
+            return
+        }
+
+        isCallingRc = true
+        defer {
+            if isCurrentRuntime(generation: generation, runtimeToken: runtimeToken) {
+                isCallingRc = false
+            }
+        }
+
+        do {
+            let response = try await performRcRequest(
+                url: rcURL,
+                secondaryToken: secondaryToken,
+                sitekey: effectiveSitekey
+            )
+            guard isCurrentRuntime(generation: generation, runtimeToken: runtimeToken) else {
+                return
+            }
+
+            try await resolveRc(id: id, statusCode: response.statusCode, body: response.body)
+            try await Task.sleep(for: Self.cookiePropagationDelay)
+
+            guard
+                isCurrentRuntime(generation: generation, runtimeToken: runtimeToken),
+                let loginCoordinator
+            else {
+                return
+            }
+
+            let refreshed = try await loginCoordinator.refreshPlatformCookies()
+            guard isCurrentRuntime(generation: generation, runtimeToken: runtimeToken) else {
+                return
+            }
+
+            consecutiveFailureCount = 0
+            session = refreshed
+            FireAPMManager.shared.recordBreadcrumb(
+                target: Self.logTarget,
+                message: "cf clearance refresh succeeded status=\(response.statusCode)"
+            )
+
+            if let onSessionRefreshed {
+                await onSessionRefreshed(refreshed)
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            try? await resolveRc(id: id, statusCode: 500, body: "{}")
+            await handleRuntimeFailure(
+                message: "cf clearance refresh rc call failed: \(error.localizedDescription)",
+                generation: generation,
+                runtimeToken: runtimeToken
+            )
+        }
+    }
+
+    private func performRcRequest(
+        url: URL,
+        secondaryToken: String?,
+        sitekey: String
+    ) async throws -> (statusCode: Int, body: String) {
+        var payload: [String: String] = ["sitekey": sitekey]
+        if let secondaryToken = normalizedNonEmpty(secondaryToken) {
+            payload["secondaryToken"] = secondaryToken
+        }
+
+        var request = URLRequest(
+            url: url,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 30
+        )
+        request.httpMethod = "POST"
+        request.httpShouldHandleCookies = true
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(session.bootstrap.baseUrl, forHTTPHeaderField: "Origin")
+
+        let referer = session.bootstrap.baseUrl.hasSuffix("/")
+            ? session.bootstrap.baseUrl
+            : "\(session.bootstrap.baseUrl)/"
+        request.setValue(referer, forHTTPHeaderField: "Referer")
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload, options: [])
+
+        let (data, response) = try await urlSession.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NSError(
+                domain: "FireCfClearanceRefreshService",
+                code: 2,
+                userInfo: [NSLocalizedDescriptionKey: "Cloudflare rc endpoint returned a non-HTTP response"]
+            )
+        }
+
+        let body = String(data: data, encoding: .utf8) ?? "{}"
+        return (httpResponse.statusCode, body)
+    }
+
+    private func resolveRc(id: String, statusCode: Int, body: String) async throws {
+        guard let webView else { return }
+
+        let script = "window._resolveRc(\(Self.javaScriptStringLiteral(id)), \(statusCode), \(Self.javaScriptStringLiteral(body)))"
+        _ = try await evaluateJavaScript(script, in: webView)
+    }
+
+    private func evaluateJavaScript(_ script: String, in webView: WKWebView) async throws -> Any? {
+        try await withCheckedThrowingContinuation { continuation in
+            webView.evaluateJavaScript(script) { result, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else {
+                    continuation.resume(returning: result)
+                }
+            }
+        }
+    }
+
+    nonisolated private static func javaScriptStringLiteral(_ value: String) -> String {
+        let payload = [value]
+        guard
+            let data = try? JSONSerialization.data(withJSONObject: payload, options: []),
+            let json = String(data: data, encoding: .utf8),
+            json.count >= 2
+        else {
+            let escaped = value
+                .replacingOccurrences(of: "\\", with: "\\\\")
+                .replacingOccurrences(of: "\"", with: "\\\"")
+                .replacingOccurrences(of: "\n", with: "\\n")
+                .replacingOccurrences(of: "\r", with: "\\r")
+            return "\"\(escaped)\""
+        }
+
+        return String(json.dropFirst().dropLast())
+    }
+
+    private func handleNavigationFailure(_ error: Error) {
+        let generation = self.generation
+        let runtimeToken = activeRuntimeToken ?? ""
+        let wasLoading = loadContinuation != nil
+        resumeLoad(.failure(error))
+
+        guard !wasLoading else { return }
+
+        Task { [weak self] in
+            await self?.handleRuntimeFailure(
+                message: "cf clearance refresh navigation failed: \(error.localizedDescription)",
+                generation: generation,
+                runtimeToken: runtimeToken
+            )
+        }
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
@@ -169,7 +811,7 @@ final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate {
         didFail navigation: WKNavigation!,
         withError error: Error
     ) {
-        resumeLoad(.failure(error))
+        handleNavigationFailure(error)
     }
 
     func webView(
@@ -177,14 +819,14 @@ final class FireCfClearanceRefreshService: NSObject, WKNavigationDelegate {
         didFailProvisionalNavigation navigation: WKNavigation!,
         withError error: Error
     ) {
-        resumeLoad(.failure(error))
+        handleNavigationFailure(error)
     }
 
     func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-        resumeLoad(.failure(NSError(
+        handleNavigationFailure(NSError(
             domain: "FireCfClearanceRefreshService",
             code: 1,
             userInfo: [NSLocalizedDescriptionKey: "Cloudflare refresh WebView terminated"]
-        )))
+        ))
     }
 }

--- a/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
+++ b/native/ios-app/Tests/Unit/FireSessionSecurityTests.swift
@@ -676,6 +676,37 @@ final class FireSessionSecurityTests: XCTestCase {
         )
     }
 
+    func testCfClearanceRefreshServiceTurnstileRuntimeIncludesRcBridge() {
+        let html = FireCfClearanceRefreshService.turnstileHTML(
+            sitekey: "sitekey",
+            runtimeToken: "runtime-token"
+        )
+
+        XCTAssertTrue(
+            FireCfClearanceRefreshService.fetchInterceptionUserScriptSource
+                .contains("onRcIntercepted")
+        )
+        XCTAssertTrue(
+            FireCfClearanceRefreshService.fetchInterceptionUserScriptSource
+                .contains("window._resolveRc")
+        )
+        XCTAssertTrue(html.contains("window.__fireCfRuntimeToken = \"runtime-token\""))
+        XCTAssertTrue(html.contains("'refresh-expired': 'auto'"))
+        XCTAssertTrue(html.contains("onTurnstileError"))
+    }
+
+    func testCfClearanceRefreshServiceBuildsRcEndpointURL() {
+        let url = FireCfClearanceRefreshService.rcEndpointURL(
+            baseURL: URL(string: "https://linux.do")!,
+            challengeID: "challenge-id"
+        )
+
+        XCTAssertEqual(
+            url?.absoluteString,
+            "https://linux.do/cdn-cgi/challenge-platform/h/g/rc/challenge-id"
+        )
+    }
+
     @MainActor
     func testOpenLoginPresentsLoginImmediatelyBeforeWarmupCompletes() async {
         let gate = AsyncGate()
@@ -784,6 +815,51 @@ final class FireSessionSecurityTests: XCTestCase {
         XCTAssertTrue(viewModel.session.readiness.hasCloudflareClearance)
         let calls = await recoveryStore.recordedCalls()
         XCTAssertEqual(calls, [true])
+    }
+
+    @MainActor
+    func testLoginRequiredRecoveryDeduplicatesConcurrentReset() async {
+        let enteredGate = AsyncGate()
+        let releaseGate = AsyncGate()
+        let recoveryStore = BlockingChallengeRecoveryStore(
+            enteredGate: enteredGate,
+            releaseGate: releaseGate,
+            result: .success(challengedLoggedOutSession())
+        )
+        let viewModel = FireAppViewModel(
+            initialSession: authenticatedSession(),
+            challengeRecoveryStore: recoveryStore
+        )
+
+        let firstTask = Task {
+            await viewModel.handleLoginRequiredIfNeeded(
+                FireUniFfiError.LoginRequired(details: "您需要登录才能执行此操作。")
+            )
+        }
+
+        await enteredGate.wait()
+
+        let secondTask = Task {
+            await viewModel.handleLoginRequiredIfNeeded(
+                FireUniFfiError.LoginRequired(details: "您需要登录才能执行此操作。")
+            )
+        }
+
+        let secondRecovered = await secondTask.value
+        let intermediateCalls = await recoveryStore.recordedCalls()
+        XCTAssertTrue(secondRecovered)
+        XCTAssertEqual(intermediateCalls, [true])
+
+        await releaseGate.open()
+
+        let firstRecovered = await firstTask.value
+        let finalCalls = await recoveryStore.recordedCalls()
+
+        XCTAssertTrue(firstRecovered)
+        XCTAssertTrue(viewModel.isPresentingLogin)
+        XCTAssertEqual(viewModel.errorMessage, "您需要登录才能执行此操作。")
+        XCTAssertFalse(viewModel.session.hasLoginSession)
+        XCTAssertEqual(finalCalls, [true])
     }
 
     @MainActor
@@ -1537,6 +1613,34 @@ private actor MockChallengeRecoveryStore: FireChallengeSessionRecovering {
 
     func logoutLocalAndClearPlatformCookies(preserveCfClearance: Bool) async throws -> SessionState {
         calls.append(preserveCfClearance)
+        return try result.get()
+    }
+
+    func recordedCalls() -> [Bool] {
+        calls
+    }
+}
+
+private actor BlockingChallengeRecoveryStore: FireChallengeSessionRecovering {
+    private let enteredGate: AsyncGate
+    private let releaseGate: AsyncGate
+    private let result: Result<SessionState, Error>
+    private var calls: [Bool] = []
+
+    init(
+        enteredGate: AsyncGate,
+        releaseGate: AsyncGate,
+        result: Result<SessionState, Error>
+    ) {
+        self.enteredGate = enteredGate
+        self.releaseGate = releaseGate
+        self.result = result
+    }
+
+    func logoutLocalAndClearPlatformCookies(preserveCfClearance: Bool) async throws -> SessionState {
+        calls.append(preserveCfClearance)
+        await enteredGate.open()
+        await releaseGate.wait()
         return try result.get()
     }
 

--- a/rust/crates/fire-core/src/cookies.rs
+++ b/rust/crates/fire-core/src/cookies.rs
@@ -46,6 +46,10 @@ impl CookieJar for FireSessionCookieJar {
                 continue;
             };
 
+            if should_ignore_network_auth_cookie_deletion(&cookie) {
+                continue;
+            }
+
             match cookie.name.as_str() {
                 "_t" => patch.t_token = Some(cookie.value.clone()),
                 "_forum_session" => patch.forum_session = Some(cookie.value.clone()),
@@ -81,6 +85,10 @@ impl CookieJar for FireSessionCookieJar {
 
         HeaderValue::from_str(&cookies).ok()
     }
+}
+
+fn should_ignore_network_auth_cookie_deletion(cookie: &fire_models::PlatformCookie) -> bool {
+    cookie.value.is_empty() && matches!(cookie.name.as_str(), "_t" | "_forum_session")
 }
 
 fn same_origin_scope(base_url: &Url, request_url: &Url) -> bool {

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -827,7 +827,9 @@ struct LoginInvalidationSignal {
 
 impl LoginInvalidationSignal {
     fn any(self) -> bool {
-        self.discourse_logged_out || self.cleared_t_cookie || self.cleared_forum_session
+        // Deleted auth cookies are useful diagnostics, but only explicit server
+        // invalidation signals should force local logout.
+        self.discourse_logged_out
     }
 }
 

--- a/rust/crates/fire-core/tests/network.rs
+++ b/rust/crates/fire-core/tests/network.rs
@@ -400,6 +400,73 @@ async fn fetch_topic_list_surfaces_cloudflare_challenge_error() {
 }
 
 #[tokio::test]
+async fn fetch_topic_list_keeps_local_login_when_success_response_only_clears_auth_cookies() {
+    let body = sample_latest_json();
+    let response = format!(
+        "HTTP/1.1 200 TEST\r\nContent-Type: application/json\r\nContent-Length: {}\r\nSet-Cookie: _t=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax\r\nSet-Cookie: _forum_session=; path=/; max-age=0; expires=Thu, 01 Jan 1970 00:00:00 GMT; SameSite=Lax\r\nConnection: close\r\n\r\n{body}",
+        body.len()
+    );
+    let server = TestServer::spawn(vec![response]).await.expect("server");
+    let core = FireCore::new(FireCoreConfig {
+        base_url: server.base_url(),
+        workspace_path: None,
+    })
+    .expect("core");
+
+    let _ = core.sync_login_context(LoginSyncInput {
+        username: Some("alice".into()),
+        home_html: Some(sample_home_html()),
+        csrf_token: Some("csrf-token".into()),
+        current_url: Some(server.base_url()),
+        browser_user_agent: None,
+        cookies: vec![
+            PlatformCookie {
+                name: "_t".into(),
+                value: "token".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+            PlatformCookie {
+                name: "_forum_session".into(),
+                value: "forum".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+            PlatformCookie {
+                name: "cf_clearance".into(),
+                value: "clearance".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+            },
+        ],
+    });
+
+    let _response = core
+        .fetch_topic_list(TopicListQuery {
+            kind: TopicListKind::Latest,
+            page: Some(1),
+            ..TopicListQuery::default()
+        })
+        .await
+        .expect("auth-cookie deletion alone should not invalidate login");
+    let _ = server.shutdown().await;
+
+    let snapshot = core.snapshot();
+    assert_eq!(snapshot.cookies.t_token.as_deref(), Some("token"));
+    assert_eq!(snapshot.cookies.forum_session.as_deref(), Some("forum"));
+    assert_eq!(snapshot.cookies.csrf_token.as_deref(), Some("csrf-token"));
+    assert_eq!(snapshot.cookies.cf_clearance.as_deref(), Some("clearance"));
+    assert_eq!(
+        snapshot.bootstrap.current_username.as_deref(),
+        Some("alice")
+    );
+    assert!(snapshot.bootstrap.has_preloaded_data);
+}
+
+#[tokio::test]
 async fn fetch_topic_list_surfaces_login_required_when_success_response_invalidates_auth() {
     let body = sample_latest_json();
     let response = format!(


### PR DESCRIPTION
## Summary
- ignore network auth-cookie delete directives until a stronger invalidation signal arrives
- stop treating auth-cookie deletion alone as a sufficient LoginRequired trigger while keeping the deletion flags for diagnostics
- add a regression test for successful 200 responses that only clear auth cookies and document the follow-up design

## Validation
- cargo test -p fire-core fetch_topic_list_keeps_local_login_when_success_response_only_clears_auth_cookies -- --nocapture
- cargo test -p fire-core fetch_topic_list_surfaces_login_required -- --nocapture
- cargo test -p fire-core stale_response -- --nocapture
- cargo fmt --all --check