### PR TITLE
fix(ios): prepare UniFFI before TestFlight archive

### DIFF
--- a/docs/architecture/ios-testflight-release.md
+++ b/docs/architecture/ios-testflight-release.md
@@ -13,6 +13,7 @@ This document defines the production TestFlight release lane for the native iOS 
 
 - `scripts/ios/archive_release.sh`
   - Default mode remains unsigned archive generation with `CODE_SIGNING_ALLOWED=NO`.
+  - Before regenerating `Fire.xcodeproj`, the script prepares the Release UniFFI Swift bindings, FFI module, and static library for `iphoneos` so generated Swift sources are present when XcodeGen enumerates project files.
   - TestFlight mode is enabled by setting `CODE_SIGNING_ALLOWED=YES` plus `EXPORT_METHOD=app-store-connect`.
   - Direct upload is enabled with `TESTFLIGHT_UPLOAD=YES`; otherwise the script exports a signed `.ipa`.
 - `.github/workflows/ios-release-artifacts.yml`
@@ -71,6 +72,14 @@ No `.p8`, `.p12`, `.mobileprovision`, or local `Fire-Local-*.xcconfig` file shou
 - `build-metadata.json`
 
 The metadata file records the git SHA, version, build number, archive path, export method, export destination, and IPA path when present.
+
+## UniFFI archive preparation
+
+`archive_release.sh` runs `native/ios-app/scripts/sync_uniffi_bindings.sh` before `xcodegen generate` with `PLATFORM_NAME=iphoneos` and the selected archive `CONFIGURATION`. This is required because `Generated/FireUniFfi/*.swift` is ignored by git, but XcodeGen only includes optional source groups that exist at generation time.
+
+After that preparation succeeds, the script exports `FIRE_SKIP_UNIFFI_BINDGEN=1` for the Xcode archive step so the target build phase reuses the already prepared bindings and static library instead of doing the same work again.
+
+Use `FIRE_UNIFFI_PLATFORM_NAME=<platform>` only when archiving a non-default platform. Use `FIRE_SKIP_UNIFFI_PREPARE=1` only when another CI step has already populated `native/ios-app/Generated/FireUniFfi` and `native/ios-app/Generated/lib/<platform>/libfire_uniffi.a` before `archive_release.sh` starts.
 
 ## Local TestFlight rehearsal
 

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -286,6 +286,7 @@ Release artifact note:
 - `FIRE_MARKETING_VERSION` and `FIRE_BUILD_NUMBER` now drive the generated app version and build number through `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION`.
 - The settings page displays the app version, build number, and short `FireGitSha` when the build includes one.
 - `.github/workflows/ios-testflight.yml` is the manual signed release lane for App Store Connect/TestFlight. It can either export a signed `.ipa` artifact or upload directly to TestFlight.
+- `./scripts/ios/archive_release.sh` prepares Release UniFFI generated sources for `iphoneos` before running XcodeGen, because the generated Swift files must exist before the optional `Generated/FireUniFfi` source group is written into `Fire.xcodeproj`.
 - `just ios-release-info`, `just ios-release-tag`, `just ios-testflight-dry-run`, and `just ios-testflight-upload` are the local release helpers for coordinating version/build/tag and workflow dispatch.
 - The TestFlight lane requires App Store Connect API key secrets and an Apple team id. Optional certificate/profile secrets can install explicit signing assets on GitHub runners; local machines should keep signing overrides in ignored `Fire-Local-Release.xcconfig`.
 - The full production release contract lives in `docs/architecture/ios-testflight-release.md`.

--- a/scripts/ios/archive_release.sh
+++ b/scripts/ios/archive_release.sh
@@ -23,6 +23,7 @@ ALLOW_PROVISIONING_UPDATES="${ALLOW_PROVISIONING_UPDATES:-NO}"
 APP_STORE_CONNECT_API_KEY_PATH="${APP_STORE_CONNECT_API_KEY_PATH:-${ASC_API_KEY_PATH:-}}"
 APP_STORE_CONNECT_API_KEY_ID="${APP_STORE_CONNECT_API_KEY_ID:-${ASC_API_KEY_ID:-}}"
 APP_STORE_CONNECT_API_ISSUER_ID="${APP_STORE_CONNECT_API_ISSUER_ID:-${ASC_API_KEY_ISSUER_ID:-}}"
+FIRE_UNIFFI_PLATFORM_NAME="${FIRE_UNIFFI_PLATFORM_NAME:-iphoneos}"
 
 is_truthy() {
   case "${1:-}" in
@@ -55,10 +56,31 @@ if ! command -v xcodegen >/dev/null 2>&1; then
   exit 1
 fi
 
+prepare_uniffi_artifacts() {
+  if is_truthy "${FIRE_SKIP_UNIFFI_PREPARE:-NO}"; then
+    echo "FIRE_SKIP_UNIFFI_PREPARE=1: skipping UniFFI preparation before XcodeGen"
+    return 0
+  fi
+
+  echo "Preparing UniFFI artifacts for $FIRE_UNIFFI_PLATFORM_NAME before XcodeGen"
+  (
+    cd "$IOS_DIR"
+    SRCROOT="$IOS_DIR" \
+      PLATFORM_NAME="$FIRE_UNIFFI_PLATFORM_NAME" \
+      CONFIGURATION="$CONFIGURATION" \
+      FIRE_SKIP_UNIFFI_BINDGEN= \
+      ./scripts/sync_uniffi_bindings.sh
+  )
+
+  export FIRE_SKIP_UNIFFI_BINDGEN=1
+}
+
 pushd "$ROOT_DIR" >/dev/null
 git submodule update --init --recursive
 ./scripts/check_clean_submodules.sh
 popd >/dev/null
+
+prepare_uniffi_artifacts
 
 pushd "$ROOT_DIR" >/dev/null
 xcodegen generate --spec native/ios-app/project.yml
@@ -103,17 +125,31 @@ if [[ -n "${FIRE_PROVISIONING_PROFILE_SPECIFIER:-}" ]]; then
   build_setting_args+=(FIRE_PROVISIONING_PROFILE_SPECIFIER="$FIRE_PROVISIONING_PROFILE_SPECIFIER")
 fi
 
-xcodebuild "${auth_args[@]}" "${provisioning_args[@]}" \
-  -project "$IOS_DIR/Fire.xcodeproj" \
-  -scheme "$SCHEME" \
-  -configuration "$CONFIGURATION" \
-  -destination "$DESTINATION" \
-  -archivePath "$ARCHIVE_PATH" \
-  -derivedDataPath "$DERIVED_DATA_PATH" \
-  CODE_SIGNING_ALLOWED="$CODE_SIGNING_ALLOWED" \
-  FIRE_GIT_SHA="$GIT_SHA" \
-  "${build_setting_args[@]}" \
+declare -a archive_args=(xcodebuild)
+if [[ ${#auth_args[@]} -gt 0 ]]; then
+  archive_args+=("${auth_args[@]}")
+fi
+if [[ ${#provisioning_args[@]} -gt 0 ]]; then
+  archive_args+=("${provisioning_args[@]}")
+fi
+archive_args+=(
+  -project "$IOS_DIR/Fire.xcodeproj"
+  -scheme "$SCHEME"
+  -configuration "$CONFIGURATION"
+  -destination "$DESTINATION"
+  -archivePath "$ARCHIVE_PATH"
+  -derivedDataPath "$DERIVED_DATA_PATH"
+  CODE_SIGNING_ALLOWED="$CODE_SIGNING_ALLOWED"
+  FIRE_GIT_SHA="$GIT_SHA"
+)
+if [[ ${#build_setting_args[@]} -gt 0 ]]; then
+  archive_args+=("${build_setting_args[@]}")
+fi
+archive_args+=(
   archive
+)
+
+"${archive_args[@]}"
 
 mkdir -p "$DSYMS_DIR"
 if [[ -d "$ARCHIVE_PATH/dSYMs" ]]; then
@@ -192,11 +228,21 @@ if [[ -n "$EXPORT_METHOD" ]]; then
   fi
 
   mkdir -p "$EXPORT_PATH"
-  xcodebuild "${auth_args[@]}" "${provisioning_args[@]}" \
-    -exportArchive \
-    -archivePath "$ARCHIVE_PATH" \
-    -exportPath "$EXPORT_PATH" \
+  declare -a export_args=(xcodebuild)
+  if [[ ${#auth_args[@]} -gt 0 ]]; then
+    export_args+=("${auth_args[@]}")
+  fi
+  if [[ ${#provisioning_args[@]} -gt 0 ]]; then
+    export_args+=("${provisioning_args[@]}")
+  fi
+  export_args+=(
+    -exportArchive
+    -archivePath "$ARCHIVE_PATH"
+    -exportPath "$EXPORT_PATH"
     -exportOptionsPlist "$EXPORT_OPTIONS_PLIST"
+  )
+
+  "${export_args[@]}"
 
   if [[ "$EXPORT_DESTINATION" == "export" ]]; then
     IPA_PATH="$(find "$EXPORT_PATH" -maxdepth 1 -name "*.ipa" -print -quit)"
@@ -211,6 +257,7 @@ cat >"$METADATA_PATH" <<EOF
   "git_sha": "$GIT_SHA",
   "marketing_version": "${FIRE_MARKETING_VERSION:-}",
   "build_number": "${FIRE_BUILD_NUMBER:-}",
+  "uniffi_platform_name": "$FIRE_UNIFFI_PLATFORM_NAME",
   "archive_path": "$ARCHIVE_PATH",
   "derived_data_path": "$DERIVED_DATA_PATH",
   "code_signing_allowed": "$CODE_SIGNING_ALLOWED",


### PR DESCRIPTION
## Summary
- prepare iOS UniFFI generated Swift/FFI/staticlib artifacts before XcodeGen in archive_release.sh
- skip the Xcode UniFFI build phase after successful pre-generation to avoid duplicate work
- fix empty xcodebuild argument arrays under macOS Bash set -u
- document the TestFlight archive preparation behavior

## Verification
- bash -n scripts/ios/archive_release.sh
- SRCROOT="/Users/zhangfan/develop/github.com/fire-worktrees/fire-ios-testflight-uniffi-fix/native/ios-app" PLATFORM_NAME=iphoneos CONFIGURATION=Release native/ios-app/scripts/sync_uniffi_bindings.sh
- xcodegen generate --spec native/ios-app/project.yml && rg -n "fire_uniffi_session.swift|fire_uniffi_topics.swift|Generated/FireUniFfi" native/ios-app/Fire.xcodeproj/project.pbxproj
- OUT_ROOT=/tmp/fire-ios-testflight-fix-archive FIRE_SKIP_RUST_CROSS_BUILD=1 FIRE_MARKETING_VERSION=0.1.0 FIRE_BUILD_NUMBER=1 ./scripts/ios/archive_release.sh
- git diff --check