### PR TITLE
fix(ios): single-shot host cookie resync before read-path login reset

### DIFF
--- a/docs/architecture/ios-auth-alignment-plan.md
+++ b/docs/architecture/ios-auth-alignment-plan.md
@@ -12,6 +12,7 @@ This document is now only a historical umbrella note for the earlier iOS auth/se
 
 - Non-authoritative auth-cookie deletion on an otherwise successful response: [ios-auth-cookie-invalidation-fix.md](ios-auth-cookie-invalidation-fix.md)
 - Partial auth rotation and authenticated-write host resync: [ios-auth-cookie-rotation-recovery-plan.md](ios-auth-cookie-rotation-recovery-plan.md)
+- Read-path single-shot host resync before reset/login: [ios-auth-read-path-resync.md](ios-auth-read-path-resync.md)
 
 ## Historical Note
 

--- a/docs/architecture/ios-auth-read-path-resync.md
+++ b/docs/architecture/ios-auth-read-path-resync.md
@@ -1,0 +1,53 @@
+# Read-Path Login Recovery Resync
+
+This document describes the v0.1.0 hotfix that prevents passive reads (home feed and topic detail) from prematurely tearing down the session and presenting the WebView login when Discourse rotates auth cookies between requests. The two earlier auth incidents are still scoped narrowly:
+
+- Cookie deletion misread as logout: [ios-auth-cookie-invalidation-fix.md](ios-auth-cookie-invalidation-fix.md)
+- Partial auth rotation before an authenticated write: [ios-auth-cookie-rotation-recovery-plan.md](ios-auth-cookie-rotation-recovery-plan.md)
+
+## Incident Shape
+
+- Users on the v0.1.0 TestFlight build reported that a successful day of browsing would suddenly drop them back into the WebView login flow.
+- The most common triggers were a passive home feed pull or a topic detail open, not an explicit write.
+- The shared layer correctly classified `403 not_logged_in` and `discourse-logged-out` responses as `LoginRequired`, but on the read path iOS treated every `LoginRequired` as authoritative logout evidence.
+- Empirically, a fraction of those errors were transient: the WebKit cookie store already held a freshly rotated `_t` / `_forum_session` while the shared Rust cookie jar had not yet observed the rotation.
+- There was no read-path equivalent of the authenticated-write host resync, so a single transient mismatch was enough to nuke the session.
+
+## Landed Route
+
+### Single host resync per session epoch on the read path
+
+- `FireAppViewModel.attemptReadPathLoginRecovery(operation:error:)` is the new read-side recovery entry. It only reacts to `FireUniFfiError.LoginRequired`.
+- The recovery is single-flight: at most one resync runs per shared session epoch, and the same epoch will not be retried after one attempt fails. This bounds the work even under bursty error storms.
+- The recovery flow:
+  1. Read the current shared session epoch through `FireSessionStore.currentSessionEpoch()`.
+  2. Pull the latest LinuxDo browser-context cookies through the existing `FireWebViewLoginCoordinator.platformCookiesForSessionResync()` helper.
+  3. Push them through `FireSessionStore.applyPlatformCookies(_:)`.
+  4. Read the post-resync epoch. If it advanced, the resync actually rotated auth cookies and the caller may retry the original read once. If it did not advance, the resync produced no new auth state and the caller must fall through to the existing `handleRecoverableSessionErrorIfNeeded` reset path.
+- Diagnostics breadcrumbs and `auth` host log lines record both the success and the no-op cases for support triage.
+
+### Read-site usage
+
+- `FireHomeFeedStore.loadTopics` and `FireTopicDetailStore.loadTopicDetail` call the new helper before falling back to the legacy reset path.
+- Both call sites release their in-flight gates (`isLoadingTopics` / `loadingTopicIDs`) before recursing, and the recursive load passes `force: true` so cache or dedupe guards do not short-circuit the retry.
+- All other call sites of `handleRecoverableSessionErrorIfNeeded` are unchanged. Writes still rely on the existing `runAuthenticatedWritePreflight` flow.
+
+### State management
+
+- A new `readPathLoginRecoveryAttemptedEpochs` set lives on `FireAppViewModel` and is cleared in two places:
+  - When a resync rotates the session into a new epoch, only the markers tied to that new epoch are kept.
+  - When `resetSessionAndPresentLogin` runs, the set is cleared completely so a future cold-start session can recover again.
+- A `readPathLoginRecoveryTask` lives alongside it for the in-flight coalescing, scoped to a specific `readPathLoginRecoveryEpoch`.
+
+## Boundaries
+
+- Do not rotate the session from the read path itself: the helper only consumes platform cookies the WebView already holds, never opens a new auth WebView.
+- Do not bypass `handleRecoverableSessionErrorIfNeeded` for non-`LoginRequired` errors: stale responses, Cloudflare challenges, and generic HTTP errors keep their existing handlers.
+- Do not retry more than once per session epoch on the read path: the call site falls back to the original reset/login flow after that, so we do not mask repeated server-side invalidation.
+- Do not change the shared Rust invalidation policy: this hotfix only adds a host-side recovery attempt before the existing logout/login flow runs.
+
+## Why This Matters
+
+- It removes the v0.1.0 TestFlight failure mode where one transient `not_logged_in` response on a passive read kicked authenticated users back to the WebView.
+- It keeps the existing strong-invalidation handling intact, so explicit server logout still wins.
+- It mirrors the design choice of the authenticated-write recovery: `FireSessionStore` and `FireAppViewModel` together own host-side recovery policy, leaving Rust as the source of truth for shared session state.

--- a/native/ios-app/App/FireAppViewModel.swift
+++ b/native/ios-app/App/FireAppViewModel.swift
@@ -239,6 +239,12 @@ final class FireAppViewModel: ObservableObject {
     private var cachedLoginSyncReadiness: CachedLoginSyncReadiness?
     private var pendingCloudflareRecovery: PendingCloudflareRecovery?
     private var isResettingSession = false
+    /// Single-flight read-path login recovery: at most one resync runs per session
+    /// epoch, and once an epoch's resync has failed we stop retrying it on read
+    /// errors so the caller falls back to the original logout/login flow.
+    private var readPathLoginRecoveryTask: Task<Bool, Never>?
+    private var readPathLoginRecoveryEpoch: UInt64?
+    private var readPathLoginRecoveryAttemptedEpochs: Set<UInt64> = []
     private let loginURL = URL(string: "https://linux.do/login")!
     private let challengeRecoveryStore: (any FireChallengeSessionRecovering)?
     private let loginCoordinatorPreloader: LoginCoordinatorPreloader?
@@ -1652,6 +1658,170 @@ final class FireAppViewModel: ObservableObject {
         }
     }
 
+    /// Read-side recovery for transient `LoginRequired` errors observed during
+    /// passive reads (home feed, topic detail). Discourse occasionally rotates
+    /// `_t` / `_forum_session` between requests, and the WKWebView cookie store
+    /// can be ahead of the shared Rust cookie jar for a short window. Before
+    /// nuking the session and presenting the login WebView, try a single host
+    /// cookie resync per session epoch — if that resync actually replaces the
+    /// auth cookies, the read can be retried in place.
+    ///
+    /// - Parameters:
+    ///   - operation: human-readable name of the originating call site, used
+    ///     for diagnostic breadcrumbs only.
+    ///   - error: the error that was caught. Only `FireUniFfiError.LoginRequired`
+    ///     attempts recovery; everything else returns `false` immediately.
+    /// - Returns: `true` if a host cookie resync rotated the shared session
+    ///   into a new auth epoch. The caller should retry the original read
+    ///   exactly once. `false` means there is nothing more we can do at this
+    ///   layer; the caller should fall back to
+    ///   `handleRecoverableSessionErrorIfNeeded` to reset and present login.
+    @discardableResult
+    func attemptReadPathLoginRecovery(
+        operation: String,
+        error: Error
+    ) async -> Bool {
+        guard case FireUniFfiError.LoginRequired = error else {
+            return false
+        }
+
+        guard !isResettingSession else {
+            return false
+        }
+
+        let logger = await authDiagnosticsLogger()
+
+        let beforeEpoch: UInt64
+        do {
+            beforeEpoch = try await currentSessionEpoch()
+        } catch {
+            logger?.warning(
+                "read-path resync skipped operation=\(operation) reason=epoch_unavailable error=\(error.localizedDescription)"
+            )
+            return false
+        }
+
+        if readPathLoginRecoveryAttemptedEpochs.contains(beforeEpoch) {
+            logger?.notice(
+                "read-path resync skipped operation=\(operation) reason=already_attempted epoch=\(beforeEpoch)"
+            )
+            return false
+        }
+
+        if let existingTask = readPathLoginRecoveryTask,
+            readPathLoginRecoveryEpoch == beforeEpoch {
+            return await existingTask.value
+        }
+
+        let task = Task<Bool, Never> { [weak self] in
+            guard let self else { return false }
+            return await self.runReadPathLoginRecovery(
+                operation: operation,
+                beforeEpoch: beforeEpoch
+            )
+        }
+        readPathLoginRecoveryTask = task
+        readPathLoginRecoveryEpoch = beforeEpoch
+        defer {
+            if readPathLoginRecoveryEpoch == beforeEpoch {
+                readPathLoginRecoveryTask = nil
+                readPathLoginRecoveryEpoch = nil
+            }
+        }
+        return await task.value
+    }
+
+    private func runReadPathLoginRecovery(
+        operation: String,
+        beforeEpoch: UInt64
+    ) async -> Bool {
+        readPathLoginRecoveryAttemptedEpochs.insert(beforeEpoch)
+        let logger = await authDiagnosticsLogger()
+
+        let coordinator: FireWebViewLoginCoordinator
+        do {
+            coordinator = try await loginCoordinatorValue()
+        } catch {
+            logger?.warning(
+                "read-path resync skipped operation=\(operation) epoch=\(beforeEpoch) reason=no_coordinator error=\(error.localizedDescription)"
+            )
+            return false
+        }
+
+        let cookies: [PlatformCookieState]
+        do {
+            cookies = try await coordinator.platformCookiesForSessionResync()
+        } catch {
+            logger?.warning(
+                "read-path resync failed operation=\(operation) epoch=\(beforeEpoch) reason=cookie_fetch_failed error=\(error.localizedDescription)"
+            )
+            return false
+        }
+
+        guard !cookies.isEmpty else {
+            logger?.notice(
+                "read-path resync skipped operation=\(operation) epoch=\(beforeEpoch) reason=no_webview_cookies"
+            )
+            return false
+        }
+
+        let sessionStore: FireSessionStore
+        do {
+            sessionStore = try await sessionStoreValue()
+        } catch {
+            logger?.warning(
+                "read-path resync skipped operation=\(operation) epoch=\(beforeEpoch) reason=no_session_store error=\(error.localizedDescription)"
+            )
+            return false
+        }
+
+        do {
+            _ = try await sessionStore.applyPlatformCookies(cookies)
+        } catch {
+            logger?.warning(
+                "read-path resync failed operation=\(operation) epoch=\(beforeEpoch) reason=apply_failed error=\(error.localizedDescription)"
+            )
+            return false
+        }
+
+        let afterEpoch: UInt64
+        do {
+            afterEpoch = try await sessionStore.currentSessionEpoch()
+        } catch {
+            logger?.warning(
+                "read-path resync inconclusive operation=\(operation) epoch=\(beforeEpoch) reason=post_epoch_unavailable error=\(error.localizedDescription)"
+            )
+            return false
+        }
+
+        let didRotate = afterEpoch != beforeEpoch
+        if didRotate {
+            // Once the resync actually rotated us into a new auth epoch, the
+            // older `attempted` markers no longer protect us from anything;
+            // keep the set small so a long-lived session doesn't accumulate
+            // stale markers.
+            readPathLoginRecoveryAttemptedEpochs = readPathLoginRecoveryAttemptedEpochs
+                .filter { $0 == afterEpoch }
+            FireAPMManager.shared.recordBreadcrumb(
+                target: Self.authDiagnosticsLogTarget,
+                message: "read-path resync rotated auth operation=\(operation) before_epoch=\(beforeEpoch) after_epoch=\(afterEpoch) cookie_count=\(cookies.count)"
+            )
+            logger?.notice(
+                "read-path resync rotated auth operation=\(operation) before_epoch=\(beforeEpoch) after_epoch=\(afterEpoch) cookie_count=\(cookies.count)"
+            )
+        } else {
+            logger?.notice(
+                "read-path resync no_change operation=\(operation) epoch=\(beforeEpoch) cookie_count=\(cookies.count)"
+            )
+        }
+        return didRotate
+    }
+
+    private func currentSessionEpoch() async throws -> UInt64 {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.currentSessionEpoch()
+    }
+
     @discardableResult
     func handleRecoverableSessionErrorIfNeeded(_ error: Error) async -> Bool {
         if await handleLoginRequiredIfNeeded(error) {
@@ -1748,6 +1918,7 @@ final class FireAppViewModel: ObservableObject {
             with: .failure(FireCloudflareRecoveryError.cancelled)
         )
         stopMessageBus()
+        readPathLoginRecoveryAttemptedEpochs.removeAll()
 
         do {
             let recoveryStore = try await challengeRecoveryStoreValue()

--- a/native/ios-app/App/Stores/FireHomeFeedStore.swift
+++ b/native/ios-app/App/Stores/FireHomeFeedStore.swift
@@ -408,6 +408,26 @@ final class FireHomeFeedStore: ObservableObject {
             }
             return true
         } catch {
+            let recoveryOperationDescription = (page == nil && reset)
+                ? "刷新首页话题列表"
+                : "加载更多首页话题"
+            if await appViewModel.attemptReadPathLoginRecovery(
+                operation: recoveryOperationDescription,
+                error: error
+            ) {
+                // Tear down the in-flight gate before recursing; without this
+                // the inner `loadTopics` returns immediately on the
+                // `isLoadingTopics` guard, and the `reset && !force && !rows.isEmpty`
+                // guard would also short-circuit incremental refreshes.
+                isLoadingTopics = false
+                isAppendingTopics = false
+                return await loadTopics(
+                    page: page,
+                    reset: reset,
+                    force: true,
+                    refreshMode: refreshMode
+                )
+            }
             if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
                 return false
             }

--- a/native/ios-app/App/Stores/FireTopicDetailStore.swift
+++ b/native/ios-app/App/Stores/FireTopicDetailStore.swift
@@ -221,6 +221,20 @@ final class FireTopicDetailStore: ObservableObject {
             appViewModel.topicDetailLogger()?.error(
                 "topic detail load failed topic_id=\(topicId) error=\(error.localizedDescription)"
             )
+            if await appViewModel.attemptReadPathLoginRecovery(
+                operation: "加载话题详情",
+                error: error
+            ) {
+                // Release the in-flight gate before recursing; the inner call
+                // returns immediately on `loadingTopicIDs.contains(topicId)`.
+                loadingTopicIDs.remove(topicId)
+                await loadTopicDetail(
+                    topicId: topicId,
+                    targetPostNumber: targetPostNumber,
+                    force: true
+                )
+                return
+            }
             if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
                 if topicDetails[topicId] == nil {
                     errorMessage = error.localizedDescription

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -87,6 +87,7 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - now owns the foreground MessageBus transport lifecycle on iOS and forwards runtime refresh work into the bound feature stores instead of publishing home/topic-detail state itself
   - now treats Rust-owned `CloudflareChallenge` errors as the signal to delete stale WebView `cf_clearance`, present the host auth WebView in the LinuxDo browser context, re-sync the browser cookie batch back into Rust, and automatically retry the blocked read/write flow without tearing down the current authenticated snapshot
   - now also treats Rust-owned `LoginRequired` invalidation the same way, clearing host-side auth cookies while preserving `cf_clearance` so passive session loss, explicit logout, and bootstrap-challenged recovery all converge on one reset path
+  - now attempts a single-flight host cookie resync before that reset path on passive reads (home feed, topic detail): if the WebKit cookie store has already rotated `_t` / `_forum_session` past the shared Rust epoch, the resync rotates the shared session in place and the read retries once; otherwise the existing reset/login flow runs
   - now probes login sync readiness from the embedded `WKWebView` and keeps the `完成登录` button disabled until the shared login prerequisites are actually satisfied
   - now also emits host-owned APM spans for cold-start restore, login sync, bootstrap refresh, latest-feed load, topic-detail load, reply submit, notification refresh, and MessageBus start
 - `App/FireMessageBusCoordinator.swift`

--- a/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
+++ b/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
@@ -1061,6 +1061,12 @@ public actor FireSessionStore {
         )
     }
 
+    /// Read-side helper: returns the current shared session epoch so callers can
+    /// detect whether a host cookie resync actually replaced the auth cookies.
+    public func currentSessionEpoch() throws -> UInt64 {
+        try core.session().sessionEpoch()
+    }
+
     private func refreshCsrfTokenForAuthenticatedWritePreflight() async throws -> AuthenticatedWritePreflightContext {
         _ = try await refreshCsrfTokenIfNeeded()
         return try authenticatedWritePreflightContext()


### PR DESCRIPTION
## Summary

v0.1.0 TestFlight 用户反馈登录态偶尔会"掉",在首页 list 拉取和帖子详情页打开时容易触发,被弹回 WebView 重新登录。本 hotfix 在读路径上加一次"先重同步、再决定"的恢复尝试,不破坏现有的强失效信号处理。

## Root Cause

- 共享层(`fire-core`)已正确把 `discourse-logged-out` 头和 `403 + error_type: "not_logged_in"` 分类成 `LoginRequired`。
- 但 iOS 读路径(`FireHomeFeedStore.loadTopics` / `FireTopicDetailStore.loadTopicDetail`)只要看到 `LoginRequired` 就直接走 `resetSessionAndPresentLogin`,**没有任何重试或重同步**。
- 实际有一类错误是瞬时的:`WKWebView` 已经拿到滚动后的 `_t` / `_forum_session`,而 Rust 共享 cookie jar 还停留在上一代;这个窗口期内一次"假性 401/403 not_logged_in"就足以把用户踢下线。
- 写路径已经通过 `runAuthenticatedWritePreflight` 的单飞 host resync 解过这个问题,读路径还没补上。

## Change

新增一条读路径的单飞恢复入口,**只对 `FireUniFfiError.LoginRequired` 起作用**,每个共享 session epoch 至多尝试一次:

- `FireSessionStore.currentSessionEpoch()`:暴露共享 epoch,让 ViewModel 比较 resync 前后是否真的换了一拨 cookie。
- `FireAppViewModel.attemptReadPathLoginRecovery(operation:error:)`:
  1. 读取当前 epoch;同 epoch 已经尝试过则跳过
  2. 调用既有的 `FireWebViewLoginCoordinator.platformCookiesForSessionResync()` 抓 WebKit 最新 cookies
  3. 走 `applyPlatformCookies(_:)` 注入共享层
  4. 比较前后 epoch:递增了 → 返回 `true`,调用方重试一次;没动 → 返回 `false`,走原有 reset/login 流程
  5. Single-flight 协调(`readPathLoginRecoveryTask` + `readPathLoginRecoveryEpoch`)+ 已尝试 epoch 集合(`readPathLoginRecoveryAttemptedEpochs`),避免错误风暴下的重复重同步
  6. 成功 rotate 后清掉无关 epoch markers;`resetSessionAndPresentLogin` 全清,确保未来 cold-start 还能恢复
- `FireHomeFeedStore.loadTopics` 与 `FireTopicDetailStore.loadTopicDetail` 在 catch 中先调新 helper,再回退到 `handleRecoverableSessionErrorIfNeeded`。
  - 递归调用前手动释放 `isLoadingTopics` / `loadingTopicIDs`(`defer` 还没触发),并用 `force: true` 跳过 cache 与 dedupe 守卫。
- Diagnostics:`ios.auth` host log + `FireAPMManager` breadcrumb 同时记录"成功 rotate"与"无变化"两种结果,便于线上观测。

## Boundaries

- 不动共享层 invalidation 策略:Rust 仍然只把强失效信号视为登录失效。
- 不引入新的 WebView 弹出:仅消费 `WKWebsiteDataStore` 现有 cookies,不会主动打开 auth WebView。
- 仅作用于读路径:`Cloudflare`、`StaleSession`、写路径全部不变。
- 同 epoch 仅尝试一次:失败后立即 fallback 到原 reset/login,避免遮蔽真正的服务端登出。

## Verification

- `xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination 'generic/platform=iOS Simulator' build` ✅
- `xcodebuild ... -destination 'platform=iOS Simulator,name=iPhone 17,OS=latest' test` ✅ `** TEST SUCCEEDED **`(全套 Unit Test 通过)

## Docs

- 新增 `docs/architecture/ios-auth-read-path-resync.md`
- `docs/architecture/ios-auth-alignment-plan.md` 加入指向
- `native/ios-app/README.md` 在 `FireAppViewModel` 行为说明中追加一条
