### PR TITLE
Optimize iOS topic detail navigation and list rendering

### DIFF
--- a/native/ios-app/App/FireComponents.swift
+++ b/native/ios-app/App/FireComponents.swift
@@ -861,15 +861,23 @@ struct FireRemoteImage<Content: View, Placeholder: View>: View {
             return
         }
 
-        loadedImage = nil
-        loadedImageKey = nil
-        loadFailed = false
+        if loadedImageKey == request.cacheKey, loadedImage != nil {
+            loadFailed = false
+            return
+        }
 
         if let cachedImage = FireRemoteImagePipeline.shared.cachedImage(for: request) {
             loadedImage = cachedImage
             loadedImageKey = request.cacheKey
+            loadFailed = false
             return
         }
+
+        if loadedImageKey != request.cacheKey {
+            loadedImage = nil
+            loadedImageKey = nil
+        }
+        loadFailed = false
 
         do {
             let image = try await FireRemoteImagePipeline.shared.loadImage(for: request)

--- a/native/ios-app/App/FireRichTextRenderer.swift
+++ b/native/ios-app/App/FireRichTextRenderer.swift
@@ -1362,10 +1362,16 @@ final class FireRichTextEmojiAttachment: NSTextAttachment {
 
 /// A UIViewRepresentable that displays rich attributed text with interactive links.
 struct FireRichTextView: UIViewRepresentable {
+    let contentID: String
     let attributedString: NSAttributedString
     let onLinkTapped: ((URL) -> Void)?
 
-    init(attributedString: NSAttributedString, onLinkTapped: ((URL) -> Void)? = nil) {
+    init(
+        contentID: String,
+        attributedString: NSAttributedString,
+        onLinkTapped: ((URL) -> Void)? = nil
+    ) {
+        self.contentID = contentID
         self.attributedString = attributedString
         self.onLinkTapped = onLinkTapped
     }
@@ -1388,7 +1394,8 @@ struct FireRichTextView: UIViewRepresentable {
     }
 
     func updateUIView(_ uiView: FireRichTextUIView, context: Context) {
-        if uiView.attributedText != attributedString {
+        if uiView.renderedContentID != contentID {
+            uiView.renderedContentID = contentID
             uiView.attributedText = attributedString
             uiView.invalidateIntrinsicContentSize()
         }
@@ -1420,7 +1427,12 @@ struct FireRichTextView: UIViewRepresentable {
 
 /// Custom UITextView that sizes itself to content.
 final class FireRichTextUIView: UITextView {
+    private static let intrinsicHeightCache = NSCache<NSString, NSNumber>()
+
+    var renderedContentID: String?
     private var emojiLoadTasks: [String: Task<Void, Never>] = [:]
+    private var measuredWidth: CGFloat = 0
+    private var cachedIntrinsicHeight: CGFloat?
 
     deinit {
         cancelEmojiLoadTasks()
@@ -1428,27 +1440,67 @@ final class FireRichTextUIView: UITextView {
 
     override var attributedText: NSAttributedString! {
         didSet {
+            resetIntrinsicMeasurement()
             cancelEmojiLoadTasks()
             loadEmojiAttachmentsIfNeeded()
         }
     }
 
     override var intrinsicContentSize: CGSize {
-        let fixedWidth = bounds.width > 0 ? bounds.width : UIScreen.main.bounds.width - 80
-        let size = sizeThatFits(CGSize(width: fixedWidth, height: .greatestFiniteMagnitude))
-        return CGSize(width: UIView.noIntrinsicMetric, height: ceil(size.height))
+        let width = resolvedMeasurementWidth()
+        if let cachedIntrinsicHeight, abs(width - measuredWidth) < 0.5 {
+            return CGSize(width: UIView.noIntrinsicMetric, height: cachedIntrinsicHeight)
+        }
+
+        if let renderedContentID,
+           let cachedHeight = Self.intrinsicHeightCache.object(
+               forKey: intrinsicHeightCacheKey(contentID: renderedContentID, width: width)
+           ) {
+            measuredWidth = width
+            cachedIntrinsicHeight = CGFloat(truncating: cachedHeight)
+            return CGSize(width: UIView.noIntrinsicMetric, height: CGFloat(truncating: cachedHeight))
+        }
+
+        let size = sizeThatFits(CGSize(width: width, height: .greatestFiniteMagnitude))
+        let resolvedHeight = ceil(size.height)
+        measuredWidth = width
+        cachedIntrinsicHeight = resolvedHeight
+        if let renderedContentID {
+            Self.intrinsicHeightCache.setObject(
+                NSNumber(value: resolvedHeight),
+                forKey: intrinsicHeightCacheKey(contentID: renderedContentID, width: width)
+            )
+        }
+        return CGSize(width: UIView.noIntrinsicMetric, height: resolvedHeight)
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        if bounds.size != intrinsicContentSize {
+        let width = resolvedMeasurementWidth()
+        if abs(width - measuredWidth) >= 0.5 {
+            cachedIntrinsicHeight = nil
             invalidateIntrinsicContentSize()
         }
+    }
+
+    private func resolvedMeasurementWidth() -> CGFloat {
+        let width = bounds.width > 0 ? bounds.width : UIScreen.main.bounds.width - 80
+        return max(width, 1)
     }
 
     private func cancelEmojiLoadTasks() {
         emojiLoadTasks.values.forEach { $0.cancel() }
         emojiLoadTasks.removeAll()
+    }
+
+    private func resetIntrinsicMeasurement() {
+        measuredWidth = 0
+        cachedIntrinsicHeight = nil
+    }
+
+    private func intrinsicHeightCacheKey(contentID: String, width: CGFloat) -> NSString {
+        let scaledWidth = Int((width * UIScreen.main.scale).rounded())
+        return "\(contentID)|w:\(scaledWidth)" as NSString
     }
 
     private func loadEmojiAttachmentsIfNeeded() {
@@ -1521,7 +1573,6 @@ final class FireRichTextUIView: UITextView {
         }
 
         layoutManager.invalidateDisplay(forCharacterRange: changedRange)
-        invalidateIntrinsicContentSize()
         setNeedsLayout()
     }
 }

--- a/native/ios-app/App/FireTabRoot.swift
+++ b/native/ios-app/App/FireTabRoot.swift
@@ -58,6 +58,9 @@ struct FireTabRoot: View {
                         .tag(2)
                 }
                 .tint(FireTheme.accent)
+                .toolbar(.visible, for: .tabBar)
+                .toolbarBackground(FireTheme.tabBarBackground, for: .tabBar)
+                .toolbarBackground(.visible, for: .tabBar)
                 .environmentObject(homeFeedStore)
                 .environmentObject(topicDetailStore)
             } else {

--- a/native/ios-app/App/FireTopicDetailView.swift
+++ b/native/ios-app/App/FireTopicDetailView.swift
@@ -538,6 +538,38 @@ struct FireTopicDetailView: View {
         topicDetailStore.pendingScrollTarget(topicId: topic.id)
     }
 
+    private var detailError: String? {
+        topicDetailStore.errorMessage
+    }
+
+    private var hasMoreTopicPosts: Bool {
+        topicDetailStore.hasMoreTopicPosts(topicId: topic.id)
+    }
+
+    private var isLoadingTopic: Bool {
+        topicDetailStore.isLoadingTopic(topicId: topic.id)
+    }
+
+    private var isLoadingMoreTopicPosts: Bool {
+        topicDetailStore.isLoadingMoreTopicPosts(topicId: topic.id)
+    }
+
+    private var topicAiSummary: TopicAiSummaryState? {
+        topicDetailStore.topicAiSummary(for: topic.id)
+    }
+
+    private var isLoadingTopicAiSummary: Bool {
+        topicDetailStore.isLoadingTopicAiSummary(topicId: topic.id)
+    }
+
+    private var topicAiSummaryError: String? {
+        topicDetailStore.topicAiSummaryError(for: topic.id)
+    }
+
+    private var topicListRevision: UInt64 {
+        topicDetailStore.topicListRevision(topicId: topic.id)
+    }
+
     private var nonHeartReactionOptions: [FireReactionOption] {
         reactionOptions.filter { $0.id != "heart" }
     }
@@ -642,15 +674,37 @@ struct FireTopicDetailView: View {
             detail: detail,
             renderState: renderState,
             pendingScrollTarget: pendingScrollTarget,
+            detailError: detailError,
+            hasMoreTopicPosts: hasMoreTopicPosts,
+            isLoadingTopic: isLoadingTopic,
+            isLoadingMoreTopicPosts: isLoadingMoreTopicPosts,
+            topicAiSummary: topicAiSummary,
+            isLoadingTopicAiSummary: isLoadingTopicAiSummary,
+            topicAiSummaryError: topicAiSummaryError,
+            topicListRevision: topicListRevision,
             canWriteInteractions: canWriteInteractions,
+            isMutatingPost: { topicDetailStore.isMutatingPost(postId: $0) },
             onVisiblePostNumbersChanged: handleVisiblePostNumbersChanged(_:),
             onRefresh: {
                 timingTracker.recordInteraction()
                 topicDetailStore.clearTopicDetailAnchor(topicId: topic.id)
                 await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
             },
+            onLoadTopicDetail: {
+                timingTracker.recordInteraction()
+                await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
+            },
             onScrollTargetHandled: { postNumber in
                 topicDetailStore.markScrollTargetSatisfied(topicId: topic.id, postNumber: postNumber)
+            },
+            onPreloadTopicPosts: { visiblePostNumbers in
+                topicDetailStore.preloadTopicPostsIfNeeded(
+                    topicId: topic.id,
+                    visiblePostNumbers: visiblePostNumbers
+                )
+            },
+            onReloadTopicAiSummary: {
+                topicDetailStore.reloadTopicAiSummary(topicId: topic.id)
             },
             onOpenComposer: openComposer(replyToPost:),
             onOpenPostNumber: openPostNumber(_:),
@@ -1744,6 +1798,11 @@ struct FirePostRow: View {
             || (post.canDelete && !post.hidden)
     }
 
+    private var richTextContentID: String {
+        let contentHash = post.cooked.hashValue
+        return "post:\(post.id)|hash:\(contentHash)|images:\(renderContent.imageAttachments.count)"
+    }
+
     var body: some View {
         HStack(alignment: .top, spacing: visualDepth > 0 ? 6 : 10) {
             if visualDepth > 0 {
@@ -1875,7 +1934,10 @@ struct FirePostRow: View {
                 }
 
                 if let attributedText = renderContent.attributedText, attributedText.length > 0 {
-                    FireRichTextView(attributedString: attributedText) { url in
+                    FireRichTextView(
+                        contentID: richTextContentID,
+                        attributedString: attributedText
+                    ) { url in
                         onLinkTapped(url)
                     }
                     .fixedSize(horizontal: false, vertical: true)

--- a/native/ios-app/App/ListKit/FireCollectionHost.swift
+++ b/native/ios-app/App/ListKit/FireCollectionHost.swift
@@ -16,6 +16,44 @@ enum FireCollectionLayouts {
 struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: View>:
     UIViewControllerRepresentable
 {
+    final class Coordinator {
+        private var cachedSections: [FireListSectionModel<SectionID, ItemID>] = []
+        private var cachedContentVersion: AnyHashable?
+        private var cachedItemContentTokens: [ItemID: AnyHashable]?
+
+        func resolveItemContentTokens(
+            sections: [FireListSectionModel<SectionID, ItemID>],
+            contentVersion: AnyHashable,
+            itemContentToken: ((ItemID) -> AnyHashable)?
+        ) -> [ItemID: AnyHashable]? {
+            guard let itemContentToken else {
+                cachedSections = []
+                cachedContentVersion = nil
+                cachedItemContentTokens = nil
+                return nil
+            }
+
+            if cachedSections == sections,
+               cachedContentVersion == contentVersion,
+               let cachedItemContentTokens {
+                return cachedItemContentTokens
+            }
+
+            var tokens: [ItemID: AnyHashable] = [:]
+            tokens.reserveCapacity(sections.reduce(0) { $0 + $1.items.count })
+            for section in sections {
+                for item in section.items {
+                    tokens[item] = itemContentToken(item)
+                }
+            }
+
+            cachedSections = sections
+            cachedContentVersion = contentVersion
+            cachedItemContentTokens = tokens
+            return tokens
+        }
+    }
+
     let sections: [FireListSectionModel<SectionID, ItemID>]
     let layoutVersion: AnyHashable
     let contentVersion: AnyHashable
@@ -78,6 +116,10 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
         self.rowContent = rowContent
     }
 
+    func makeCoordinator() -> Coordinator {
+        Coordinator()
+    }
+
     func makeUIViewController(context: Context)
         -> FireDiffableListController<SectionID, ItemID, RowContent>
     {
@@ -120,19 +162,11 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
             showsVerticalScrollIndicator: showsVerticalScrollIndicator,
             backgroundColor: backgroundColor
         )
-        let itemContentTokens: [ItemID: AnyHashable]?
-        if let itemContentToken {
-            var tokens: [ItemID: AnyHashable] = [:]
-            tokens.reserveCapacity(sections.reduce(0) { $0 + $1.items.count })
-            for section in sections {
-                for item in section.items {
-                    tokens[item] = itemContentToken(item)
-                }
-            }
-            itemContentTokens = tokens
-        } else {
-            itemContentTokens = nil
-        }
+        let itemContentTokens = context.coordinator.resolveItemContentTokens(
+            sections: sections,
+            contentVersion: contentVersion,
+            itemContentToken: itemContentToken
+        )
         uiViewController.setSections(
             sections,
             contentVersion: contentVersion,

--- a/native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift
@@ -68,9 +68,21 @@ enum FireTopicDetailCollectionAdapter {
     }
 }
 
+private struct FireTopicDetailCollectionContentVersion: Hashable {
+    let topicID: UInt64
+    let topicListRevision: UInt64
+    let detailError: String
+    let hasMoreTopicPosts: Bool
+    let isLoadingTopic: Bool
+    let isLoadingMoreTopicPosts: Bool
+    let isLoadingTopicAiSummary: Bool
+    let topicAiSummaryError: String
+    let pendingScrollTarget: UInt32?
+    let canWriteInteractions: Bool
+    let baseURLString: String
+}
 
 struct FireTopicDetailCollectionView: View {
-    @EnvironmentObject private var topicDetailStore: FireTopicDetailStore
     @Environment(\.colorScheme) private var colorScheme
 
     let viewModel: FireAppViewModel
@@ -78,10 +90,22 @@ struct FireTopicDetailCollectionView: View {
     let detail: TopicDetailState?
     let renderState: FireTopicDetailRenderState?
     let pendingScrollTarget: UInt32?
+    let detailError: String?
+    let hasMoreTopicPosts: Bool
+    let isLoadingTopic: Bool
+    let isLoadingMoreTopicPosts: Bool
+    let topicAiSummary: TopicAiSummaryState?
+    let isLoadingTopicAiSummary: Bool
+    let topicAiSummaryError: String?
+    let topicListRevision: UInt64
     let canWriteInteractions: Bool
+    let isMutatingPost: (UInt64) -> Bool
     let onVisiblePostNumbersChanged: (Set<UInt32>) -> Void
     let onRefresh: () async -> Void
+    let onLoadTopicDetail: () async -> Void
     let onScrollTargetHandled: (UInt32) -> Void
+    let onPreloadTopicPosts: (Set<UInt32>) -> Void
+    let onReloadTopicAiSummary: () -> Void
     let onOpenComposer: (TopicPostState?) -> Void
     let onOpenPostNumber: (UInt32) -> Void
     let onOpenPostReplies: (TopicPostState) -> Void
@@ -101,10 +125,6 @@ struct FireTopicDetailCollectionView: View {
 
     private var topic: TopicSummaryState {
         row.topic
-    }
-
-    private var detailError: String? {
-        topicDetailStore.errorMessage
     }
 
     private var displayedTopicTitle: String {
@@ -221,18 +241,6 @@ struct FireTopicDetailCollectionView: View {
         return trimmed.isEmpty ? "https://linux.do" : trimmed
     }
 
-    private var hasMoreTopicPosts: Bool {
-        topicDetailStore.hasMoreTopicPosts(topicId: topic.id)
-    }
-
-    private var isLoadingTopic: Bool {
-        topicDetailStore.isLoadingTopic(topicId: topic.id)
-    }
-
-    private var isLoadingMoreTopicPosts: Bool {
-        topicDetailStore.isLoadingMoreTopicPosts(topicId: topic.id)
-    }
-
     private var showsTopicVote: Bool {
         guard let detail, !isPrivateMessageThread else {
             return false
@@ -240,20 +248,24 @@ struct FireTopicDetailCollectionView: View {
         return detail.canVote || detail.userVoted || detail.voteCount > 0
     }
 
-    private var topicAiSummary: TopicAiSummaryState? {
-        topicDetailStore.topicAiSummary(for: topic.id)
-    }
-
-    private var isLoadingTopicAiSummary: Bool {
-        topicDetailStore.isLoadingTopicAiSummary(topicId: topic.id)
-    }
-
-    private var topicAiSummaryError: String? {
-        topicDetailStore.topicAiSummaryError(for: topic.id)
-    }
-
     private var showsTopicAiSummary: Bool {
         topicAiSummary != nil || isLoadingTopicAiSummary || topicAiSummaryError != nil
+    }
+
+    private var contentVersion: FireTopicDetailCollectionContentVersion {
+        FireTopicDetailCollectionContentVersion(
+            topicID: topic.id,
+            topicListRevision: topicListRevision,
+            detailError: detailError ?? "",
+            hasMoreTopicPosts: hasMoreTopicPosts,
+            isLoadingTopic: isLoadingTopic,
+            isLoadingMoreTopicPosts: isLoadingMoreTopicPosts,
+            isLoadingTopicAiSummary: isLoadingTopicAiSummary,
+            topicAiSummaryError: topicAiSummaryError ?? "",
+            pendingScrollTarget: pendingScrollTarget,
+            canWriteInteractions: canWriteInteractions,
+            baseURLString: baseURLString
+        )
     }
 
     private var sections: [FireListSectionModel<FireTopicDetailCollectionSection, FireTopicDetailCollectionItem>] {
@@ -335,7 +347,7 @@ struct FireTopicDetailCollectionView: View {
                 Self.postContentToken(
                     post,
                     renderContent: originalPostRenderContent,
-                    isMutating: topicDetailStore.isMutatingPost(postId: post.id)
+                    isMutating: isMutatingPost(post.id)
                 )
             }
             return AnyHashable([
@@ -387,7 +399,7 @@ struct FireTopicDetailCollectionView: View {
                 post: post,
                 renderContent: renderState?.contentByPostID[row.entry.postId],
                 showsThreadLine: showsTimelineThreadLine(in: replyRows, at: index),
-                isMutating: post.map { topicDetailStore.isMutatingPost(postId: $0.id) } ?? false
+                isMutating: post.map { isMutatingPost($0.id) } ?? false
             )
             return AnyHashable("\(token)|\(canWriteInteractions)")
         case .replyFooter:
@@ -421,6 +433,7 @@ struct FireTopicDetailCollectionView: View {
         let replyIndexByPostID = makeReplyIndexByPostID()
         return FireCollectionHost(
             sections: sections,
+            contentVersion: contentVersion,
             itemContentToken: { item in
                 itemContentToken(for: item, replyIndexByPostID: replyIndexByPostID)
             },
@@ -467,10 +480,7 @@ struct FireTopicDetailCollectionView: View {
             originalPostNumber: originalPost?.postNumber
         )
         guard !postNumbers.isEmpty else { return }
-        topicDetailStore.preloadTopicPostsIfNeeded(
-            topicId: topic.id,
-            visiblePostNumbers: postNumbers
-        )
+        onPreloadTopicPosts(postNumbers)
     }
 
     private func handleScrollRequestCompleted(_ item: FireTopicDetailCollectionItem) {
@@ -634,7 +644,7 @@ struct FireTopicDetailCollectionView: View {
                         .lineLimit(2)
                     Spacer(minLength: 0)
                     Button("重试") {
-                        topicDetailStore.reloadTopicAiSummary(topicId: topic.id)
+                        onReloadTopicAiSummary()
                     }
                     .font(.caption.weight(.semibold))
                 }
@@ -665,7 +675,7 @@ struct FireTopicDetailCollectionView: View {
                         showsThreadLine: false,
                         baseURLString: baseURLString,
                         canWriteInteractions: canWriteInteractions,
-                        isMutating: topicDetailStore.isMutatingPost(postId: originalPost.id),
+                        isMutating: isMutatingPost(originalPost.id),
                         onLinkTapped: onLinkTapped,
                         onOpenImage: onOpenImage,
                         onToggleLike: onToggleLike,
@@ -779,7 +789,7 @@ struct FireTopicDetailCollectionView: View {
 
                 Button("重试") {
                     Task {
-                        await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
+                        await onLoadTopicDetail()
                     }
                 }
                 .buttonStyle(.bordered)
@@ -791,7 +801,7 @@ struct FireTopicDetailCollectionView: View {
         } else {
             Button("加载帖子") {
                 Task {
-                    await topicDetailStore.loadTopicDetail(topicId: topic.id, force: true)
+                    await onLoadTopicDetail()
                 }
             }
             .frame(maxWidth: .infinity)
@@ -838,7 +848,7 @@ struct FireTopicDetailCollectionView: View {
                         showsThreadLine: showsTimelineThreadLine(in: replyRows, at: replyIndex ?? 0),
                         baseURLString: baseURLString,
                         canWriteInteractions: canWriteInteractions,
-                        isMutating: topicDetailStore.isMutatingPost(postId: post.id),
+                        isMutating: isMutatingPost(post.id),
                         onLinkTapped: onLinkTapped,
                         onOpenImage: onOpenImage,
                         onToggleLike: onToggleLike,
@@ -884,10 +894,7 @@ struct FireTopicDetailCollectionView: View {
                 .task(id: topic.id) {
                     guard replyRows.isEmpty else { return }
                     let seedVisiblePostNumbers = originalPost.map { Set([$0.postNumber]) } ?? []
-                    topicDetailStore.preloadTopicPostsIfNeeded(
-                        topicId: topic.id,
-                        visiblePostNumbers: seedVisiblePostNumbers
-                    )
+                    onPreloadTopicPosts(seedVisiblePostNumbers)
                 }
         }
     }

--- a/native/ios-app/App/Stores/FireTopicDetailStore.swift
+++ b/native/ios-app/App/Stores/FireTopicDetailStore.swift
@@ -29,6 +29,7 @@ final class FireTopicDetailStore: ObservableObject {
     @Published private(set) var loadingTopicAiSummaryIDs: Set<UInt64> = []
     @Published private(set) var unavailableTopicAiSummaryIDs: Set<UInt64> = []
     @Published private(set) var topicAiSummaryErrorsByTopicID: [UInt64: String] = [:]
+    @Published private(set) var topicListRevisions: [UInt64: UInt64] = [:]
     @Published var errorMessage: String?
 
     private let appViewModel: FireAppViewModel
@@ -49,6 +50,68 @@ final class FireTopicDetailStore: ObservableObject {
     private var renderBaseURLString: String {
         let trimmed = appViewModel.session.bootstrap.baseUrl.trimmingCharacters(in: .whitespacesAndNewlines)
         return trimmed.isEmpty ? "https://linux.do" : trimmed
+    }
+
+    private func bumpTopicListRevision(topicId: UInt64) {
+        topicListRevisions[topicId, default: 0] &+= 1
+    }
+
+    private func setLoadingTopic(_ isLoading: Bool, topicId: UInt64) {
+        let changed: Bool
+        if isLoading {
+            changed = loadingTopicIDs.insert(topicId).inserted
+        } else {
+            changed = loadingTopicIDs.remove(topicId) != nil
+        }
+        if changed {
+            bumpTopicListRevision(topicId: topicId)
+        }
+    }
+
+    private func setLoadingMoreTopicPosts(_ isLoading: Bool, topicId: UInt64) {
+        let changed: Bool
+        if isLoading {
+            changed = loadingMoreTopicPostIDs.insert(topicId).inserted
+        } else {
+            changed = loadingMoreTopicPostIDs.remove(topicId) != nil
+        }
+        if changed {
+            bumpTopicListRevision(topicId: topicId)
+        }
+    }
+
+    private func setLoadingTopicAiSummary(_ isLoading: Bool, topicId: UInt64) {
+        let changed: Bool
+        if isLoading {
+            changed = loadingTopicAiSummaryIDs.insert(topicId).inserted
+        } else {
+            changed = loadingTopicAiSummaryIDs.remove(topicId) != nil
+        }
+        if changed {
+            bumpTopicListRevision(topicId: topicId)
+        }
+    }
+
+    private func setMutatingPost(
+        _ isMutating: Bool,
+        topicId: UInt64,
+        postId: UInt64
+    ) {
+        let changed: Bool
+        if isMutating {
+            changed = mutatingPostIDs.insert(postId).inserted
+        } else {
+            changed = mutatingPostIDs.remove(postId) != nil
+        }
+        if changed {
+            bumpTopicListRevision(topicId: topicId)
+        }
+    }
+
+    private func updateTopicErrorMessage(_ message: String?, topicId: UInt64) {
+        guard errorMessage != message else { return }
+        errorMessage = message
+        bumpTopicListRevision(topicId: topicId)
     }
 
     func applySession(_ session: SessionState) {
@@ -112,6 +175,7 @@ final class FireTopicDetailStore: ObservableObject {
         topicAiSummaries = [:]
         unavailableTopicAiSummaryIDs = []
         topicAiSummaryErrorsByTopicID = [:]
+        topicListRevisions = [:]
         topicPresenceUsersByTopic = [:]
         loadingMoreTopicPostIDs = []
         loadingTopicIDs = []
@@ -154,7 +218,7 @@ final class FireTopicDetailStore: ObservableObject {
                anchorPostNumber: anchorPostNumber,
                window: topicWindowStates[topicId]
            ) {
-            errorMessage = nil
+            updateTopicErrorMessage(nil, topicId: topicId)
             refreshTopicWindowState(
                 topicId: topicId,
                 detail: cachedDetail,
@@ -174,12 +238,12 @@ final class FireTopicDetailStore: ObservableObject {
         appViewModel.topicDetailLogger()?.debug(
             "loading topic detail topic_id=\(topicId) force=\(force) had_cache=\(hadCachedDetail) target_post=\(String(describing: targetPostNumber))"
         )
-        loadingTopicIDs.insert(topicId)
-        defer { loadingTopicIDs.remove(topicId) }
+        setLoadingTopic(true, topicId: topicId)
+        defer { setLoadingTopic(false, topicId: topicId) }
 
         do {
             let sessionStore = try await appViewModel.sessionStoreValue()
-            errorMessage = nil
+            updateTopicErrorMessage(nil, topicId: topicId)
             let detail = try await performWithTimeout(30, operation: "加载话题详情") { [appViewModel] in
                 try await FireAPMManager.shared.withSpan(
                     .topicDetailInitialLoad,
@@ -227,7 +291,7 @@ final class FireTopicDetailStore: ObservableObject {
             ) {
                 // Release the in-flight gate before recursing; the inner call
                 // returns immediately on `loadingTopicIDs.contains(topicId)`.
-                loadingTopicIDs.remove(topicId)
+                setLoadingTopic(false, topicId: topicId)
                 await loadTopicDetail(
                     topicId: topicId,
                     targetPostNumber: targetPostNumber,
@@ -237,11 +301,11 @@ final class FireTopicDetailStore: ObservableObject {
             }
             if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
                 if topicDetails[topicId] == nil {
-                    errorMessage = error.localizedDescription
+                    updateTopicErrorMessage(error.localizedDescription, topicId: topicId)
                 }
                 return
             }
-            errorMessage = error.localizedDescription
+            updateTopicErrorMessage(error.localizedDescription, topicId: topicId)
         }
     }
 
@@ -294,6 +358,10 @@ final class FireTopicDetailStore: ObservableObject {
 
     func topicAiSummaryError(for topicId: UInt64) -> String? {
         topicAiSummaryErrorsByTopicID[topicId]
+    }
+
+    func topicListRevision(topicId: UInt64) -> UInt64 {
+        topicListRevisions[topicId] ?? 0
     }
 
     func isLoadingTopic(topicId: UInt64) -> Bool {
@@ -579,8 +647,8 @@ final class FireTopicDetailStore: ObservableObject {
             return try await sessionStore.fetchPost(postID: postID)
         }
 
-        mutatingPostIDs.insert(postID)
-        defer { mutatingPostIDs.remove(postID) }
+        setMutatingPost(true, topicId: topicID, postId: postID)
+        defer { setMutatingPost(false, topicId: topicID, postId: postID) }
 
         do {
             errorMessage = nil
@@ -779,8 +847,8 @@ final class FireTopicDetailStore: ObservableObject {
             return
         }
 
-        mutatingPostIDs.insert(postId)
-        defer { mutatingPostIDs.remove(postId) }
+        setMutatingPost(true, topicId: topicId, postId: postId)
+        defer { setMutatingPost(false, topicId: topicId, postId: postId) }
 
         do {
             errorMessage = nil
@@ -824,8 +892,8 @@ final class FireTopicDetailStore: ObservableObject {
             return
         }
 
-        mutatingPostIDs.insert(postId)
-        defer { mutatingPostIDs.remove(postId) }
+        setMutatingPost(true, topicId: topicId, postId: postId)
+        defer { setMutatingPost(false, topicId: topicId, postId: postId) }
 
         do {
             errorMessage = nil
@@ -858,8 +926,8 @@ final class FireTopicDetailStore: ObservableObject {
             return
         }
 
-        mutatingPostIDs.insert(postID)
-        defer { mutatingPostIDs.remove(postID) }
+        setMutatingPost(true, topicId: topicID, postId: postID)
+        defer { setMutatingPost(false, topicId: topicID, postId: postID) }
 
         do {
             errorMessage = nil
@@ -1037,6 +1105,7 @@ final class FireTopicDetailStore: ObservableObject {
         let removedAiSummary = topicAiSummaries.removeValue(forKey: topicId) != nil
         let removedAiSummaryUnavailable = unavailableTopicAiSummaryIDs.remove(topicId) != nil
         let removedAiSummaryError = topicAiSummaryErrorsByTopicID.removeValue(forKey: topicId) != nil
+        topicListRevisions.removeValue(forKey: topicId)
         let removedLoadingTopic = loadingTopicIDs.remove(topicId) != nil
         let removedLoadingMore = loadingMoreTopicPostIDs.remove(topicId) != nil
         let removedLoadingAiSummary = loadingTopicAiSummaryIDs.remove(topicId) != nil
@@ -1086,7 +1155,8 @@ final class FireTopicDetailStore: ObservableObject {
             stream: detail.postStream.stream
         )
 
-        if topicDetails[topicId] != cachedDetail {
+        let didUpdateDetail = topicDetails[topicId] != cachedDetail
+        if didUpdateDetail {
             topicDetails[topicId] = cachedDetail
         }
 
@@ -1098,10 +1168,15 @@ final class FireTopicDetailStore: ObservableObject {
         )
         topicRenderCaches[topicId] = renderCache
 
-        if previousRenderCache?.baseURLString != renderCache.baseURLString
+        let didUpdateRenderState =
+            previousRenderCache?.baseURLString != renderCache.baseURLString
             || previousRenderCache?.rowInputs != renderCache.rowInputs
-            || previousRenderCache?.contentInputsByPostID != renderCache.contentInputsByPostID {
+            || previousRenderCache?.contentInputsByPostID != renderCache.contentInputsByPostID
+        if didUpdateRenderState {
             topicRenderStates[topicId] = renderCache.renderState
+        }
+        if didUpdateDetail || didUpdateRenderState {
+            bumpTopicListRevision(topicId: topicId)
         }
         return cachedDetail
     }
@@ -1164,14 +1239,17 @@ final class FireTopicDetailStore: ObservableObject {
         }
 
         topicAiSummaryTasks[topicId]?.cancel()
-        loadingTopicAiSummaryIDs.insert(topicId)
-        unavailableTopicAiSummaryIDs.remove(topicId)
-        topicAiSummaryErrorsByTopicID.removeValue(forKey: topicId)
+        let clearedUnavailable = unavailableTopicAiSummaryIDs.remove(topicId) != nil
+        let clearedError = topicAiSummaryErrorsByTopicID.removeValue(forKey: topicId) != nil
+        setLoadingTopicAiSummary(true, topicId: topicId)
+        if clearedUnavailable || clearedError {
+            bumpTopicListRevision(topicId: topicId)
+        }
 
         topicAiSummaryTasks[topicId] = Task { @MainActor [weak self] in
             guard let self else { return }
             defer {
-                self.loadingTopicAiSummaryIDs.remove(topicId)
+                self.setLoadingTopicAiSummary(false, topicId: topicId)
                 self.topicAiSummaryTasks.removeValue(forKey: topicId)
             }
 
@@ -1188,12 +1266,19 @@ final class FireTopicDetailStore: ObservableObject {
 
                 if let summary,
                    !summary.summarizedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    let didChangeSummary = self.topicAiSummaries[topicId] != summary
                     self.topicAiSummaries[topicId] = summary
-                    self.unavailableTopicAiSummaryIDs.remove(topicId)
-                    self.topicAiSummaryErrorsByTopicID.removeValue(forKey: topicId)
+                    let clearedUnavailable = self.unavailableTopicAiSummaryIDs.remove(topicId) != nil
+                    let clearedError = self.topicAiSummaryErrorsByTopicID.removeValue(forKey: topicId) != nil
+                    if didChangeSummary || clearedUnavailable || clearedError {
+                        self.bumpTopicListRevision(topicId: topicId)
+                    }
                 } else {
-                    self.topicAiSummaries.removeValue(forKey: topicId)
-                    self.unavailableTopicAiSummaryIDs.insert(topicId)
+                    let removedSummary = self.topicAiSummaries.removeValue(forKey: topicId) != nil
+                    let insertedUnavailable = self.unavailableTopicAiSummaryIDs.insert(topicId).inserted
+                    if removedSummary || insertedUnavailable {
+                        self.bumpTopicListRevision(topicId: topicId)
+                    }
                 }
             } catch {
                 if await self.appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
@@ -1202,7 +1287,10 @@ final class FireTopicDetailStore: ObservableObject {
                     )
                     return
                 }
-                self.topicAiSummaryErrorsByTopicID[topicId] = error.localizedDescription
+                if self.topicAiSummaryErrorsByTopicID[topicId] != error.localizedDescription {
+                    self.topicAiSummaryErrorsByTopicID[topicId] = error.localizedDescription
+                    self.bumpTopicListRevision(topicId: topicId)
+                }
                 self.appViewModel.topicDetailLogger()?.error(
                     "topic AI summary load failed topic_id=\(topicId) error=\(error.localizedDescription)"
                 )
@@ -1386,8 +1474,8 @@ final class FireTopicDetailStore: ObservableObject {
             return
         }
 
-        loadingMoreTopicPostIDs.insert(topicId)
-        defer { loadingMoreTopicPostIDs.remove(topicId) }
+        setLoadingMoreTopicPosts(true, topicId: topicId)
+        defer { setLoadingMoreTopicPosts(false, topicId: topicId) }
 
         var hydratedPosts: [TopicPostState] = []
         var hydratedPostIDs: Set<UInt64> = []
@@ -1458,7 +1546,7 @@ final class FireTopicDetailStore: ObservableObject {
                 if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
                     return
                 }
-                errorMessage = error.localizedDescription
+                updateTopicErrorMessage(error.localizedDescription, topicId: topicId)
                 return
             }
         }


### PR DESCRIPTION
## Summary
- keep topic detail full-screen while explicitly stabilizing root tab bar visibility configuration
- reduce topic detail list invalidation fan-out by caching collection item tokens and keying updates off topic-scoped revisions
- optimize heavy first-post rendering by caching rich-text intrinsic height and avoiding image placeholder churn on reuse/cache hits

## Testing
- xcodebuildmcp build_sim
- xcodebuildmcp test_sim (96 passed)
