### PR TITLE
[codex] fix iOS TestFlight export validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,13 +406,17 @@ jobs:
     name: iOS Release Build
     needs: [rust-ios-cross-build, rust-ios-uniffi]
     if: github.event_name == 'push'
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 90
 
     steps:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
+
+      - name: Verify Xcode 26 App Store toolchain
+        shell: bash
+        run: ./scripts/ios/verify_xcode26_toolchain.sh
 
       - name: Verify required submodules are initialized and clean
         shell: bash

--- a/.github/workflows/ios-release-artifacts.yml
+++ b/.github/workflows/ios-release-artifacts.yml
@@ -13,12 +13,16 @@ env:
 jobs:
   archive:
     name: Archive iOS Release Artifacts
-    runs-on: macos-15
+    runs-on: macos-26
 
     steps:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
+
+      - name: Verify Xcode 26 App Store toolchain
+        shell: bash
+        run: ./scripts/ios/verify_xcode26_toolchain.sh
 
       - name: Install Rust toolchain and iOS targets
         shell: bash

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -34,7 +34,7 @@ env:
 jobs:
   testflight:
     name: Archive and Upload iOS TestFlight
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 90
     env:
       APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -57,6 +57,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           submodules: recursive
+
+      - name: Verify Xcode 26 App Store toolchain
+        shell: bash
+        run: ./scripts/ios/verify_xcode26_toolchain.sh
 
       - name: Verify required submodules are initialized and clean
         shell: bash

--- a/docs/architecture/ios-testflight-release.md
+++ b/docs/architecture/ios-testflight-release.md
@@ -17,9 +17,9 @@ This document defines the production TestFlight release lane for the native iOS 
   - TestFlight mode is enabled by setting `CODE_SIGNING_ALLOWED=YES` plus `EXPORT_METHOD=app-store-connect`.
   - Direct upload is enabled with `TESTFLIGHT_UPLOAD=YES`; otherwise the script exports a signed `.ipa`.
 - `.github/workflows/ios-release-artifacts.yml`
-  - Manual unsigned archive/dSYM artifact generation.
+  - Manual unsigned archive/dSYM artifact generation on GitHub Actions `macos-26`.
 - `.github/workflows/ios-testflight.yml`
-  - Manual signed TestFlight archive/export/upload lane.
+  - Manual signed TestFlight archive/export/upload lane on GitHub Actions `macos-26`.
 
 ## Versioning
 
@@ -62,6 +62,8 @@ These optional repository variables tune the signed export:
 - `IOS_CODE_SIGN_IDENTITY`, when the archive signing identity must differ from `IOS_EXPORT_SIGNING_CERTIFICATE`
 
 No `.p8`, `.p12`, `.mobileprovision`, or local `Fire-Local-*.xcconfig` file should be committed.
+
+Both release workflows run `scripts/ios/verify_xcode26_toolchain.sh` before archive work starts so the lane fails early if the active GitHub runner image is not exposing Xcode 26+ and the iPhoneOS 26+ SDK required by App Store Connect since April 28, 2026.
 
 ## Output artifacts
 
@@ -134,5 +136,6 @@ just ios-testflight-upload 0.1.0 123 main true
 ## Guardrails
 
 - The generated Xcode project stays derived from `native/ios-app/project.yml`.
+- The generated Info.plist for the universal app target now declares the iPhone orientations plus the full four-orientation iPad variant required for iPad multitasking validation.
 - Release signing values flow through xcconfig settings or environment overrides, not manual edits to `Fire.xcodeproj`.
 - The default archive script remains safe for CI artifact rehearsal because it does not sign or upload unless explicitly requested.

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -842,6 +842,17 @@
 					"remote-notification",
 				);
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = (
+					UIInterfaceOrientationPortrait,
+					UIInterfaceOrientationLandscapeLeft,
+					UIInterfaceOrientationLandscapeRight,
+				);
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = (
+					UIInterfaceOrientationPortrait,
+					UIInterfaceOrientationPortraitUpsideDown,
+					UIInterfaceOrientationLandscapeLeft,
+					UIInterfaceOrientationLandscapeRight,
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1052,6 +1063,17 @@
 					"remote-notification",
 				);
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = (
+					UIInterfaceOrientationPortrait,
+					UIInterfaceOrientationLandscapeLeft,
+					UIInterfaceOrientationLandscapeRight,
+				);
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = (
+					UIInterfaceOrientationPortrait,
+					UIInterfaceOrientationPortraitUpsideDown,
+					UIInterfaceOrientationLandscapeLeft,
+					UIInterfaceOrientationLandscapeRight,
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -283,9 +283,11 @@ Release artifact note:
 
 - `native/ios-app/project.yml` now carries a user-defined `FIRE_GIT_SHA` build setting and writes it into the generated Info.plist as `FireGitSha`.
 - `.github/workflows/ios-release-artifacts.yml` produces an unsigned release archive, collected `dSYMs/`, and `build-metadata.json` for beta crash symbolication rehearsal.
+- The release/TestFlight workflows now run on GitHub Actions `macos-26` and fail early unless the active runner exposes Xcode 26+ with an iPhoneOS 26+ SDK.
 - `FIRE_MARKETING_VERSION` and `FIRE_BUILD_NUMBER` now drive the generated app version and build number through `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION`.
 - The settings page displays the app version, build number, and short `FireGitSha` when the build includes one.
 - `.github/workflows/ios-testflight.yml` is the manual signed release lane for App Store Connect/TestFlight. It can either export a signed `.ipa` artifact or upload directly to TestFlight.
+- `native/ios-app/project.yml` now sets generated Info.plist interface orientations for both iPhone and iPad, including the full iPad multitasking set required by App Store Connect validation for the universal target.
 - The optional `APPLE_DISTRIBUTION_CERTIFICATE_BASE64` secret used by that lane must be a `.p12` export that includes the Apple Distribution private key, not only the certificate.
 - `./scripts/ios/archive_release.sh` prepares Release UniFFI generated sources for `iphoneos` before running XcodeGen, because the generated Swift files must exist before the optional `Generated/FireUniFfi` source group is written into `Fire.xcodeproj`.
 - `just ios-release-info`, `just ios-release-tag`, `just ios-testflight-dry-run`, and `just ios-testflight-upload` are the local release helpers for coordinating version/build/tag and workflow dispatch.

--- a/native/ios-app/project.yml
+++ b/native/ios-app/project.yml
@@ -77,6 +77,15 @@ targets:
         INFOPLIST_KEY_UIBackgroundModes:
           - fetch
           - remote-notification
+        INFOPLIST_KEY_UISupportedInterfaceOrientations:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
+        INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad:
+          - UIInterfaceOrientationPortrait
+          - UIInterfaceOrientationPortraitUpsideDown
+          - UIInterfaceOrientationLandscapeLeft
+          - UIInterfaceOrientationLandscapeRight
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UIApplicationSceneManifest_Generation: YES
         LIBRARY_SEARCH_PATHS:

--- a/scripts/ios/verify_xcode26_toolchain.sh
+++ b/scripts/ios/verify_xcode26_toolchain.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+developer_dir="$(xcode-select -p)"
+xcode_version="$(xcodebuild -version | awk '/^Xcode / { print $2; exit }')"
+iphoneos_sdk_version="$(xcrun --sdk iphoneos --show-sdk-version)"
+
+echo "Selected DEVELOPER_DIR: $developer_dir"
+echo "Selected Xcode: $xcode_version"
+echo "Selected iPhoneOS SDK: $iphoneos_sdk_version"
+
+if [[ -z "$xcode_version" || -z "$iphoneos_sdk_version" ]]; then
+  echo "Failed to resolve the active Xcode toolchain or iPhoneOS SDK version" >&2
+  exit 1
+fi
+
+xcode_major="${xcode_version%%.*}"
+iphoneos_sdk_major="${iphoneos_sdk_version%%.*}"
+
+if ! [[ "$xcode_major" =~ ^[0-9]+$ && "$iphoneos_sdk_major" =~ ^[0-9]+$ ]]; then
+  echo "Unable to parse Xcode or iPhoneOS SDK major version" >&2
+  exit 1
+fi
+
+if (( xcode_major < 26 )); then
+  echo "App Store Connect uploads now require Xcode 26 or later; found Xcode $xcode_version" >&2
+  exit 1
+fi
+
+if (( iphoneos_sdk_major < 26 )); then
+  echo "App Store Connect uploads now require the iOS 26 SDK or later; found iPhoneOS SDK $iphoneos_sdk_version" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add generated Info.plist orientation keys for the universal iOS target, including the full iPad multitasking orientation set App Store Connect requires
- move the release, TestFlight, and native iOS release CI lanes to GitHub Actions `macos-26`
- add an early Xcode/iPhoneOS SDK guard so release workflows fail fast unless they are running on Xcode 26+ with the iOS 26+ SDK
- sync the iOS release documentation with the new toolchain and plist requirements

## Root cause
The TestFlight lane was still running on `macos-15`, which produced an archive with the iOS 18.5 SDK. App Store Connect now rejects uploads unless they are built with the iOS 26 SDK or later. Separately, the generated Info.plist for the universal app target did not declare `UISupportedInterfaceOrientations`, so App Store validation rejected the bundle for missing iPad multitasking orientations.

## Validation
- `./scripts/ios/verify_xcode26_toolchain.sh`
- `xcodegen generate --spec native/ios-app/project.yml`
- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -configuration Release -showBuildSettings | rg "INFOPLIST_KEY_UISupportedInterfaceOrientations(_iPad)?|TARGETED_DEVICE_FAMILY|GENERATE_INFOPLIST_FILE"`
- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -configuration Release -destination 'generic/platform=iOS' -derivedDataPath /tmp/fire-ios-release-verify CODE_SIGNING_ALLOWED=NO build`
- `plutil -p /tmp/fire-ios-release-verify/Build/Products/Release-iphoneos/Fire.app/Info.plist | rg "UISupportedInterfaceOrientations|UISupportedInterfaceOrientations~ipad|UIRequiresFullScreen" -A 8 -B 1`
- `git diff --check`
- `ruby -e 'require "yaml"; %w[.github/workflows/ios-testflight.yml .github/workflows/ios-release-artifacts.yml .github/workflows/ci.yml native/ios-app/project.yml].each { |path| YAML.load_file(path); puts "OK #{path}" }'`
