### PR TITLE
Fix iOS TestFlight signing identity import

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -122,10 +122,17 @@ jobs:
             security create-keychain -p "$keychain_password" "$keychain_path"
             security set-keychain-settings -lut 21600 "$keychain_path"
             security unlock-keychain -p "$keychain_password" "$keychain_path"
-            security import "$certificate_path" -P "$APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD" -A -t cert -f pkcs12 -k "$keychain_path"
+            security import "$certificate_path" -P "$APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD" -A -f pkcs12 -k "$keychain_path"
             security list-keychains -d user -s "$keychain_path" "$HOME/Library/Keychains/login.keychain-db"
             security default-keychain -d user -s "$keychain_path"
             security set-key-partition-list -S apple-tool:,apple: -k "$keychain_password" "$keychain_path"
+
+            identity_output="$(security find-identity -v -p codesigning "$keychain_path" || true)"
+            echo "$identity_output"
+            if grep -q "0 valid identities found" <<< "$identity_output"; then
+              echo "Imported signing identity is missing a private key or is otherwise unusable. Export the Apple Distribution certificate as a .p12 that includes the private key." >&2
+              exit 1
+            fi
           fi
 
           if [[ -n "${APPLE_PROVISIONING_PROFILE_BASE64}" ]]; then

--- a/docs/architecture/ios-testflight-release.md
+++ b/docs/architecture/ios-testflight-release.md
@@ -51,6 +51,8 @@ These optional secrets support explicit local-keychain signing on GitHub runners
 - `APPLE_PROVISIONING_PROFILE_BASE64`
 - `APPLE_SIGNING_KEYCHAIN_PASSWORD`
 
+`APPLE_DISTRIBUTION_CERTIFICATE_BASE64` must decode to a `.p12` exported with the Apple Distribution private key included. The workflow now validates that the imported temporary keychain exposes at least one usable code-signing identity before archive starts, so malformed exports fail early with a clear error.
+
 These optional repository variables tune the signed export:
 
 - `IOS_BUNDLE_ID`

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -286,6 +286,7 @@ Release artifact note:
 - `FIRE_MARKETING_VERSION` and `FIRE_BUILD_NUMBER` now drive the generated app version and build number through `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION`.
 - The settings page displays the app version, build number, and short `FireGitSha` when the build includes one.
 - `.github/workflows/ios-testflight.yml` is the manual signed release lane for App Store Connect/TestFlight. It can either export a signed `.ipa` artifact or upload directly to TestFlight.
+- The optional `APPLE_DISTRIBUTION_CERTIFICATE_BASE64` secret used by that lane must be a `.p12` export that includes the Apple Distribution private key, not only the certificate.
 - `./scripts/ios/archive_release.sh` prepares Release UniFFI generated sources for `iphoneos` before running XcodeGen, because the generated Swift files must exist before the optional `Generated/FireUniFfi` source group is written into `Fire.xcodeproj`.
 - `just ios-release-info`, `just ios-release-tag`, `just ios-testflight-dry-run`, and `just ios-testflight-upload` are the local release helpers for coordinating version/build/tag and workflow dispatch.
 - The TestFlight lane requires App Store Connect API key secrets and an Apple team id. Optional certificate/profile secrets can install explicit signing assets on GitHub runners; local machines should keep signing overrides in ignored `Fire-Local-Release.xcconfig`.


### PR DESCRIPTION
## Summary
- import the Apple Distribution .p12 without forcing certificate-only type so the private key remains available
- fail early when the temporary keychain has no usable code-signing identity
- document that the optional distribution certificate secret must include the private key

## Verification
- git diff --check -- .github/workflows/ios-testflight.yml docs/architecture/ios-testflight-release.md native/ios-app/README.md
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-testflight.yml"); puts "workflow yaml ok"'