### PR TITLE
iOS: complete native topic reply cell slice

### DIFF
--- a/docs/architecture/plans/ios-topic-detail-native-reply-cell-plan.md
+++ b/docs/architecture/plans/ios-topic-detail-native-reply-cell-plan.md
@@ -1,0 +1,685 @@
+# iOS Topic Detail Native Reply Cell Plan
+
+Status: proposed (2026-05-28)
+
+## Summary
+
+We want the iOS topic-detail reading surface to keep its current visual design
+and screen-level SwiftUI shell while moving the hot-path reply rows off
+`UIHostingConfiguration` and onto a pure UIKit `UICollectionViewCell` path.
+This is the first concrete step in a broader direction: performance-critical and
+interaction-heavy reading surfaces should progressively move to UIKit/AppKit,
+while SwiftUI remains the shell and orchestration layer where it is not the
+scroll-time bottleneck.
+
+The current reply path is expensive in exactly the places we care about:
+`FireTopicDetailCollectionView` builds every `.reply` item as `FirePostRow`,
+`FireDiffableListController` hosts that view tree inside a single hosted cell
+registration, and `FireRichTextView` still relies on `UITextView` intrinsic
+measurement. That means reply rows pay SwiftUI tree rebuild, hosted-cell
+reconfiguration, and main-thread text self-sizing costs during scroll and
+incremental hydration.
+
+The target state is a mixed collection host:
+
+- non-hot-path items stay on the existing hosted path
+- `.reply` items that meet a native-eligibility check render through a pure
+  `FirePostCollectionViewCell`
+- reply height and child frames are precomputed on a background queue and
+  published in coalesced batches
+- poll, placeholder, and temporary layout-miss cases retain a hosted fallback
+  during the first delivery slice
+
+This plan incorporates the latest code review feedback. The biggest adjustments
+from the original proposal are:
+
+- explicitly model native and hosted cells as parallel paths inside the generic
+  `FireDiffableListController`, instead of treating the native cell as a small
+  extension of the existing `RowContent` generic
+- add a concrete width-change callback chain from collection controller to
+  SwiftUI wrapper to reply layout manager, instead of relying on rotation-only
+  hooks
+- keep poll rows on hosted fallback in the first slice instead of embedding a
+  `UIHostingController` inside a reusable native cell
+- specify the missing parity work for menu actions, accessibility,
+  trait-collection handling, divider rendering, and `prepareForReuse()` cleanup
+
+## Current State
+
+### Reply Rendering Path
+
+- `native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift`
+  builds `.reply` items in `replyRow(for:replyIndexByPostID:)`.
+- Each loaded reply is wrapped in `FireSwipeToReplyContainer` and rendered by
+  `FirePostRow` from `native/ios-app/App/FireTopicDetailView.swift`.
+- `FirePostRow` owns the visual contract for:
+  - avatar and thread line
+  - single-line metadata header
+  - `FireRichTextView`
+  - `FireCookedImageCard`
+  - `FirePollCard`
+  - reaction capsules
+  - post actions menu
+- The collection host still uses a single
+  `UICollectionView.CellRegistration<UICollectionViewListCell, ItemID>` and
+  sets `UIHostingConfiguration` for every item.
+
+### Host and Revision Path
+
+- `native/ios-app/App/ListKit/FireCollectionHost.swift` caches per-item content
+  tokens in `Coordinator.resolveItemContentTokens(...)`, keyed by
+  `sections + contentVersion`.
+- `native/ios-app/App/ListKit/FireDiffableListController.swift` diffs sections,
+  derives `reconfigureItems`, and applies snapshots while preserving scroll
+  anchors.
+- `native/ios-app/App/Stores/FireTopicDetailStore.swift` publishes a coarse
+  `topicCollectionRevision` whenever detail state or render cache state changes.
+- `native/ios-app/App/FireTopicDetailView.swift` listens to that revision and
+  refreshes `cachedDetail` / `cachedRenderState`, so any reply-native work must
+  remain compatible with the existing revision flow.
+
+### Existing Performance Boundaries
+
+- `native/ios-app/App/FireTopicPresentation.swift` already builds
+  `FireTopicDetailRenderCache` off the main actor and exposes
+  `FireTopicPostRenderContent` as the right host-owned rendering boundary.
+- `native/ios-app/App/FireRichTextRenderer.swift` still measures rich text via
+  `FireRichTextUIView.intrinsicContentSize`, so even with off-main HTML parsing,
+  the final row size is still determined on the main thread.
+- `onPrefetchItems` already exists in the collection host and is a better first
+  layout-warmup signal than immediately adding more display lifecycle hooks.
+
+## Goals
+
+- Move common `.reply` rows in topic detail from hosted SwiftUI rows to a pure
+  UIKit cell path.
+- Precompute reply row height and child geometry off the main thread.
+- Preserve the current visual hierarchy, reply depth chrome, swipe-to-reply
+  behavior, anchored scrolling, and mutation callbacks.
+- Keep the SwiftUI screen shell, topic-detail store, render-cache production,
+  and Rust/UniFFI surfaces unchanged.
+- Reduce scroll-time `UIHostingConfiguration` churn and hosted-row rebuilds for
+  large threads.
+- Establish a reusable migration pattern for other UIKit/AppKit-heavy screens.
+
+## Non-Goals
+
+- No redesign of the topic-detail page.
+- No same-slice rewrite of `FireTopicDetailStore`, `FireTopicPresentation`, or
+  any Rust/UniFFI code.
+- No first-slice migration of `.originalPost`; it remains hosted because it is a
+  single instance, not the repeated scroll hotspot.
+- No requirement that poll rows become native in the first delivery slice.
+- No same-slice rewrite of the topic-detail quick-reply bar, screen shell,
+  sheets, or navigation stack.
+
+## Review-Driven Design Corrections
+
+### 1. Mixed Registration Must Be Explicit
+
+`FireDiffableListController<SectionID, ItemID, RowContent: View>` remains a
+single generic controller, but the native reply path must be modeled as a
+parallel cell-registration path, not as a mutation of `RowContent`.
+
+The controller must gain:
+
+- `shouldUseNativeCell: (ItemID) -> Bool`
+- `nativeCellProvider: (UICollectionView, IndexPath, ItemID) -> UICollectionViewCell?`
+- an update method for both closures during `updateUIViewController`
+
+The data source cell provider becomes:
+
+- if `shouldUseNativeCell(itemID)` is true, ask `nativeCellProvider` for a cell
+- otherwise dequeue the existing hosted `UICollectionViewListCell`
+
+This preserves the current `RowContent` generic for non-native items and keeps
+native reply cells completely parallel.
+
+### 2. Original Post Stays Hosted in Slice 1
+
+`.originalPost` also renders `FirePostRow` today, but it is not the first
+migration target.
+
+The plan is:
+
+- keep `.originalPost` on the hosted path in slice 1
+- keep all visual constants in the new native code aligned to the existing
+  `FirePostRow` contract
+- only extract shared post-row metrics if implementation drift becomes likely
+
+That gives us the performance win where it matters without widening the first
+migration surface.
+
+### 3. Divider Rendering Must Be Manual
+
+Choosing `UICollectionViewCell` over `UICollectionViewListCell` means reply-row
+separators are now the cell's responsibility. The native cell needs an explicit
+bottom divider view that is shown for every reply except the last visible reply
+in the loaded sequence.
+
+### 4. Menu Actions Must Stay on the Ellipsis Button
+
+`FirePostRow` currently exposes a SwiftUI `Menu` behind the ellipsis icon. The
+native cell should keep the same interaction model with:
+
+- an ellipsis `UIButton`
+- a `UIMenu` built from the current post permissions
+- `showsMenuAsPrimaryAction = true`
+
+That is closer to the current UX than a long-press-only context menu.
+
+### 5. Avatar Loading Needs a UIKit Path
+
+The native cell cannot depend on `FireAvatarView`. It should reuse the existing
+avatar URL helper and the shared image pipeline to feed a plain `UIImageView`
+with a circle mask and monogram fallback.
+
+### 6. Callback Surface Must Be Explicit
+
+The native cell needs a typed callback bundle instead of a growing list of ad hoc
+closures.
+
+```swift
+struct FirePostCellCallbacks {
+    let onLinkTapped: (URL) -> Void
+    let onOpenImage: (FireCookedImage) -> Void
+    let onToggleLike: (TopicPostState) -> Void
+    let onSelectReaction: (TopicPostState, String) -> Void
+    let onEditPost: (TopicPostState) -> Void
+    let onBookmarkPost: (TopicPostState) -> Void
+    let onDeletePost: (TopicPostState) -> Void
+    let onRecoverPost: (TopicPostState) -> Void
+    let onFlagPost: (TopicPostState) -> Void
+    let onOpenReplyTarget: (UInt32) -> Void
+    let onOpenReplies: (TopicPostState) -> Void
+    let onVotePoll: (TopicPostState, PollState, [String]) -> Void
+    let onUnvotePoll: (TopicPostState, PollState) -> Void
+    let onSwipeReply: (TopicPostState) -> Void
+}
+```
+
+### 7. Accessibility and Trait Changes Are First-Class Work
+
+SwiftUI gives us accessibility and trait adaptation implicitly. Native reply
+cells must implement them explicitly:
+
+- labels and values for post body and metadata
+- selected traits for the active reaction capsule
+- accessibility labels for ellipsis menu, links, reply target, and images
+- `traitCollectionDidChange` handling for color refresh and Dynamic Type-driven
+  layout invalidation
+
+### 8. Width Changes Need a Real Callback Chain
+
+Width changes should not rely only on `viewWillTransition(to:with:)`. The
+collection host already owns the actual `UICollectionView` geometry, so the
+plan adds:
+
+- width observation in `FireDiffableListController.viewDidLayoutSubviews`
+- `onContentWidthChanged` passthrough in `FireCollectionHost`
+- local width state in `FireTopicDetailCollectionView`
+- `FirePostLayoutManager.invalidateAll(reason: .widthChanged)` when the width
+  changes
+
+That covers rotation, split view, and other bounds changes with the real
+measured content width.
+
+### 9. Layout Publication Must Trigger Token Changes
+
+Because `FireCollectionHost.Coordinator` caches tokens by `contentVersion`, the
+layout manager cannot publish per-post results silently. It must coalesce ready
+layouts into a batch and bump a local `replyLayoutSnapshotRevision` that is part
+of `FireTopicDetailCollectionContentVersion`.
+
+### 10. `prepareForReuse()` Must Reset More Than Images
+
+The native cell needs a full reuse contract:
+
+- cancel image-loading tasks
+- cancel emoji-loading tasks
+- reset swipe gesture state
+- clear image views
+- clear text delegates if needed
+- clear placeholder/skeleton state
+- clear per-post menu/actions state
+
+## Architectural Decision
+
+Use a mixed hosted/native topic-detail collection host with a reply-local
+background layout manager.
+
+### Key Design Points
+
+1. `.reply` is the only native item type in slice 1.
+2. The native path is gated by a reply-cell eligibility matrix.
+3. Layout cache keys include only geometry-affecting inputs.
+4. Render payload stays separate and is applied on every rebind.
+5. Width and Dynamic Type changes are explicit invalidation sources.
+6. Poll and placeholder rows stay hosted until the native path is stable.
+7. Text height is precomputed off-main, but the first slice still reuses the
+   existing rich-text interaction behavior through a fixed-frame UIKit wrapper.
+
+### New Core Types
+
+```swift
+struct FirePostLayoutTraitSignature: Hashable, Sendable {
+    let contentWidthPixels: Int
+    let contentSizeCategory: String
+}
+
+struct FirePostCellLayoutKey: Hashable, Sendable {
+    let postID: UInt64
+    let depth: Int
+    let showsThreadLine: Bool
+    let replyTargetPostNumber: UInt32?
+    let replyContext: String?
+    let textContentID: String
+    let imageSignature: [String]
+    let pollSignature: [UInt64]
+    let hasReactions: Bool
+    let acceptedAnswer: Bool
+    let trait: FirePostLayoutTraitSignature
+}
+
+struct FirePostCellLayout: Equatable, Sendable {
+    let key: FirePostCellLayoutKey
+    let totalHeight: CGFloat
+    let avatarFrame: CGRect
+    let threadLineFrame: CGRect?
+    let metaFrame: CGRect
+    let textFrame: CGRect?
+    let textContainerSize: CGSize
+    let imageFrames: [CGRect]
+    let pollFrames: [CGRect]
+    let reactionsFrame: CGRect?
+    let menuFrame: CGRect?
+    let dividerFrame: CGRect?
+}
+
+struct FirePostCellRenderPayload {
+    let post: TopicPostState
+    let renderContent: FireTopicPostRenderContent
+    let baseURLString: String
+    let canWriteInteractions: Bool
+    let isMutating: Bool
+    let replyContext: String?
+    let replyTargetPostNumber: UInt32?
+    let showsDivider: Bool
+}
+```
+
+### Native Eligibility Matrix
+
+The first slice uses explicit reply modes:
+
+```swift
+enum FireReplyCellMode {
+    case native
+    case hostedPoll
+    case hostedPlaceholder
+    case hostedLayoutMiss
+}
+```
+
+Rules:
+
+- `post == nil` -> `.hostedPlaceholder`
+- `!post.polls.isEmpty` -> `.hostedPoll`
+- layout not ready on first bind -> `.hostedLayoutMiss`
+- all other common reply rows -> `.native`
+
+This keeps the first win focused on the majority path.
+
+## Proposed Execution Plan
+
+### Phase 0. Baseline, Metrics, and Guardrails
+
+Files:
+
+- `native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift`
+- `native/ios-app/App/ListKit/FireDiffableListController.swift`
+- `native/ios-app/App/FireTopicDetailView.swift`
+
+Changes:
+
+- Record the current behavior baseline for:
+  - anchored scroll-to-post
+  - reply swipe and back-swipe coexistence
+  - load-more and hydration churn
+  - reaction optimistic updates
+  - poll rows and placeholder rows
+- Add or expand APM signposts around reply-row configure cost if the current
+  instrumentation is insufficient.
+- Define success criteria before code motion begins:
+  - no regression in anchored scrolling
+  - no regression in swipe/back gesture arbitration
+  - fewer hosted reply reconfigurations during large-thread scroll
+
+Rationale: the migration needs a concrete before/after bar, not just a target
+architecture diagram.
+
+### Phase 1. Shared ListKit Capability Lift
+
+Files:
+
+- `native/ios-app/App/ListKit/FireDiffableListController.swift`
+- `native/ios-app/App/ListKit/FireCollectionHost.swift`
+
+Changes:
+
+- Add `shouldUseNativeCell`, `nativeCellProvider`, and update methods for both.
+- Keep the existing hosted `UICollectionViewListCell` registration for all
+  non-native items.
+- Extend the controller with `onContentWidthChanged` published from
+  `viewDidLayoutSubviews` when the effective content width changes.
+- Keep `onPrefetchItems` as the first pre-layout signal.
+- Do not add `willDisplay` / `didEndDisplaying` yet unless the native image and
+  emoji lifetime work proves it is necessary.
+
+Rationale: the host layer must first support mixed registration and real width
+reporting before the reply-native implementation can remain local and reliable.
+
+Exit criteria:
+
+- the collection host can render a mix of hosted and native cells
+- topic detail can receive actual collection content width changes without any
+  GeometryReader-specific hacks
+
+### Phase 2. Reply Layout Modeling and Background Cache
+
+Files:
+
+- `native/ios-app/App/ListKit/TopicDetail/FirePostCellLayout.swift` (new)
+- `native/ios-app/App/ListKit/TopicDetail/FirePostCellLayoutCalculator.swift` (new)
+- `native/ios-app/App/ListKit/TopicDetail/FirePostLayoutManager.swift` (new)
+- `native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift`
+
+Changes:
+
+- Introduce `FirePostLayoutTraitSignature`, `FirePostCellLayoutKey`, and
+  `FirePostCellLayout`.
+- Keep `NSAttributedString`, `TopicPostState`, and TextKit objects out of the
+  `Equatable` layout model.
+- Build a stateless calculator that mirrors current `FirePostRow` layout
+  constants:
+  - `visualDepth = max(depth - 1, 0)`
+  - `indentWidth = CGFloat(min(visualDepth, 3)) * 20`
+  - `avatarSize = visualDepth > 0 ? 26 : 32`
+  - `avatarSpacing = visualDepth > 0 ? 6 : 10`
+  - outer horizontal padding remains 16
+- Measure rich-text height via temporary TextKit 2 objects created entirely on
+  the background worker.
+- Exclude reaction count from the layout key; include only whether a reaction
+  row exists.
+- Keep poll rows off the native path in this phase.
+- Add a reply-local `FirePostLayoutManager` that:
+  - owns the layout cache on the main actor
+  - computes missing layouts on a serial background worker
+  - coalesces ready layouts into batch publication
+  - exposes a `snapshotRevision` for diffable content-token invalidation
+- In `FireTopicDetailCollectionView`:
+  - own the layout manager locally
+  - track current content width from `onContentWidthChanged`
+  - include `replyLayoutSnapshotRevision` in `FireTopicDetailCollectionContentVersion`
+  - derive a native eligibility mode per reply row
+  - enqueue layout work from render-state changes and prefetch callbacks
+
+Rationale: layout must be modeled and published before the cell can bind with
+stable, non-self-sizing geometry.
+
+Exit criteria:
+
+- reply layout is cached by post + width + Dynamic Type + geometry-affecting
+  inputs
+- a batch of ready layouts results in one content-version bump, not one per post
+
+### Phase 3. Native Reply Cell Skeleton and Fixed-Frame Rich Text
+
+Files:
+
+- `native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift` (new)
+- `native/ios-app/App/ListKit/TopicDetail/FirePostRichTextContainerView.swift` (new)
+- `native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift`
+- `native/ios-app/App/FireComponents.swift`
+
+Changes:
+
+- Add `FirePostCollectionViewCell: UICollectionViewCell` with explicit subviews:
+  - avatar image view
+  - monogram fallback view
+  - thread line view
+  - metadata labels
+  - accepted-answer badge
+  - post number label
+  - ellipsis menu button
+  - rich-text container
+  - image container
+  - reaction scroll container
+  - manual divider view
+- Add `bind(layout:payload:callbacks:)` and `prepareForReuse()`.
+- Add `preferredLayoutAttributesFitting(_:)` so the collection layout consumes
+  the precomputed height instead of asking UIKit to self-measure the full row.
+- Add `FirePostRichTextContainerView` as a fixed-frame wrapper around the
+  existing `FireRichTextUIView` interaction behavior:
+  - no intrinsic height path
+  - explicit text-container size assignment
+  - existing link callback behavior preserved
+  - existing emoji attachment loading pattern reused
+- Add a UIKit avatar path using `fireAvatarURL(...)`, `FireRemoteImagePipeline`,
+  and a plain `UIImageView`.
+- Keep `.hostedLayoutMiss` as a temporary fallback until native pre-layout is
+  reliably warm for the common path.
+
+Rationale: first ship the native reply cell with stable height and rich-text
+interaction parity before adding every edge-case interaction.
+
+Exit criteria:
+
+- common reply rows can render natively with correct height and visual parity
+- hosted fallback still covers layout misses without breaking the screen
+
+### Phase 4. Native Images, Menu, Reactions, Swipe, and Accessibility
+
+Files:
+
+- `native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift`
+- `native/ios-app/App/ListKit/FireDiffableListController.swift`
+- `native/ios-app/App/ListKit/FireCollectionHost.swift`
+
+Changes:
+
+- Render cooked images with lightweight `UIImageView` instances positioned by
+  precomputed frames.
+- Reuse the shared image pipeline and cancel image tasks on reuse.
+- Build the ellipsis `UIMenu` from current post permissions so edit/bookmark/
+  flag/recover/delete remain available from the same affordance.
+- Implement reaction capsules with `UIScrollView + UIButton` and keep the
+  current callback split between heart and non-heart reactions.
+- Implement swipe-to-reply with `UIPanGestureRecognizer`, preserving:
+  - 32pt back-navigation reservation width
+  - horizontal vs vertical axis arbitration
+  - 55pt trigger threshold
+  - 75pt max offset with dampening past threshold
+  - haptic pulse on trigger
+  - spring reset to zero on completion
+- Add accessibility labels, values, and selected traits.
+- If image or emoji lifetime handling needs explicit view lifecycle, add
+  `onItemWillDisplay` / `onItemDidEndDisplaying` to the host layer in this
+  phase, not earlier.
+
+Rationale: these are the high-frequency interactions that make the reply-native
+path actually complete and usable.
+
+Exit criteria:
+
+- native reply rows support the current menu, reaction, and swipe behaviors
+- accessibility parity is functionally acceptable
+
+### Phase 5. Invalidation, Trait Adaptation, and Fallback Hardening
+
+Files:
+
+- `native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift`
+- `native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift`
+- `native/ios-app/App/ListKit/FireDiffableListController.swift`
+
+Changes:
+
+- Invalidate all reply layouts when content width changes.
+- Invalidate all reply layouts when the Dynamic Type category changes.
+- Refresh colors and other trait-dependent UI in `traitCollectionDidChange`.
+- Keep normal reaction count changes as render-only rebinds; only invalidate
+  layout if the row crosses the `hasReactions` boundary.
+- Keep bookmark, accepted-answer, mutating state, and menu availability as
+  render-only updates unless a height-affecting visual change is introduced.
+- Preserve hosted fallback for poll and placeholder rows.
+- If placeholder frequency proves high enough to matter, add a native skeleton
+  state in this phase.
+
+Rationale: invalidation granularity determines whether the native path keeps its
+performance win under live updates.
+
+Exit criteria:
+
+- width, Dynamic Type, and live update changes do not leave stale heights behind
+- hosted fallback still safely covers the remaining complex cases
+
+### Phase 6. Poll Strategy Decision and Follow-Up Slice
+
+Files:
+
+- `native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift`
+- `native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift`
+
+Changes:
+
+- Decide after profiling whether poll rows need to migrate.
+- If poll incidence is low and the hosted fallback cost is acceptable, keep the
+  hosted poll path.
+- If poll rows remain a measurable hotspot, implement a dedicated native poll
+  subview instead of embedding a `UIHostingController` inside the reusable cell.
+
+Rationale: poll complexity should not block the common reply-row win.
+
+Exit criteria:
+
+- the team has a measured decision on whether poll rows stay hosted or move to
+  a dedicated native poll surface
+
+### Phase 7. Verification and Rollout
+
+Files:
+
+- `native/ios-app/Tests/Unit/FireTopicPresentationTests.swift`
+- `native/ios-app/Tests/Unit/FirePostCellLayoutCalculatorTests.swift` (new)
+- `native/ios-app/Tests/Unit/FirePostLayoutManagerTests.swift` (new)
+- `native/ios-app/App/ListKit/FireDiffableListController.swift`
+- `native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift`
+
+Changes:
+
+- Add focused unit tests for:
+  - layout-key stability
+  - layout calculation for long text, images, reaction presence, depth, and
+    Dynamic Type
+  - layout manager batch publication and invalidation semantics
+- Keep existing topic-detail store and presentation tests passing.
+- Add APM signposts for:
+  - layout batch calculation time
+  - native cell bind time
+  - hosted fallback frequency
+- Manually verify:
+  - anchored open to target post
+  - reply swipe and back-swipe coexistence
+  - load-more and hydration
+  - reaction optimistic updates
+  - image open
+  - menu actions
+  - Dynamic Type changes
+  - rotation and split-view width changes
+- Optionally gate the native reply path behind a temporary local feature flag if
+  rollout risk remains high after verification.
+
+Rationale: the migration should close with evidence, not only with code.
+
+## Topic Detail Design Constraints
+
+These remain non-negotiable:
+
+1. One continuous scroll surface.
+   Header, original post, replies, and footer remain on a single collection view.
+
+2. Stable anchored scrolling.
+   Route jumps must still work when the target reply becomes available later.
+
+3. Back-swipe reservation.
+   Reply swipe cannot steal the system back-navigation gesture from the leading
+   edge.
+
+4. Store boundary preservation.
+   UIKit-only layout cache stays out of `FireTopicDetailStore`.
+
+5. Batch publication.
+   Layout readiness must publish in coalesced revisions, not one-item bursts.
+
+6. Fallback is allowed.
+   Poll, placeholder, and early layout-miss cases may stay hosted until their
+   native path is justified.
+
+7. Accessibility parity.
+   Native reply cells cannot silently drop semantics that SwiftUI was giving us.
+
+8. Width and Dynamic Type invalidation.
+   Cached reply heights must respect both.
+
+## Verification Checklist
+
+- Build the iOS app target successfully.
+- Run the focused unit tests for layout calculation and manager invalidation.
+- Confirm existing topic-detail presentation and store tests still pass.
+- Compare scroll smoothness and hosted-row rebuild frequency before and after.
+- Verify that reply swipe, menu actions, reaction updates, image taps, and
+  anchored scrolling still behave correctly.
+- Verify rotation, split view, and Dynamic Type changes do not leave stale
+  heights or broken colors.
+
+## File Change Summary
+
+- `docs/architecture/plans/ios-topic-detail-native-reply-cell-plan.md` -- adds
+  the full migration plan for native topic-detail reply cells.
+- `native/ios-app/App/ListKit/FireDiffableListController.swift` -- adds mixed
+  hosted/native cell routing and content-width publication.
+- `native/ios-app/App/ListKit/FireCollectionHost.swift` -- threads native cell
+  routing and width-change callbacks through the SwiftUI wrapper.
+- `native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift`
+  -- adds reply-cell eligibility, local layout-manager ownership, width-driven
+  invalidation, and native reply wiring.
+- `native/ios-app/App/ListKit/TopicDetail/FirePostCellLayout.swift` -- adds the
+  reply layout key, trait signature, and geometry model.
+- `native/ios-app/App/ListKit/TopicDetail/FirePostCellLayoutCalculator.swift`
+  -- adds the pure background layout calculator.
+- `native/ios-app/App/ListKit/TopicDetail/FirePostLayoutManager.swift` -- adds
+  the reply-local layout cache and batch publication logic.
+- `native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift` --
+  adds the pure UIKit reply cell implementation.
+- `native/ios-app/App/ListKit/TopicDetail/FirePostRichTextContainerView.swift`
+  -- adds the fixed-frame rich-text UIKit wrapper.
+- `native/ios-app/App/FireComponents.swift` -- may be touched only if the native
+  reply cell needs a shared avatar helper promoted from existing code.
+- `native/ios-app/Tests/Unit/FirePostCellLayoutCalculatorTests.swift` -- adds
+  focused layout-calculation tests.
+- `native/ios-app/Tests/Unit/FirePostLayoutManagerTests.swift` -- adds focused
+  cache and invalidation tests.
+- `native/ios-app/Tests/Unit/FireTopicPresentationTests.swift` -- adds any
+  small helper- or token-level coverage that belongs with existing topic-detail
+  presentation tests.
+
+## Explicitly Not Changed in Slice 1
+
+- `native/ios-app/App/FireTopicDetailView.swift` stays the screen shell and
+  continues to own the hosted `.originalPost` path.
+- `native/ios-app/App/FireTopicPresentation.swift` remains the source of render
+  content and render-cache production.
+- `native/ios-app/App/Stores/FireTopicDetailStore.swift` remains the source of
+  topic detail state and collection revisions.
+- all Rust, UniFFI, and backend protocol surfaces remain untouched.

--- a/native/ios-app/App/ListKit/FireCollectionHost.swift
+++ b/native/ios-app/App/ListKit/FireCollectionHost.swift
@@ -70,10 +70,13 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
     let onPrefetchItems: (([ItemID]) -> Void)?
     let onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)?
     let onRefresh: (() async -> Void)?
+    let onContentWidthChanged: ((CGFloat) -> Void)?
     let scrollAnchorRestorePolicy: FireCollectionScrollAnchorRestorePolicy
     let updatePolicy: FireCollectionUpdatePolicy
     let scrollRequest: FireCollectionScrollRequest<ItemID>?
     let onScrollRequestCompleted: ((ItemID) -> Void)?
+    let shouldUseNativeCell: ((ItemID) -> Bool)?
+    let nativeCellProvider: ((UICollectionView, IndexPath, ItemID) -> UICollectionViewCell?)?
     let rowContent: (ItemID) -> RowContent
 
     init(
@@ -90,10 +93,13 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
         onPrefetchItems: (([ItemID]) -> Void)? = nil,
         onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)? = nil,
         onRefresh: (() async -> Void)? = nil,
+        onContentWidthChanged: ((CGFloat) -> Void)? = nil,
         scrollAnchorRestorePolicy: FireCollectionScrollAnchorRestorePolicy = .whenNotAnimatingDifferences,
         updatePolicy: FireCollectionUpdatePolicy = .applyImmediately,
         scrollRequest: FireCollectionScrollRequest<ItemID>? = nil,
         onScrollRequestCompleted: ((ItemID) -> Void)? = nil,
+        shouldUseNativeCell: ((ItemID) -> Bool)? = nil,
+        nativeCellProvider: ((UICollectionView, IndexPath, ItemID) -> UICollectionViewCell?)? = nil,
         makeLayout: @escaping () -> UICollectionViewLayout,
         rowContent: @escaping (ItemID) -> RowContent
     ) {
@@ -110,10 +116,13 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
         self.onPrefetchItems = onPrefetchItems
         self.onScrollMetricsChanged = onScrollMetricsChanged
         self.onRefresh = onRefresh
+        self.onContentWidthChanged = onContentWidthChanged
         self.scrollAnchorRestorePolicy = scrollAnchorRestorePolicy
         self.updatePolicy = updatePolicy
         self.scrollRequest = scrollRequest
         self.onScrollRequestCompleted = onScrollRequestCompleted
+        self.shouldUseNativeCell = shouldUseNativeCell
+        self.nativeCellProvider = nativeCellProvider
         self.makeLayout = makeLayout
         self.rowContent = rowContent
     }
@@ -138,10 +147,13 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
                 onPrefetchItems: onPrefetchItems,
                 onScrollMetricsChanged: onScrollMetricsChanged,
                 onRefresh: onRefresh,
+                onContentWidthChanged: onContentWidthChanged,
                 scrollAnchorRestorePolicy: scrollAnchorRestorePolicy,
                 updatePolicy: updatePolicy,
                 scrollRequest: scrollRequest,
                 onScrollRequestCompleted: onScrollRequestCompleted,
+                shouldUseNativeCell: shouldUseNativeCell,
+                nativeCellProvider: nativeCellProvider,
                 rowContent: rowContent
             )
         return controller
@@ -152,6 +164,11 @@ struct FireCollectionHost<SectionID: Hashable, ItemID: Hashable, RowContent: Vie
         context: Context
     ) {
         uiViewController.updateRowContent(rowContent)
+        uiViewController.updateNativeCellRouting(
+            shouldUseNativeCell: shouldUseNativeCell,
+            nativeCellProvider: nativeCellProvider
+        )
+        uiViewController.updateOnContentWidthChanged(onContentWidthChanged)
         uiViewController.updateScrollRequest(
             scrollRequest,
             onCompleted: onScrollRequestCompleted

--- a/native/ios-app/App/ListKit/FireDiffableListController.swift
+++ b/native/ios-app/App/ListKit/FireDiffableListController.swift
@@ -91,6 +91,16 @@ func fireCollectionChangedItems<SectionID: Hashable, ItemID: Hashable>(
         }
 }
 
+func fireCollectionChangedCellRoutingItems<ItemID: Hashable>(
+    changedItems: [ItemID],
+    previousRouting: [ItemID: Bool],
+    incomingRouting: [ItemID: Bool]
+) -> [ItemID] {
+    changedItems.filter { item in
+        previousRouting[item] != incomingRouting[item]
+    }
+}
+
 func fireCollectionScrollRequestDidChange<ItemID: Hashable>(
     current: FireCollectionScrollRequest<ItemID>?,
     incoming: FireCollectionScrollRequest<ItemID>?
@@ -136,6 +146,7 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
     private var hostedCellRegistration: UICollectionView.CellRegistration<UICollectionViewListCell, ItemID>?
     private var currentSections: [FireListSectionModel<SectionID, ItemID>] = []
     private var currentItemContentTokens: [ItemID: AnyHashable] = [:]
+    private var currentNativeCellUsage: [ItemID: Bool] = [:]
     private var lastVisibleItemIDs: [ItemID] = []
     private var lastScrollMetrics: FireCollectionScrollMetrics?
     private var lastContentWidth: CGFloat?
@@ -373,14 +384,15 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
         itemContentTokens: [ItemID: AnyHashable]?,
         animatingDifferences: Bool
     ) {
-        guard let dataSource else { return }
         let sectionsChanged = fireCollectionNeedsSectionUpdate(
             current: currentSections,
             incoming: sections
         )
         let legacyContentChanged = self.contentVersion != contentVersion
+        let incomingNativeCellUsage = resolveNativeCellUsage(for: sections)
 
         let reconfiguredItems: [ItemID]
+        let reloadedItems: [ItemID]
         let contentChanged: Bool
         if let itemContentTokens {
             let changed = fireCollectionChangedItems(
@@ -389,12 +401,23 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
                 previousTokens: currentItemContentTokens,
                 currentTokens: itemContentTokens
             )
-            reconfiguredItems = changed
+            reloadedItems = fireCollectionChangedCellRoutingItems(
+                changedItems: changed,
+                previousRouting: currentNativeCellUsage,
+                incomingRouting: incomingNativeCellUsage
+            )
+            reconfiguredItems = changed.filter { !reloadedItems.contains($0) }
             contentChanged = !changed.isEmpty
         } else {
-            reconfiguredItems = legacyContentChanged
+            let changedItems = legacyContentChanged
                 ? fireCollectionCommonItems(current: currentSections, incoming: sections)
                 : []
+            reloadedItems = fireCollectionChangedCellRoutingItems(
+                changedItems: changedItems,
+                previousRouting: currentNativeCellUsage,
+                incomingRouting: incomingNativeCellUsage
+            )
+            reconfiguredItems = changedItems.filter { !reloadedItems.contains($0) }
             contentChanged = legacyContentChanged
         }
 
@@ -431,8 +454,10 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
             sections: sections,
             contentVersion: contentVersion,
             itemContentTokens: itemContentTokens,
+            nativeCellUsage: incomingNativeCellUsage,
             animatingDifferences: animatingDifferences,
             sectionsChanged: sectionsChanged,
+            reloadedItems: reloadedItems,
             reconfiguredItems: reconfiguredItems
         )
     }
@@ -441,14 +466,17 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
         sections: [FireListSectionModel<SectionID, ItemID>],
         contentVersion: AnyHashable,
         itemContentTokens: [ItemID: AnyHashable]?,
+        nativeCellUsage: [ItemID: Bool],
         animatingDifferences: Bool,
         sectionsChanged: Bool,
+        reloadedItems: [ItemID],
         reconfiguredItems: [ItemID]
     ) {
         guard let dataSource else { return }
 
         currentSections = sections
         self.contentVersion = contentVersion
+        currentNativeCellUsage = nativeCellUsage
         if let itemContentTokens {
             currentItemContentTokens = itemContentTokens
         }
@@ -468,6 +496,9 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
             snapshot.appendSections([section.id])
             snapshot.appendItems(section.items, toSection: section.id)
         }
+        if !reloadedItems.isEmpty {
+            snapshot.reloadItems(reloadedItems)
+        }
         if !reconfiguredItems.isEmpty {
             snapshot.reconfigureItems(reconfiguredItems)
         }
@@ -480,6 +511,23 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
             self.publishVisibleItems()
             self.publishScrollMetrics()
         }
+    }
+
+    private func resolveNativeCellUsage(
+        for sections: [FireListSectionModel<SectionID, ItemID>]
+    ) -> [ItemID: Bool] {
+        guard let shouldUseNativeCell else {
+            return [:]
+        }
+
+        var nativeCellUsage: [ItemID: Bool] = [:]
+        nativeCellUsage.reserveCapacity(sections.reduce(0) { $0 + $1.items.count })
+        for section in sections {
+            for item in section.items {
+                nativeCellUsage[item] = shouldUseNativeCell(item)
+            }
+        }
+        return nativeCellUsage
     }
 
     private func applyPendingSectionUpdateIfNeeded() {

--- a/native/ios-app/App/ListKit/FireDiffableListController.swift
+++ b/native/ios-app/App/ListKit/FireDiffableListController.swift
@@ -112,12 +112,15 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
     UICollectionViewDataSourcePrefetching
 {
     private var rowContent: (ItemID) -> RowContent
+    private var shouldUseNativeCell: ((ItemID) -> Bool)?
+    private var nativeCellProvider: ((UICollectionView, IndexPath, ItemID) -> UICollectionViewCell?)?
     private let onSelectItem: ((ItemID) -> Void)?
     private let canSelectItem: ((ItemID) -> Bool)?
     private let onVisibleItemsChanged: (([ItemID]) -> Void)?
     private let onPrefetchItems: (([ItemID]) -> Void)?
     private let onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)?
     private let onRefresh: (() async -> Void)?
+    private var onContentWidthChanged: ((CGFloat) -> Void)?
     private let scrollAnchorRestorePolicy: FireCollectionScrollAnchorRestorePolicy
     private let updatePolicy: FireCollectionUpdatePolicy
     private var onScrollRequestCompleted: ((ItemID) -> Void)?
@@ -130,10 +133,12 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
 
     private var collectionView: UICollectionView?
     private var dataSource: UICollectionViewDiffableDataSource<SectionID, ItemID>?
+    private var hostedCellRegistration: UICollectionView.CellRegistration<UICollectionViewListCell, ItemID>?
     private var currentSections: [FireListSectionModel<SectionID, ItemID>] = []
     private var currentItemContentTokens: [ItemID: AnyHashable] = [:]
     private var lastVisibleItemIDs: [ItemID] = []
     private var lastScrollMetrics: FireCollectionScrollMetrics?
+    private var lastContentWidth: CGFloat?
     private var isRefreshing = false
     // Set when `endRefreshing()` starts the refresh control's retraction animation,
     // and cleared once the scroll view finishes the post-rebound deceleration (or a
@@ -146,6 +151,7 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
     private var handledScrollRequestID: AnyHashable?
     private var animatingScrollRequest: FireCollectionScrollRequest<ItemID>?
     private var pendingSectionUpdate: FirePendingSectionUpdate<SectionID, ItemID>?
+    private var didRegisterNativeCell = false
 
     init(
         layout: UICollectionViewLayout,
@@ -159,10 +165,13 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
         onPrefetchItems: (([ItemID]) -> Void)? = nil,
         onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)? = nil,
         onRefresh: (() async -> Void)? = nil,
+        onContentWidthChanged: ((CGFloat) -> Void)? = nil,
         scrollAnchorRestorePolicy: FireCollectionScrollAnchorRestorePolicy = .whenNotAnimatingDifferences,
         updatePolicy: FireCollectionUpdatePolicy = .applyImmediately,
         scrollRequest: FireCollectionScrollRequest<ItemID>? = nil,
         onScrollRequestCompleted: ((ItemID) -> Void)? = nil,
+        shouldUseNativeCell: ((ItemID) -> Bool)? = nil,
+        nativeCellProvider: ((UICollectionView, IndexPath, ItemID) -> UICollectionViewCell?)? = nil,
         rowContent: @escaping (ItemID) -> RowContent
     ) {
         self.listLayout = layout
@@ -176,10 +185,13 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
         self.onPrefetchItems = onPrefetchItems
         self.onScrollMetricsChanged = onScrollMetricsChanged
         self.onRefresh = onRefresh
+        self.onContentWidthChanged = onContentWidthChanged
         self.scrollAnchorRestorePolicy = scrollAnchorRestorePolicy
         self.updatePolicy = updatePolicy
         self.scrollRequest = scrollRequest
         self.onScrollRequestCompleted = onScrollRequestCompleted
+        self.shouldUseNativeCell = shouldUseNativeCell
+        self.nativeCellProvider = nativeCellProvider
         self.rowContent = rowContent
         super.init(nibName: nil, bundle: nil)
     }
@@ -202,6 +214,23 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
         view = collectionView
     }
 
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        publishContentWidthChangeIfNeeded()
+    }
+
+    private func publishContentWidthChangeIfNeeded() {
+        guard let collectionView else { return }
+        let width = collectionView.bounds.width
+            - collectionView.adjustedContentInset.left
+            - collectionView.adjustedContentInset.right
+        guard width > 0, width != lastContentWidth else {
+            return
+        }
+        lastContentWidth = width
+        onContentWidthChanged?(width)
+    }
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -218,7 +247,7 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
             collectionView.refreshControl = refreshControl
         }
 
-        let registration = UICollectionView.CellRegistration<UICollectionViewListCell, ItemID> {
+        let hostedReg = UICollectionView.CellRegistration<UICollectionViewListCell, ItemID> {
             [weak self] cell, _, itemID in
             guard let self else { return }
             cell.backgroundConfiguration = UIBackgroundConfiguration.clear()
@@ -227,14 +256,28 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
             }
             .margins(.all, 0)
         }
+        hostedCellRegistration = hostedReg
+
+        ensureNativeCellRegisteredIfNeeded()
 
         dataSource = UICollectionViewDiffableDataSource<SectionID, ItemID>(
             collectionView: collectionView
-        ) { collectionView, indexPath, itemID in
-            collectionView.dequeueConfiguredReusableCell(
-                using: registration,
-                for: indexPath,
-                item: itemID
+        ) { [weak self] collectionView, indexPath, itemID in
+            guard let self else {
+                return collectionView.dequeueConfiguredReusableCell(
+                    using: hostedReg, for: indexPath, item: itemID
+                )
+            }
+
+            if let shouldUseNativeCell = self.shouldUseNativeCell,
+               shouldUseNativeCell(itemID),
+               let nativeCellProvider = self.nativeCellProvider,
+               let nativeCell = nativeCellProvider(collectionView, indexPath, itemID) {
+                return nativeCell
+            }
+
+            return collectionView.dequeueConfiguredReusableCell(
+                using: hostedReg, for: indexPath, item: itemID
             )
         }
     }
@@ -255,6 +298,33 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
 
     func updateRowContent(_ rowContent: @escaping (ItemID) -> RowContent) {
         self.rowContent = rowContent
+    }
+
+    func updateNativeCellRouting(
+        shouldUseNativeCell: ((ItemID) -> Bool)?,
+        nativeCellProvider: ((UICollectionView, IndexPath, ItemID) -> UICollectionViewCell?)?
+    ) {
+        self.shouldUseNativeCell = shouldUseNativeCell
+        self.nativeCellProvider = nativeCellProvider
+        ensureNativeCellRegisteredIfNeeded()
+    }
+
+    private func ensureNativeCellRegisteredIfNeeded() {
+        guard !didRegisterNativeCell,
+              shouldUseNativeCell != nil || nativeCellProvider != nil,
+              let collectionView else {
+            return
+        }
+
+        collectionView.register(
+            FirePostCollectionViewCell.self,
+            forCellWithReuseIdentifier: FirePostCollectionViewCell.reuseID
+        )
+        didRegisterNativeCell = true
+    }
+
+    func updateOnContentWidthChanged(_ handler: ((CGFloat) -> Void)?) {
+        self.onContentWidthChanged = handler
     }
 
     func updateAppearance(

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostCellLayout.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostCellLayout.swift
@@ -1,0 +1,71 @@
+import Foundation
+import UIKit
+
+struct FirePostLayoutTraitSignature: Hashable, Sendable {
+    let contentWidthPixels: Int
+    let contentSizeCategory: String
+}
+
+struct FirePostCellLayoutKey: Hashable, Sendable {
+    let postID: UInt64
+    let depth: Int
+    let showsThreadLine: Bool
+    let showsDivider: Bool
+    let replyTargetPostNumber: UInt32?
+    let replyContext: String?
+    let textContentID: String
+    let imageSignature: [String]
+    let pollSignature: [UInt64]
+    let hasReactions: Bool
+    let acceptedAnswer: Bool
+    let trait: FirePostLayoutTraitSignature
+}
+
+struct FirePostCellLayout: Equatable, Sendable {
+    let key: FirePostCellLayoutKey
+    let totalHeight: CGFloat
+    let avatarFrame: CGRect
+    let threadLineFrame: CGRect?
+    let metaFrame: CGRect
+    let textFrame: CGRect?
+    let textContainerSize: CGSize
+    let imageFrames: [CGRect]
+    let reactionsFrame: CGRect?
+    let menuFrame: CGRect?
+    let dividerFrame: CGRect?
+}
+
+struct FirePostCellRenderPayload {
+    let post: TopicPostState
+    let renderContent: FireTopicPostRenderContent
+    let baseURLString: String
+    let canWriteInteractions: Bool
+    let isMutating: Bool
+    let replyContext: String?
+    let replyTargetPostNumber: UInt32?
+    let showsDivider: Bool
+}
+
+struct FirePostCellCallbacks {
+    let onLinkTapped: (URL) -> Void
+    let onOpenImage: (FireCookedImage) -> Void
+    let onToggleLike: (TopicPostState) -> Void
+    let onSelectReaction: (TopicPostState, String) -> Void
+    let onEditPost: (TopicPostState) -> Void
+    let onBookmarkPost: (TopicPostState) -> Void
+    let onDeletePost: (TopicPostState) -> Void
+    let onRecoverPost: (TopicPostState) -> Void
+    let onFlagPost: (TopicPostState) -> Void
+    let onOpenReplyTarget: (UInt32) -> Void
+    let onOpenReplies: (TopicPostState) -> Void
+    let onVotePoll: (TopicPostState, PollState, [String]) -> Void
+    let onUnvotePoll: (TopicPostState, PollState) -> Void
+    let onSwipeReply: (TopicPostState) -> Void
+}
+
+enum FireReplyCellMode {
+    case native
+    case hostedPoll
+    case hostedPlaceholder
+    case hostedLayoutMiss
+}

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostCellLayoutCalculator.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostCellLayoutCalculator.swift
@@ -88,7 +88,7 @@ enum FirePostCellLayoutCalculator {
         }
 
         // Meta line
-        let metaHeight: CGFloat = 18
+        let metaHeight: CGFloat = 20
         let metaFrame = CGRect(
             x: contentLeading,
             y: cursorY,

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostCellLayoutCalculator.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostCellLayoutCalculator.swift
@@ -1,0 +1,236 @@
+import Foundation
+import UIKit
+
+enum FirePostCellLayoutCalculator {
+    static let maxVisualDepth = 3
+    static let outerHorizontalPadding: CGFloat = 16
+    static let indentWidthPerDepth: CGFloat = 20
+    static let avatarSizeRoot: CGFloat = 32
+    static let avatarSizeNested: CGFloat = 26
+    static let avatarSpacingRoot: CGFloat = 10
+    static let avatarSpacingNested: CGFloat = 6
+    static let avatarThreadLineTopPadding: CGFloat = 6
+    static let threadLineWidth: CGFloat = 1
+    static let metaLineSpacing: CGFloat = 8
+    static let textTopSpacing: CGFloat = 0
+    static let imageTopSpacing: CGFloat = 10
+    static let imageSpacing: CGFloat = 10
+    static let reactionTopSpacing: CGFloat = 0
+    static let contentVerticalPadding: CGFloat = 8
+    static let menuButtonSize: CGFloat = 20
+    static let dividerHeight: CGFloat = 0.5
+
+    static func visualDepth(for depth: Int) -> Int {
+        max(depth - 1, 0)
+    }
+
+    static func indentWidth(for depth: Int) -> CGFloat {
+        CGFloat(min(visualDepth(for: depth), maxVisualDepth)) * indentWidthPerDepth
+    }
+
+    static func avatarSize(for depth: Int) -> CGFloat {
+        visualDepth(for: depth) > 0 ? avatarSizeNested : avatarSizeRoot
+    }
+
+    static func avatarSpacing(for depth: Int) -> CGFloat {
+        visualDepth(for: depth) > 0 ? avatarSpacingNested : avatarSpacingRoot
+    }
+
+    static func availableContentWidth(
+        for key: FirePostCellLayoutKey,
+        trait: FirePostLayoutTraitSignature
+    ) -> CGFloat {
+        let contentWidth = CGFloat(trait.contentWidthPixels)
+        let contentLeading = outerHorizontalPadding
+            + indentWidth(for: key.depth)
+            + avatarSize(for: key.depth)
+            + avatarSpacing(for: key.depth)
+        let contentTrailing = outerHorizontalPadding
+        return max(contentWidth - contentLeading - contentTrailing, 1)
+    }
+
+    static func calculate(
+        key: FirePostCellLayoutKey,
+        textHeight: CGFloat?,
+        imageHeights: [CGFloat],
+        trait: FirePostLayoutTraitSignature
+    ) -> FirePostCellLayout {
+        let indent = indentWidth(for: key.depth)
+        let avatarSz = avatarSize(for: key.depth)
+        let avatarSp = avatarSpacing(for: key.depth)
+        let contentWidth = CGFloat(trait.contentWidthPixels)
+
+        let contentLeading = outerHorizontalPadding + indent + avatarSz + avatarSp
+        let contentTrailing = outerHorizontalPadding
+        let contentAvailableWidth = max(contentWidth - contentLeading - contentTrailing, 1)
+
+        var cursorY = contentVerticalPadding
+
+        // Avatar frame
+        let avatarFrame = CGRect(
+            x: outerHorizontalPadding + indent,
+            y: 0,
+            width: avatarSz,
+            height: avatarSz
+        )
+
+        // Thread line frame
+        let threadLineFrame: CGRect?
+        if key.showsThreadLine {
+            threadLineFrame = CGRect(
+                x: outerHorizontalPadding + indent + avatarSz / 2 - threadLineWidth / 2,
+                y: avatarFrame.maxY + avatarThreadLineTopPadding,
+                width: threadLineWidth,
+                height: 0
+            )
+        } else {
+            threadLineFrame = nil
+        }
+
+        // Meta line
+        let metaHeight: CGFloat = 18
+        let metaFrame = CGRect(
+            x: contentLeading,
+            y: cursorY,
+            width: contentAvailableWidth,
+            height: metaHeight
+        )
+        cursorY += metaHeight + metaLineSpacing
+
+        // Text frame
+        let textFrame: CGRect?
+        let textContainerSize: CGSize
+        if let textHeight, textHeight > 0 {
+            textContainerSize = CGSize(width: contentAvailableWidth, height: textHeight)
+            textFrame = CGRect(
+                x: contentLeading,
+                y: cursorY,
+                width: contentAvailableWidth,
+                height: textHeight
+            )
+            cursorY += textHeight + textTopSpacing
+        } else {
+            textFrame = nil
+            textContainerSize = .zero
+        }
+
+        // Image frames
+        var imageFrames: [CGRect] = []
+        for (index, imageHeight) in imageHeights.enumerated() {
+            if index == 0 {
+                if textFrame != nil {
+                    cursorY += metaLineSpacing
+                }
+            } else {
+                cursorY += imageSpacing
+            }
+            let frame = CGRect(
+                x: contentLeading,
+                y: cursorY,
+                width: contentAvailableWidth,
+                height: imageHeight
+            )
+            imageFrames.append(frame)
+            cursorY += imageHeight
+        }
+
+        // Reactions frame
+        let reactionsFrame: CGRect?
+        if key.hasReactions {
+            if textFrame != nil || !imageFrames.isEmpty {
+                cursorY += metaLineSpacing
+            }
+            let reactionHeight: CGFloat = 32
+            reactionsFrame = CGRect(
+                x: contentLeading,
+                y: cursorY,
+                width: contentAvailableWidth,
+                height: reactionHeight
+            )
+            cursorY += reactionHeight
+        } else {
+            reactionsFrame = nil
+        }
+
+        let contentBottom = cursorY + contentVerticalPadding
+        var totalHeight = max(contentBottom, avatarFrame.maxY)
+
+        // Divider frame
+        let dividerFrame: CGRect?
+        if key.showsDivider {
+            dividerFrame = CGRect(
+                x: outerHorizontalPadding,
+                y: totalHeight,
+                width: max(contentWidth - outerHorizontalPadding * 2, 1),
+                height: dividerHeight
+            )
+            totalHeight += dividerHeight
+        } else {
+            dividerFrame = nil
+        }
+
+        // Update thread line height now that we know total height
+        var resolvedThreadLineFrame = threadLineFrame
+        if let tlFrame = threadLineFrame {
+            resolvedThreadLineFrame = CGRect(
+                x: tlFrame.minX,
+                y: tlFrame.minY,
+                width: tlFrame.width,
+                height: totalHeight - tlFrame.minY
+            )
+        }
+
+        return FirePostCellLayout(
+            key: key,
+            totalHeight: totalHeight,
+            avatarFrame: avatarFrame,
+            threadLineFrame: resolvedThreadLineFrame,
+            metaFrame: metaFrame,
+            textFrame: textFrame,
+            textContainerSize: textContainerSize,
+            imageFrames: imageFrames,
+            reactionsFrame: reactionsFrame,
+            menuFrame: nil,
+            dividerFrame: dividerFrame
+        )
+    }
+
+    static func measureRichTextHeight(
+        attributedText: NSAttributedString?,
+        containerWidth: CGFloat,
+        contentSizeCategory: UIContentSizeCategory
+    ) -> CGFloat? {
+        guard let attributedText, attributedText.length > 0 else {
+            return nil
+        }
+
+        let width = max(containerWidth, 1)
+        let textStorage = NSTextStorage(attributedString: attributedText)
+        let textContainer = NSTextContainer(size: CGSize(width: width, height: .greatestFiniteMagnitude))
+        textContainer.lineFragmentPadding = 0
+        let layoutManager = NSLayoutManager()
+        layoutManager.addTextContainer(textContainer)
+        textStorage.addLayoutManager(layoutManager)
+
+        if attributedText.attribute(.font, at: 0, effectiveRange: nil) == nil {
+            let scaledFont = UIFont.preferredFont(
+                forTextStyle: .subheadline,
+                compatibleWith: UITraitCollection(preferredContentSizeCategory: contentSizeCategory)
+            )
+            textStorage.addAttribute(
+                .font,
+                value: scaledFont,
+                range: NSRange(location: 0, length: textStorage.length)
+            )
+        }
+
+        layoutManager.ensureLayout(for: textContainer)
+        let rect = layoutManager.usedRect(for: textContainer)
+        return ceil(rect.height)
+    }
+
+    static func imageHeight(for image: FireCookedImage, availableWidth: CGFloat) -> CGFloat {
+        let aspectRatio = image.aspectRatio ?? 1.45
+        return availableWidth / aspectRatio
+    }
+}

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift
@@ -9,6 +9,18 @@ final class FirePostCollectionViewCell: UICollectionViewCell, UIGestureRecognize
     private static let replySwipeTriggerThreshold: CGFloat = 55
     private static let replySwipeMaxOffset: CGFloat = 75
     private static let replyIndicatorSize = CGSize(width: 32, height: 32)
+    private static let accentTextColor = UIColor { traits in
+        if traits.userInterfaceStyle == .dark {
+            return UIColor(red: 0.96, green: 0.45, blue: 0.22, alpha: 1)
+        }
+        return UIColor(red: 0.91, green: 0.39, blue: 0.18, alpha: 1)
+    }
+    private static let tertiaryInkColor = UIColor { traits in
+        if traits.userInterfaceStyle == .dark {
+            return UIColor(red: 0.62, green: 0.63, blue: 0.67, alpha: 1)
+        }
+        return UIColor(red: 0.52, green: 0.52, blue: 0.55, alpha: 1)
+    }
 
     // MARK: - Subviews
 
@@ -17,7 +29,7 @@ final class FirePostCollectionViewCell: UICollectionViewCell, UIGestureRecognize
     private let avatarContainerView = UIView()
     private let threadLineView = UIView()
     private let usernameLabel = UILabel()
-    private let replyContextButton = UIButton(type: .system)
+    private let replyContextButton = UIButton(type: .custom)
     private let timestampLabel = UILabel()
     private let acceptedAnswerLabel = UILabel()
     private let postNumberLabel = UILabel()
@@ -88,17 +100,19 @@ final class FirePostCollectionViewCell: UICollectionViewCell, UIGestureRecognize
         // Meta line
         usernameLabel.textColor = .label
         usernameLabel.adjustsFontForContentSizeCategory = true
+        usernameLabel.numberOfLines = 1
+        usernameLabel.lineBreakMode = .byTruncatingTail
+        usernameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         usernameLabel.setContentHuggingPriority(.required, for: .horizontal)
 
-        var replyContextConfiguration = UIButton.Configuration.plain()
-        replyContextConfiguration.contentInsets = .zero
-        replyContextConfiguration.baseForegroundColor = .systemBlue
-        replyContextButton.configuration = replyContextConfiguration
         replyContextButton.isHidden = true
         replyContextButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        replyContextButton.titleLabel?.numberOfLines = 1
+        replyContextButton.titleLabel?.lineBreakMode = .byTruncatingTail
         replyContextButton.contentHorizontalAlignment = .leading
         replyContextButton.contentVerticalAlignment = .center
         replyContextButton.backgroundColor = .clear
+        replyContextButton.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         replyContextButton.setContentHuggingPriority(.required, for: .horizontal)
 
         timestampLabel.textColor = .tertiaryLabel
@@ -178,10 +192,11 @@ final class FirePostCollectionViewCell: UICollectionViewCell, UIGestureRecognize
             for: UIFont.systemFont(ofSize: subheadlinePointSize, weight: .semibold)
         )
 
-        let captionPointSize = UIFont.preferredFont(forTextStyle: .caption2).pointSize
-        replyContextButton.titleLabel?.font = UIFontMetrics(forTextStyle: .caption2).scaledFont(
-            for: UIFont.systemFont(ofSize: captionPointSize, weight: .medium)
+        replyContextButton.titleLabel?.font = UIFontMetrics(forTextStyle: .subheadline).scaledFont(
+            for: UIFont.systemFont(ofSize: subheadlinePointSize, weight: .medium)
         )
+
+        let captionPointSize = UIFont.preferredFont(forTextStyle: .caption2).pointSize
         timestampLabel.font = UIFont.preferredFont(forTextStyle: .caption2)
         acceptedAnswerLabel.font = UIFontMetrics(forTextStyle: .caption2).scaledFont(
             for: UIFont.systemFont(ofSize: captionPointSize, weight: .medium)
@@ -196,8 +211,11 @@ final class FirePostCollectionViewCell: UICollectionViewCell, UIGestureRecognize
         contentView.backgroundColor = .systemBackground
         threadLineView.backgroundColor = .separator
         dividerView.backgroundColor = .separator
-        replyContextButton.tintColor = .systemBlue
-        menuButton.tintColor = .tertiaryLabel
+        replyContextButton.setTitleColor(Self.accentTextColor, for: .normal)
+        replyContextButton.tintColor = Self.accentTextColor
+        timestampLabel.textColor = Self.tertiaryInkColor
+        postNumberLabel.textColor = Self.tertiaryInkColor
+        menuButton.tintColor = Self.tertiaryInkColor
         replyIndicatorView.tintColor = replyTriggered ? .systemBlue : .tertiaryLabel
     }
 

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift
@@ -1,0 +1,788 @@
+import UIKit
+
+final class FirePostCollectionViewCell: UICollectionViewCell, UIGestureRecognizerDelegate {
+    static let reuseID = "FirePostCollectionViewCell"
+
+    private static let replyContextActionID = UIAction.Identifier(
+        "FirePostCollectionViewCell.replyContext"
+    )
+    private static let replySwipeTriggerThreshold: CGFloat = 55
+    private static let replySwipeMaxOffset: CGFloat = 75
+    private static let replyIndicatorSize = CGSize(width: 32, height: 32)
+
+    // MARK: - Subviews
+
+    private let avatarImageView = UIImageView()
+    private let avatarMonogramView = UILabel()
+    private let avatarContainerView = UIView()
+    private let threadLineView = UIView()
+    private let usernameLabel = UILabel()
+    private let replyContextButton = UIButton(type: .system)
+    private let timestampLabel = UILabel()
+    private let acceptedAnswerLabel = UILabel()
+    private let postNumberLabel = UILabel()
+    private let menuButton = UIButton(type: .system)
+    private let metaStack = UIStackView()
+    private let richTextContainer = FirePostRichTextContainerView()
+    private let imageContainerView = UIView()
+    private let reactionScrollView = UIScrollView()
+    private let reactionStack = UIStackView()
+    private let dividerView = UIView()
+    private let replyIndicatorView = UIImageView(image: UIImage(systemName: "arrowshape.turn.up.left.fill"))
+
+    // MARK: - State
+
+    private var currentLayout: FirePostCellLayout?
+    private var currentPayload: FirePostCellRenderPayload?
+    private var currentCallbacks: FirePostCellCallbacks?
+    private var imageViews: [UIImageView] = []
+    private var imageTasks: [String: Task<Void, Never>] = [:]
+    private var avatarTask: Task<Void, Never>?
+    private var emojiLoadTasks: [String: Task<Void, Never>] = [:]
+    private var swipeOffset: CGFloat = 0
+    private var replyTriggered = false
+    private lazy var swipeGestureRecognizer: UIPanGestureRecognizer = {
+        let gestureRecognizer = UIPanGestureRecognizer(target: self, action: #selector(handleSwipePan(_:)))
+        gestureRecognizer.delegate = self
+        return gestureRecognizer
+    }()
+
+    // MARK: - Init
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupSubviews()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Setup
+
+    private func setupSubviews() {
+        clipsToBounds = true
+        contentView.backgroundColor = .systemBackground
+        backgroundView = UIView(frame: .zero)
+        backgroundView?.backgroundColor = .clear
+        replyIndicatorView.contentMode = .center
+        replyIndicatorView.alpha = 0
+        backgroundView?.addSubview(replyIndicatorView)
+        contentView.addGestureRecognizer(swipeGestureRecognizer)
+
+        // Avatar
+        avatarContainerView.addSubview(avatarImageView)
+        avatarContainerView.addSubview(avatarMonogramView)
+        avatarContainerView.isHidden = true
+        avatarImageView.contentMode = .scaleAspectFill
+        avatarImageView.clipsToBounds = true
+        avatarMonogramView.textAlignment = .center
+        avatarMonogramView.textColor = .white
+        avatarMonogramView.adjustsFontForContentSizeCategory = true
+
+        // Thread line
+        threadLineView.backgroundColor = .separator
+        threadLineView.isHidden = true
+
+        // Meta line
+        usernameLabel.textColor = .label
+        usernameLabel.adjustsFontForContentSizeCategory = true
+        usernameLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        replyContextButton.isHidden = true
+        replyContextButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        replyContextButton.setContentHuggingPriority(.required, for: .horizontal)
+
+        timestampLabel.textColor = .tertiaryLabel
+        timestampLabel.adjustsFontForContentSizeCategory = true
+        timestampLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        acceptedAnswerLabel.textColor = .systemGreen
+        acceptedAnswerLabel.adjustsFontForContentSizeCategory = true
+        acceptedAnswerLabel.isHidden = true
+        acceptedAnswerLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        postNumberLabel.textColor = .tertiaryLabel
+        postNumberLabel.adjustsFontForContentSizeCategory = true
+        postNumberLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        menuButton.setImage(UIImage(systemName: "ellipsis"), for: .normal)
+        menuButton.tintColor = .tertiaryLabel
+        menuButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .caption1)
+        menuButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        menuButton.isHidden = true
+        menuButton.showsMenuAsPrimaryAction = true
+        menuButton.setContentHuggingPriority(.required, for: .horizontal)
+        menuButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        menuButton.accessibilityLabel = "帖子操作"
+
+        metaStack.axis = .horizontal
+        metaStack.alignment = .firstBaseline
+        metaStack.spacing = 6
+        metaStack.addArrangedSubview(usernameLabel)
+        metaStack.addArrangedSubview(replyContextButton)
+        metaStack.addArrangedSubview(timestampLabel)
+        metaStack.addArrangedSubview(UIView())
+        metaStack.addArrangedSubview(acceptedAnswerLabel)
+        metaStack.addArrangedSubview(postNumberLabel)
+        metaStack.addArrangedSubview(menuButton)
+
+        // Rich text
+        richTextContainer.isHidden = true
+
+        // Images
+        imageContainerView.isHidden = true
+
+        // Reactions
+        reactionScrollView.showsHorizontalScrollIndicator = false
+        reactionScrollView.isHidden = true
+        reactionStack.axis = .horizontal
+        reactionStack.spacing = 8
+        reactionStack.translatesAutoresizingMaskIntoConstraints = false
+        reactionScrollView.addSubview(reactionStack)
+        NSLayoutConstraint.activate([
+            reactionStack.leadingAnchor.constraint(equalTo: reactionScrollView.contentLayoutGuide.leadingAnchor),
+            reactionStack.trailingAnchor.constraint(equalTo: reactionScrollView.contentLayoutGuide.trailingAnchor),
+            reactionStack.topAnchor.constraint(equalTo: reactionScrollView.contentLayoutGuide.topAnchor),
+            reactionStack.bottomAnchor.constraint(equalTo: reactionScrollView.contentLayoutGuide.bottomAnchor),
+            reactionStack.heightAnchor.constraint(equalTo: reactionScrollView.frameLayoutGuide.heightAnchor),
+        ])
+
+        // Divider
+        dividerView.backgroundColor = .separator
+        dividerView.isHidden = true
+
+        contentView.addSubview(avatarContainerView)
+        contentView.addSubview(threadLineView)
+        contentView.addSubview(metaStack)
+        contentView.addSubview(richTextContainer)
+        contentView.addSubview(imageContainerView)
+        contentView.addSubview(reactionScrollView)
+        contentView.addSubview(dividerView)
+
+        applyTypography()
+        applyColors()
+    }
+
+    private func applyTypography() {
+        let subheadlinePointSize = UIFont.preferredFont(forTextStyle: .subheadline).pointSize
+        usernameLabel.font = UIFontMetrics(forTextStyle: .subheadline).scaledFont(
+            for: UIFont.systemFont(ofSize: subheadlinePointSize, weight: .semibold)
+        )
+
+        let captionPointSize = UIFont.preferredFont(forTextStyle: .caption2).pointSize
+        replyContextButton.titleLabel?.font = UIFontMetrics(forTextStyle: .caption2).scaledFont(
+            for: UIFont.systemFont(ofSize: captionPointSize, weight: .medium)
+        )
+        timestampLabel.font = UIFont.preferredFont(forTextStyle: .caption2)
+        acceptedAnswerLabel.font = UIFontMetrics(forTextStyle: .caption2).scaledFont(
+            for: UIFont.systemFont(ofSize: captionPointSize, weight: .medium)
+        )
+        postNumberLabel.font = UIFontMetrics(forTextStyle: .caption2).scaledFont(
+            for: UIFont.monospacedDigitSystemFont(ofSize: captionPointSize, weight: .regular)
+        )
+        menuButton.titleLabel?.font = UIFont.preferredFont(forTextStyle: .caption1)
+    }
+
+    private func applyColors() {
+        contentView.backgroundColor = .systemBackground
+        threadLineView.backgroundColor = .separator
+        dividerView.backgroundColor = .separator
+        replyContextButton.tintColor = .systemBlue
+        menuButton.tintColor = .tertiaryLabel
+        replyIndicatorView.tintColor = replyTriggered ? .systemBlue : .tertiaryLabel
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        backgroundView?.frame = bounds
+        replyIndicatorView.frame = CGRect(
+            x: 4,
+            y: max((bounds.height - Self.replyIndicatorSize.height) / 2, 0),
+            width: Self.replyIndicatorSize.width,
+            height: Self.replyIndicatorSize.height
+        )
+    }
+
+    // MARK: - Bind
+
+    func bind(layout: FirePostCellLayout, payload: FirePostCellRenderPayload, callbacks: FirePostCellCallbacks) {
+        currentLayout = layout
+        currentPayload = payload
+        currentCallbacks = callbacks
+        resetSwipeState(animated: false)
+
+        let post = payload.post
+        let vd = FirePostCellLayoutCalculator.visualDepth(for: layout.key.depth)
+        let avatarSz = vd > 0 ? FirePostCellLayoutCalculator.avatarSizeNested : FirePostCellLayoutCalculator.avatarSizeRoot
+
+        // Avatar
+        avatarContainerView.frame = layout.avatarFrame
+        avatarContainerView.isHidden = false
+        avatarContainerView.layer.cornerRadius = avatarSz / 2
+        avatarContainerView.clipsToBounds = true
+
+        avatarImageView.frame = avatarContainerView.bounds
+        avatarMonogramView.frame = avatarContainerView.bounds
+        avatarMonogramView.font = .systemFont(ofSize: avatarSz * 0.36, weight: .bold)
+
+        loadAvatar(avatarTemplate: post.avatarTemplate, username: post.username, size: avatarSz, baseURLString: payload.baseURLString)
+
+        // Thread line
+        if let threadLineFrame = layout.threadLineFrame {
+            threadLineView.frame = threadLineFrame
+            threadLineView.isHidden = false
+        } else {
+            threadLineView.isHidden = true
+        }
+
+        // Meta
+        metaStack.frame = layout.metaFrame
+        usernameLabel.text = post.username.isEmpty ? "Unknown" : post.username
+        usernameLabel.accessibilityLabel = usernameLabel.text
+        replyContextButton.removeAction(identifiedBy: Self.replyContextActionID, for: .touchUpInside)
+
+        if let replyContext = payload.replyContext,
+           let targetPN = payload.replyTargetPostNumber, targetPN > 0 {
+            replyContextButton.setTitle(replyContext, for: .normal)
+            replyContextButton.isHidden = false
+            replyContextButton.accessibilityLabel = replyContext
+            replyContextButton.addAction(UIAction(identifier: Self.replyContextActionID) { [weak self] _ in
+                guard let self, let callbacks = self.currentCallbacks else { return }
+                callbacks.onOpenReplyTarget(targetPN)
+            }, for: .touchUpInside)
+        } else {
+            replyContextButton.setTitle(nil, for: .normal)
+            replyContextButton.isHidden = true
+            replyContextButton.accessibilityLabel = nil
+        }
+
+        timestampLabel.text = FireTopicPresentation.compactTimestamp(post.createdAt)
+        timestampLabel.accessibilityLabel = timestampLabel.text
+        acceptedAnswerLabel.isHidden = !post.acceptedAnswer
+        acceptedAnswerLabel.text = nil
+        if post.acceptedAnswer {
+            acceptedAnswerLabel.text = "✓ 已采纳"
+            acceptedAnswerLabel.accessibilityLabel = "已采纳"
+        } else {
+            acceptedAnswerLabel.accessibilityLabel = nil
+        }
+        postNumberLabel.text = "#\(post.postNumber)"
+        postNumberLabel.accessibilityLabel = "楼层 #\(post.postNumber)"
+
+        // Menu
+        let canShowMenu = post.canEdit
+            || (payload.canWriteInteractions && !post.hidden)
+            || post.canRecover
+            || (post.canDelete && !post.hidden)
+        menuButton.isHidden = !canShowMenu
+        if canShowMenu {
+            menuButton.menu = buildMenu(for: post, callbacks: callbacks, canWrite: payload.canWriteInteractions, isMutating: payload.isMutating)
+        } else {
+            menuButton.menu = nil
+        }
+
+        // Rich text
+        if let textFrame = layout.textFrame, let attrText = payload.renderContent.attributedText, attrText.length > 0 {
+            richTextContainer.isHidden = false
+            richTextContainer.frame = textFrame
+            let contentID = "post:\(post.id)|hash:\(post.cooked.hashValue)|images:\(payload.renderContent.imageAttachments.count)"
+            richTextContainer.configure(
+                attributedText: attrText,
+                contentID: contentID,
+                containerSize: layout.textContainerSize
+            )
+            richTextContainer.onLinkTapped = { [weak self] url in
+                guard let self, let callbacks = self.currentCallbacks else { return }
+                callbacks.onLinkTapped(url)
+            }
+            richTextContainer.accessibilityLabel = payload.renderContent.plainText
+        } else {
+            richTextContainer.isHidden = true
+            richTextContainer.resetContent()
+            richTextContainer.accessibilityLabel = nil
+        }
+
+        // Images
+        let images = payload.renderContent.imageAttachments
+        if images.isEmpty || layout.imageFrames.isEmpty {
+            imageContainerView.isHidden = true
+            imageContainerView.frame = .zero
+        } else {
+            let imageContainerFrame = unionFrame(for: layout.imageFrames)
+            imageContainerView.isHidden = false
+            imageContainerView.frame = imageContainerFrame
+            rebuildImageViews(images: images, frames: layout.imageFrames, containerFrame: imageContainerFrame)
+        }
+
+        // Reactions
+        if let reactionsFrame = layout.reactionsFrame, !post.reactions.isEmpty {
+            reactionScrollView.isHidden = false
+            reactionScrollView.frame = reactionsFrame
+            reactionScrollView.contentOffset = .zero
+            rebuildReactionCapsules(post: post, callbacks: callbacks, canWrite: payload.canWriteInteractions, isMutating: payload.isMutating)
+        } else {
+            reactionScrollView.isHidden = true
+            clearReactionCapsules()
+        }
+
+        // Divider
+        if let dividerFrame = layout.dividerFrame, payload.showsDivider {
+            dividerView.frame = dividerFrame
+            dividerView.isHidden = false
+        } else {
+            dividerView.isHidden = true
+        }
+    }
+
+    // MARK: - Reuse
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        currentLayout = nil
+        currentPayload = nil
+        currentCallbacks = nil
+        resetSwipeState(animated: false)
+
+        avatarTask?.cancel()
+        avatarTask = nil
+        avatarImageView.image = nil
+        avatarMonogramView.text = nil
+        avatarContainerView.isHidden = true
+        avatarContainerView.frame = .zero
+        threadLineView.isHidden = true
+        threadLineView.frame = .zero
+
+        usernameLabel.text = nil
+        usernameLabel.accessibilityLabel = nil
+        replyContextButton.removeAction(identifiedBy: Self.replyContextActionID, for: .touchUpInside)
+        replyContextButton.setTitle(nil, for: .normal)
+        replyContextButton.isHidden = true
+        replyContextButton.accessibilityLabel = nil
+        timestampLabel.text = nil
+        timestampLabel.accessibilityLabel = nil
+        acceptedAnswerLabel.isHidden = true
+        acceptedAnswerLabel.text = nil
+        acceptedAnswerLabel.accessibilityLabel = nil
+        postNumberLabel.text = nil
+        postNumberLabel.accessibilityLabel = nil
+        menuButton.isHidden = true
+        menuButton.menu = nil
+
+        richTextContainer.isHidden = true
+        richTextContainer.resetContent()
+        richTextContainer.onLinkTapped = nil
+        richTextContainer.accessibilityLabel = nil
+
+        cancelImageTasks()
+        emojiLoadTasks.values.forEach { $0.cancel() }
+        emojiLoadTasks.removeAll()
+        imageViews.forEach { $0.removeFromSuperview() }
+        imageViews = []
+        imageContainerView.isHidden = true
+        imageContainerView.frame = .zero
+
+        reactionScrollView.isHidden = true
+        reactionScrollView.contentOffset = .zero
+        clearReactionCapsules()
+
+        dividerView.isHidden = true
+        dividerView.frame = .zero
+        applyColors()
+    }
+
+    override func preferredLayoutAttributesFitting(_ layoutAttributes: UICollectionViewLayoutAttributes) -> UICollectionViewLayoutAttributes {
+        if let layout = currentLayout {
+            layoutAttributes.frame.size.height = layout.totalHeight
+        }
+        return layoutAttributes
+    }
+
+    // MARK: - Avatar Loading
+
+    private func loadAvatar(avatarTemplate: String?, username: String, size: CGFloat, baseURLString: String) {
+        avatarTask?.cancel()
+        avatarTask = nil
+
+        let monogram = monogramForUsername(username: username.isEmpty ? "?" : username)
+        avatarMonogramView.text = monogram
+        avatarMonogramView.isHidden = false
+        avatarImageView.isHidden = true
+        avatarContainerView.backgroundColor = .systemBlue
+
+        guard let avatarURL = fireAvatarURL(
+            avatarTemplate: avatarTemplate,
+            size: size,
+            scale: UIScreen.main.scale,
+            baseURLString: baseURLString
+        ) else {
+            return
+        }
+
+        let request = FireRemoteImageRequest(url: avatarURL)
+
+        if let cached = FireRemoteImagePipeline.shared.cachedImage(for: request) {
+            applyAvatarImage(cached)
+            return
+        }
+
+        avatarTask = Task { [weak self] in
+            do {
+                let image = try await FireRemoteImagePipeline.shared.loadImage(for: request)
+                guard !Task.isCancelled else { return }
+                _ = await MainActor.run {
+                    self?.applyAvatarImage(image)
+                }
+            } catch {
+                // Keep monogram fallback
+            }
+        }
+    }
+
+    private func applyAvatarImage(_ image: UIImage) {
+        avatarImageView.image = image
+        avatarImageView.isHidden = false
+        avatarMonogramView.isHidden = true
+    }
+
+    // MARK: - Image Loading
+
+    private func rebuildImageViews(
+        images: [FireCookedImage],
+        frames: [CGRect],
+        containerFrame: CGRect
+    ) {
+        cancelImageTasks()
+        imageViews.forEach { $0.removeFromSuperview() }
+        imageViews = []
+
+        for (index, image) in images.enumerated() {
+            guard index < frames.count else { break }
+            let imageView = UIImageView()
+            imageView.contentMode = .scaleAspectFit
+            imageView.clipsToBounds = true
+            imageView.layer.cornerRadius = 16
+            imageView.layer.borderColor = UIColor.separator.cgColor
+            imageView.layer.borderWidth = 0.5
+            imageView.frame = CGRect(
+                x: frames[index].minX - containerFrame.minX,
+                y: frames[index].minY - containerFrame.minY,
+                width: frames[index].width,
+                height: frames[index].height
+            )
+            imageView.backgroundColor = .tertiarySystemFill
+            imageView.isUserInteractionEnabled = true
+            imageView.tag = index
+            imageView.isAccessibilityElement = true
+            imageView.accessibilityTraits = [.image, .button]
+            let altText = image.altText?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            imageView.accessibilityLabel = altText.isEmpty ? "帖子图片" : altText
+
+            let tapGesture = UITapGestureRecognizer(target: self, action: #selector(handleImageTap(_:)))
+            imageView.addGestureRecognizer(tapGesture)
+
+            imageContainerView.addSubview(imageView)
+            imageViews.append(imageView)
+
+            loadImage(into: imageView, url: image.url, cacheKey: image.id)
+        }
+    }
+
+    private func loadImage(into imageView: UIImageView, url: URL, cacheKey: String) {
+        let request = FireRemoteImageRequest(url: url)
+        if let cached = FireRemoteImagePipeline.shared.cachedImage(for: request) {
+            imageView.image = cached
+            imageView.backgroundColor = .clear
+            return
+        }
+
+        imageTasks[cacheKey] = Task { [weak self] in
+            do {
+                let image = try await FireRemoteImagePipeline.shared.loadImage(for: request)
+                guard !Task.isCancelled else { return }
+                _ = await MainActor.run {
+                    imageView.image = image
+                    imageView.backgroundColor = .clear
+                    self?.imageTasks.removeValue(forKey: cacheKey)
+                }
+            } catch {
+                _ = await MainActor.run {
+                    self?.imageTasks.removeValue(forKey: cacheKey)
+                }
+            }
+        }
+    }
+
+    private func cancelImageTasks() {
+        imageTasks.values.forEach { $0.cancel() }
+        imageTasks.removeAll()
+    }
+
+    @objc
+    private func handleImageTap(_ gestureRecognizer: UITapGestureRecognizer) {
+        guard let imageView = gestureRecognizer.view as? UIImageView,
+              let payload = currentPayload,
+              imageView.tag >= 0,
+              imageView.tag < payload.renderContent.imageAttachments.count,
+              let callbacks = currentCallbacks else {
+            return
+        }
+
+        callbacks.onOpenImage(payload.renderContent.imageAttachments[imageView.tag])
+    }
+
+    // MARK: - Menu
+
+    private func buildMenu(for post: TopicPostState, callbacks: FirePostCellCallbacks, canWrite: Bool, isMutating: Bool) -> UIMenu {
+        var actions: [UIMenu] = []
+
+        if post.canEdit {
+            let edit = UIAction(title: "编辑", image: UIImage(systemName: "pencil")) { [weak self] _ in
+                guard self != nil else { return }
+                callbacks.onEditPost(post)
+            }
+            edit.attributes = isMutating ? .disabled : []
+            actions.append(UIMenu(options: .displayInline, children: [edit]))
+        }
+
+        var interactionActions: [UIAction] = []
+        if canWrite && !post.hidden {
+            let bookmarkTitle = post.bookmarked ? "编辑书签" : "添加书签"
+            let bookmarkIcon = post.bookmarked ? "bookmark.fill" : "bookmark"
+            let bookmark = UIAction(title: bookmarkTitle, image: UIImage(systemName: bookmarkIcon)) { _ in
+                callbacks.onBookmarkPost(post)
+            }
+            bookmark.attributes = isMutating ? .disabled : []
+            interactionActions.append(bookmark)
+
+            let flag = UIAction(title: "举报", image: UIImage(systemName: "flag")) { _ in
+                callbacks.onFlagPost(post)
+            }
+            flag.attributes = isMutating ? .disabled : []
+            interactionActions.append(flag)
+        }
+
+        if post.canRecover {
+            let recover = UIAction(title: "恢复", image: UIImage(systemName: "arrow.uturn.backward")) { _ in
+                callbacks.onRecoverPost(post)
+            }
+            recover.attributes = isMutating ? .disabled : []
+            interactionActions.append(recover)
+        }
+
+        if post.canDelete && !post.hidden {
+            let delete = UIAction(title: "删除", image: UIImage(systemName: "trash"), attributes: .destructive) { _ in
+                callbacks.onDeletePost(post)
+            }
+            delete.attributes = isMutating ? [.disabled, .destructive] : .destructive
+            interactionActions.append(delete)
+        }
+
+        if !interactionActions.isEmpty {
+            actions.append(UIMenu(options: .displayInline, children: interactionActions))
+        }
+
+        return UIMenu(children: actions)
+    }
+
+    // MARK: - Reactions
+
+    private func rebuildReactionCapsules(post: TopicPostState, callbacks: FirePostCellCallbacks, canWrite: Bool, isMutating: Bool) {
+        clearReactionCapsules()
+        let canChangeReaction = canWrite && !isMutating && (post.currentUserReaction?.canUndo ?? true)
+
+        for reaction in post.reactions {
+            let option = FireTopicPresentation.reactionOption(for: reaction.id)
+            let isMine = post.currentUserReaction?.id == reaction.id
+
+            let button = UIButton(type: .system)
+            let symbolString = option.symbol
+            let countString = "\(reaction.count)"
+            let title = "\(symbolString) \(countString)"
+            button.setTitle(title, for: .normal)
+
+            let fontSize: CGFloat = 14
+            let font = UIFont.systemFont(ofSize: fontSize, weight: isMine ? .semibold : .regular)
+            button.titleLabel?.font = font
+            button.titleLabel?.adjustsFontForContentSizeCategory = true
+
+            if isMine {
+                button.setTitleColor(.systemBlue, for: .normal)
+                button.backgroundColor = UIColor.systemBlue.withAlphaComponent(0.18)
+                button.layer.borderWidth = 1
+                button.layer.borderColor = UIColor.systemBlue.withAlphaComponent(0.85).cgColor
+            } else {
+                button.setTitleColor(.secondaryLabel, for: .normal)
+                button.backgroundColor = .tertiarySystemFill
+                button.layer.borderWidth = 0
+            }
+
+            button.layer.cornerRadius = 14
+            button.layer.masksToBounds = true
+            var configuration = UIButton.Configuration.plain()
+            configuration.contentInsets = NSDirectionalEdgeInsets(top: 6, leading: 10, bottom: 6, trailing: 10)
+            button.configuration = configuration
+            button.setContentCompressionResistancePriority(.required, for: .horizontal)
+            button.setContentHuggingPriority(.required, for: .horizontal)
+
+            button.isAccessibilityElement = true
+            button.accessibilityLabel = "\(option.label) \(reaction.count)"
+            if isMine {
+                button.accessibilityTraits.insert(.selected)
+            }
+
+            let reactionID = reaction.id
+            button.addAction(UIAction { [weak self] _ in
+                guard self != nil else { return }
+                if reactionID == "heart" {
+                    callbacks.onToggleLike(post)
+                } else {
+                    callbacks.onSelectReaction(post, reactionID)
+                }
+            }, for: .touchUpInside)
+            button.isEnabled = canChangeReaction
+
+            reactionStack.addArrangedSubview(button)
+        }
+    }
+
+    private func clearReactionCapsules() {
+        for arrangedSubview in reactionStack.arrangedSubviews {
+            reactionStack.removeArrangedSubview(arrangedSubview)
+            arrangedSubview.removeFromSuperview()
+        }
+    }
+
+    // MARK: - Swipe to Reply
+
+    override func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        guard gestureRecognizer === swipeGestureRecognizer,
+              currentPayload?.canWriteInteractions == true,
+              let panGestureRecognizer = gestureRecognizer as? UIPanGestureRecognizer else {
+            return false
+        }
+
+        let startLocation = panGestureRecognizer.location(in: self)
+        let velocity = panGestureRecognizer.velocity(in: self)
+        let resolvedAxis = FireTopicReplySwipePolicy.resolvedAxis(
+            startLocationX: startLocation.x,
+            translationWidth: velocity.x,
+            translationHeight: velocity.y
+        )
+        return resolvedAxis == .horizontal && velocity.x > 0
+    }
+
+    @objc
+    private func handleSwipePan(_ gestureRecognizer: UIPanGestureRecognizer) {
+        guard currentPayload?.canWriteInteractions == true else {
+            resetSwipeState(animated: true)
+            return
+        }
+
+        switch gestureRecognizer.state {
+        case .began, .changed:
+            let translation = gestureRecognizer.translation(in: self)
+            let horizontalOffset = max(translation.x, 0)
+            let dampenedOffset: CGFloat
+            if horizontalOffset > Self.replySwipeTriggerThreshold {
+                dampenedOffset = Self.replySwipeTriggerThreshold
+                    + (horizontalOffset - Self.replySwipeTriggerThreshold) * 0.25
+            } else {
+                dampenedOffset = horizontalOffset
+            }
+
+            let resolvedOffset = min(dampenedOffset, Self.replySwipeMaxOffset)
+            applySwipeOffset(resolvedOffset)
+
+            let shouldTriggerReply = resolvedOffset >= Self.replySwipeTriggerThreshold
+            if shouldTriggerReply && !replyTriggered {
+                replyTriggered = true
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            } else if !shouldTriggerReply {
+                replyTriggered = false
+            }
+            updateReplyIndicatorAppearance()
+
+        case .ended:
+            let shouldTriggerReply = replyTriggered
+            let post = currentPayload?.post
+            let callbacks = currentCallbacks
+            resetSwipeState(animated: true)
+            if shouldTriggerReply, let post, let callbacks {
+                callbacks.onSwipeReply(post)
+            }
+
+        case .cancelled, .failed:
+            resetSwipeState(animated: true)
+
+        default:
+            break
+        }
+    }
+
+    private func applySwipeOffset(_ offset: CGFloat) {
+        swipeOffset = offset
+        contentView.transform = CGAffineTransform(translationX: offset, y: 0)
+        updateReplyIndicatorAppearance()
+    }
+
+    private func resetSwipeState(animated: Bool) {
+        let updates = {
+            self.swipeOffset = 0
+            self.replyTriggered = false
+            self.contentView.transform = .identity
+            self.updateReplyIndicatorAppearance()
+        }
+
+        if animated {
+            UIView.animate(
+                withDuration: 0.22,
+                delay: 0,
+                usingSpringWithDamping: 0.78,
+                initialSpringVelocity: 0,
+                options: [.beginFromCurrentState, .allowUserInteraction],
+                animations: updates
+            )
+        } else {
+            updates()
+        }
+    }
+
+    private func updateReplyIndicatorAppearance() {
+        guard swipeOffset > 4 else {
+            replyIndicatorView.alpha = 0
+            replyIndicatorView.transform = .identity
+            applyColors()
+            return
+        }
+
+        let progress = min(swipeOffset / Self.replySwipeTriggerThreshold, 1)
+        replyIndicatorView.alpha = Double(
+            min(swipeOffset / (Self.replySwipeTriggerThreshold * 0.5), 1)
+        )
+        replyIndicatorView.transform = CGAffineTransform(scaleX: max(progress, 0.01), y: max(progress, 0.01))
+        applyColors()
+    }
+
+    private func unionFrame(for frames: [CGRect]) -> CGRect {
+        guard let firstFrame = frames.first else {
+            return .zero
+        }
+
+        return frames.dropFirst().reduce(firstFrame) { partialResult, frame in
+            partialResult.union(frame)
+        }
+    }
+
+    // MARK: - Trait Changes
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+        if previousTraitCollection?.preferredContentSizeCategory != traitCollection.preferredContentSizeCategory {
+            applyTypography()
+        }
+        applyColors()
+    }
+}

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostCollectionViewCell.swift
@@ -90,8 +90,15 @@ final class FirePostCollectionViewCell: UICollectionViewCell, UIGestureRecognize
         usernameLabel.adjustsFontForContentSizeCategory = true
         usernameLabel.setContentHuggingPriority(.required, for: .horizontal)
 
+        var replyContextConfiguration = UIButton.Configuration.plain()
+        replyContextConfiguration.contentInsets = .zero
+        replyContextConfiguration.baseForegroundColor = .systemBlue
+        replyContextButton.configuration = replyContextConfiguration
         replyContextButton.isHidden = true
         replyContextButton.titleLabel?.adjustsFontForContentSizeCategory = true
+        replyContextButton.contentHorizontalAlignment = .leading
+        replyContextButton.contentVerticalAlignment = .center
+        replyContextButton.backgroundColor = .clear
         replyContextButton.setContentHuggingPriority(.required, for: .horizontal)
 
         timestampLabel.textColor = .tertiaryLabel
@@ -118,7 +125,7 @@ final class FirePostCollectionViewCell: UICollectionViewCell, UIGestureRecognize
         menuButton.accessibilityLabel = "帖子操作"
 
         metaStack.axis = .horizontal
-        metaStack.alignment = .firstBaseline
+        metaStack.alignment = .center
         metaStack.spacing = 6
         metaStack.addArrangedSubview(usernameLabel)
         metaStack.addArrangedSubview(replyContextButton)

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostLayoutManager.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostLayoutManager.swift
@@ -1,0 +1,170 @@
+import Foundation
+import SwiftUI
+import UIKit
+
+enum FirePostLayoutInvalidationReason {
+    case widthChanged
+    case contentSizeCategoryChanged
+    case contentChanged
+}
+
+typealias FirePostLayoutComputation = @Sendable (
+    FirePostCellLayoutKey,
+    NSAttributedString?,
+    [FireCookedImage],
+    FirePostLayoutTraitSignature
+) -> FirePostCellLayout
+
+private final class FireAttributedTextBox: @unchecked Sendable {
+    let value: NSAttributedString?
+
+    init(_ value: NSAttributedString?) {
+        self.value = value
+    }
+}
+
+@MainActor
+final class FirePostLayoutManager: ObservableObject {
+    private var layoutCache: [FirePostCellLayoutKey: FirePostCellLayout] = [:]
+    @Published private var snapshotRevision: UInt64 = 0
+    private let backgroundQueue: DispatchQueue
+    private let computeLayout: FirePostLayoutComputation
+    private var inFlightKeys: Set<FirePostCellLayoutKey> = []
+    private var publicationTask: Task<Void, Never>?
+    private var generation: UInt64 = 0
+    private var lastTraitSignature: FirePostLayoutTraitSignature?
+
+    var currentSnapshotRevision: UInt64 {
+        snapshotRevision
+    }
+
+    init(
+        backgroundQueue: DispatchQueue = DispatchQueue(
+            label: "com.fire.post-layout-manager",
+            qos: .userInitiated
+        ),
+        computeLayout: @escaping FirePostLayoutComputation = { key, attributedText, images, trait in
+            FirePostLayoutManager.defaultComputeLayout(
+                key: key,
+                attributedText: attributedText,
+                images: images,
+                trait: trait
+            )
+        }
+    ) {
+        self.backgroundQueue = backgroundQueue
+        self.computeLayout = computeLayout
+    }
+
+    func cachedLayout(forKey key: FirePostCellLayoutKey) -> FirePostCellLayout? {
+        layoutCache[key]
+    }
+
+    func layout(forKey key: FirePostCellLayoutKey) -> FirePostCellLayout? {
+        layoutCache[key]
+    }
+
+    func enqueueCalculation(
+        key: FirePostCellLayoutKey,
+        attributedText: NSAttributedString?,
+        images: [FireCookedImage],
+        trait: FirePostLayoutTraitSignature
+    ) {
+        if layoutCache[key] != nil || inFlightKeys.contains(key) {
+            return
+        }
+
+        inFlightKeys.insert(key)
+        let generation = self.generation
+        let queue = backgroundQueue
+        let computeLayout = self.computeLayout
+        let attributedTextBox = FireAttributedTextBox(attributedText?.copy() as? NSAttributedString)
+
+        queue.async { [weak self] in
+            let layout = computeLayout(key, attributedTextBox.value, images, trait)
+
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.inFlightKeys.remove(key)
+                guard generation == self.generation else {
+                    return
+                }
+                guard self.layoutCache[key] == nil else {
+                    return
+                }
+                self.layoutCache[key] = layout
+                self.scheduleSnapshotPublication()
+            }
+        }
+    }
+
+    func invalidateAll(reason: FirePostLayoutInvalidationReason) {
+        generation &+= 1
+        layoutCache.removeAll()
+        inFlightKeys.removeAll()
+        publicationTask?.cancel()
+        publicationTask = nil
+        snapshotRevision &+= 1
+        lastTraitSignature = nil
+    }
+
+    func invalidateItems(keys: Set<FirePostCellLayoutKey>) {
+        guard !keys.isEmpty else { return }
+        for key in keys {
+            layoutCache.removeValue(forKey: key)
+            inFlightKeys.remove(key)
+        }
+        snapshotRevision &+= 1
+    }
+
+    func updateTraitSignature(_ signature: FirePostLayoutTraitSignature) {
+        if let lastTraitSignature, lastTraitSignature != signature {
+            invalidateAll(reason: signature.contentSizeCategory != lastTraitSignature.contentSizeCategory
+                ? .contentSizeCategoryChanged
+                : .widthChanged)
+        }
+        lastTraitSignature = signature
+    }
+
+    private func scheduleSnapshotPublication() {
+        guard publicationTask == nil else {
+            return
+        }
+
+        publicationTask = Task { [weak self] in
+            try? await Task.sleep(for: .milliseconds(50))
+            guard let self, !Task.isCancelled else { return }
+            self.publicationTask = nil
+            self.snapshotRevision &+= 1
+        }
+    }
+
+    nonisolated private static func defaultComputeLayout(
+        key: FirePostCellLayoutKey,
+        attributedText: NSAttributedString?,
+        images: [FireCookedImage],
+        trait: FirePostLayoutTraitSignature
+    ) -> FirePostCellLayout {
+        let contentSizeCategory = UIContentSizeCategory(rawValue: trait.contentSizeCategory)
+        let availableWidth = FirePostCellLayoutCalculator.availableContentWidth(
+            for: key,
+            trait: trait
+        )
+
+        let textHeight = FirePostCellLayoutCalculator.measureRichTextHeight(
+            attributedText: attributedText,
+            containerWidth: availableWidth,
+            contentSizeCategory: contentSizeCategory
+        )
+        let imageHeights = images.map { image in
+            FirePostCellLayoutCalculator.imageHeight(for: image, availableWidth: availableWidth)
+        }
+
+        return FirePostCellLayoutCalculator.calculate(
+            key: key,
+            textHeight: textHeight,
+            imageHeights: imageHeights,
+            trait: trait
+        )
+    }
+}

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostRichTextContainerView.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostRichTextContainerView.swift
@@ -1,0 +1,81 @@
+import UIKit
+
+final class FirePostRichTextContainerView: UIView {
+    private let textView = FireRichTextUIView()
+    private var linkDelegate: RichTextLinkDelegate?
+
+    var onLinkTapped: ((URL) -> Void)?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupSubviews()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func setupSubviews() {
+        textView.isEditable = false
+        textView.isScrollEnabled = false
+        textView.textContainerInset = .zero
+        textView.textContainer.lineFragmentPadding = 0
+        textView.backgroundColor = .clear
+        textView.linkTextAttributes = [
+            .foregroundColor: UIColor.systemBlue,
+            .underlineStyle: NSUnderlineStyle.single.rawValue,
+        ]
+        textView.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        textView.setContentHuggingPriority(.defaultHigh, for: .vertical)
+
+        linkDelegate = RichTextLinkDelegate(handler: { [weak self] url in
+            self?.onLinkTapped?(url)
+        })
+        textView.delegate = linkDelegate
+
+        addSubview(textView)
+    }
+
+    func configure(
+        attributedText: NSAttributedString,
+        contentID: String,
+        containerSize: CGSize
+    ) {
+        if textView.renderedContentID != contentID {
+            textView.renderedContentID = contentID
+            textView.attributedText = attributedText
+        }
+        textView.frame = CGRect(origin: .zero, size: CGSize(width: containerSize.width, height: containerSize.height))
+        textView.invalidateIntrinsicContentSize()
+    }
+
+    func resetContent() {
+        textView.renderedContentID = nil
+        textView.attributedText = NSAttributedString(string: "")
+        textView.invalidateIntrinsicContentSize()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        textView.frame = bounds
+    }
+}
+
+private final class RichTextLinkDelegate: NSObject, UITextViewDelegate {
+    private let handler: (URL) -> Void
+
+    init(handler: @escaping (URL) -> Void) {
+        self.handler = handler
+    }
+
+    func textView(
+        _ textView: UITextView,
+        shouldInteractWith url: URL,
+        in characterRange: NSRange,
+        interaction: UITextItemInteraction
+    ) -> Bool {
+        handler(url)
+        return false
+    }
+}

--- a/native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift
@@ -422,6 +422,10 @@ struct FireTopicDetailCollectionView: View {
             }
             let row = replyRows[index]
             let post = postLookup[row.entry.postId]
+            let mode = replyCellMode(
+                for: key,
+                replyIndexByPostID: replyIndexByPostID
+            )
             let token = Self.replyRowToken(
                 row: row,
                 post: post,
@@ -429,7 +433,7 @@ struct FireTopicDetailCollectionView: View {
                 showsThreadLine: showsTimelineThreadLine(in: replyRows, at: index),
                 isMutating: post.map { isMutatingPost($0.id) } ?? false
             )
-            return AnyHashable("\(token)|\(canWriteInteractions)")
+            return AnyHashable("\(token)|mode:\(String(reflecting: mode))|\(canWriteInteractions)")
         case .replyFooter:
             return AnyHashable([
                 String(reflecting: replyFooterState),

--- a/native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FireTopicDetailCollectionView.swift
@@ -73,10 +73,13 @@ private struct FireTopicDetailCollectionContentVersion: Hashable {
     let topicCollectionRevision: UInt64
     let canWriteInteractions: Bool
     let baseURLString: String
+    let replyLayoutSnapshotRevision: UInt64
 }
 
 struct FireTopicDetailCollectionView: View {
     @Environment(\.colorScheme) private var colorScheme
+    @StateObject private var layoutManager = FirePostLayoutManager()
+    @State private var contentWidth: CGFloat?
 
     let viewModel: FireAppViewModel
     let row: FireTopicRowPresentation
@@ -288,7 +291,8 @@ struct FireTopicDetailCollectionView: View {
             topicID: topic.id,
             topicCollectionRevision: topicCollectionRevision,
             canWriteInteractions: canWriteInteractions,
-            baseURLString: baseURLString
+            baseURLString: baseURLString,
+            replyLayoutSnapshotRevision: layoutManager.currentSnapshotRevision
         )
     }
 
@@ -466,14 +470,27 @@ struct FireTopicDetailCollectionView: View {
             onVisibleItemsChanged: handleVisibleItemsChanged(_:),
             onPrefetchItems: handlePrefetchItems(_:),
             onRefresh: onRefresh,
+            onContentWidthChanged: handleContentWidthChanged(_:),
             updatePolicy: .deferWhileScrolling,
             scrollRequest: scrollRequest,
             onScrollRequestCompleted: handleScrollRequestCompleted(_:),
+            shouldUseNativeCell: { item in
+                shouldUseNativeCell(for: item, replyIndexByPostID: replyIndexByPostID)
+            },
+            nativeCellProvider: { collectionView, indexPath, item in
+                nativeCellProvider(collectionView: collectionView, indexPath: indexPath, item: item, replyIndexByPostID: replyIndexByPostID)
+            },
             makeLayout: Self.makeLayout,
             rowContent: { item in
                 rowView(for: item, replyIndexByPostID: replyIndexByPostID)
             }
         )
+        .onChange(of: topicCollectionRevision) { _, _ in
+            enqueueLayoutsForAllReplies()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UIContentSizeCategory.didChangeNotification)) { _ in
+            handleContentSizeCategoryChanged()
+        }
     }
 
     private func makeReplyIndexByPostID() -> [UInt64: Int] {
@@ -505,6 +522,266 @@ struct FireTopicDetailCollectionView: View {
         )
         guard !postNumbers.isEmpty else { return }
         onPreloadTopicPosts(postNumbers)
+
+        // Enqueue layout calculation for prefetched reply items
+        let replyIndexByPostID = makeReplyIndexByPostID()
+        for item in items {
+            guard case let .reply(key) = item,
+                  let index = replyIndexByPostID[key.postID],
+                  index < replyRows.count,
+                  let post = postLookup[key.postID],
+                  let renderContent = renderState?.contentByPostID[key.postID] else {
+                continue
+            }
+            enqueueLayoutIfNeeded(
+                post: post,
+                renderContent: renderContent,
+                replyRow: replyRows[index],
+                replyIndex: index
+            )
+        }
+    }
+
+    private func handleContentWidthChanged(_ width: CGFloat) {
+        if contentWidth != width {
+            contentWidth = width
+            let newTrait = makeTraitSignature(for: width)
+            layoutManager.updateTraitSignature(newTrait)
+            enqueueLayoutsForAllReplies()
+        }
+    }
+
+    private func handleContentSizeCategoryChanged() {
+        guard let contentWidth else {
+            return
+        }
+
+        let trait = makeTraitSignature(for: contentWidth)
+        layoutManager.updateTraitSignature(trait)
+        enqueueLayoutsForAllReplies()
+    }
+
+    private func makeTraitSignature(for width: CGFloat) -> FirePostLayoutTraitSignature {
+        FirePostLayoutTraitSignature(
+            contentWidthPixels: Int(width.rounded()),
+            contentSizeCategory: UIApplication.shared.preferredContentSizeCategory.rawValue
+        )
+    }
+
+    private func shouldUseNativeCell(
+        for item: FireTopicDetailCollectionItem,
+        replyIndexByPostID: [UInt64: Int]
+    ) -> Bool {
+        guard case let .reply(key) = item else {
+            return false
+        }
+
+        guard let index = replyIndexByPostID[key.postID],
+              index < replyRows.count,
+              postLookup[key.postID] != nil else {
+            return false
+        }
+
+        let mode = replyCellMode(
+            for: key,
+            replyIndexByPostID: replyIndexByPostID
+        )
+
+        switch mode {
+        case .native:
+            return true
+        case .hostedPoll, .hostedPlaceholder, .hostedLayoutMiss:
+            return false
+        }
+    }
+
+    private func replyCellMode(
+        for key: FireTopicDetailCollectionReplyKey,
+        replyIndexByPostID: [UInt64: Int]
+    ) -> FireReplyCellMode {
+        guard let index = replyIndexByPostID[key.postID],
+              index < replyRows.count else {
+            return .hostedPlaceholder
+        }
+
+        guard let post = postLookup[key.postID] else {
+            return .hostedPlaceholder
+        }
+
+        if !post.polls.isEmpty {
+            return .hostedPoll
+        }
+
+        guard let layoutKey = makeLayoutKey(
+            post: post,
+            renderContent: renderState?.contentByPostID[post.id],
+            replyRow: replyRows[index],
+            replyIndex: index
+        ) else {
+            return .hostedLayoutMiss
+        }
+
+        if layoutManager.layout(forKey: layoutKey) != nil {
+            return .native
+        }
+
+        return .hostedLayoutMiss
+    }
+
+    private func nativeCellProvider(
+        collectionView: UICollectionView,
+        indexPath: IndexPath,
+        item: FireTopicDetailCollectionItem,
+        replyIndexByPostID: [UInt64: Int]
+    ) -> UICollectionViewCell? {
+        guard case let .reply(key) = item,
+              let index = replyIndexByPostID[key.postID],
+              index < replyRows.count,
+              let post = postLookup[key.postID] else {
+            return nil
+        }
+
+        let renderContent = renderState?.contentByPostID[post.id] ?? fallbackRenderContent(for: post)
+        guard let layoutKey = makeLayoutKey(
+            post: post,
+            renderContent: renderContent,
+            replyRow: replyRows[index],
+            replyIndex: index
+        ) else {
+            return nil
+        }
+
+        guard let layout = layoutManager.layout(forKey: layoutKey) else {
+            return nil
+        }
+
+        let cell = collectionView.dequeueReusableCell(
+            withReuseIdentifier: FirePostCollectionViewCell.reuseID,
+            for: indexPath
+        ) as? FirePostCollectionViewCell
+
+        guard let cell else { return nil }
+
+        let showsDivider = index != replyRows.count - 1
+        let payload = FirePostCellRenderPayload(
+            post: post,
+            renderContent: renderContent,
+            baseURLString: baseURLString,
+            canWriteInteractions: canWriteInteractions,
+            isMutating: isMutatingPost(post.id),
+            replyContext: Self.replyContextLabel(
+                for: post,
+                preferredPostNumber: replyRows[index].entry.parentPostNumber
+            ),
+            replyTargetPostNumber: Self.replyTargetPostNumber(
+                for: post,
+                preferredPostNumber: replyRows[index].entry.parentPostNumber
+            ),
+            showsDivider: showsDivider
+        )
+
+        let callbacks = FirePostCellCallbacks(
+            onLinkTapped: onLinkTapped,
+            onOpenImage: onOpenImage,
+            onToggleLike: onToggleLike,
+            onSelectReaction: onSelectReaction,
+            onEditPost: onEditPost,
+            onBookmarkPost: onBookmarkPost,
+            onDeletePost: onDeletePost,
+            onRecoverPost: onRecoverPost,
+            onFlagPost: onFlagPost,
+            onOpenReplyTarget: onOpenPostNumber,
+            onOpenReplies: onOpenPostReplies,
+            onVotePoll: onVotePoll,
+            onUnvotePoll: onUnvotePoll,
+            onSwipeReply: { post in
+                onOpenComposer(post)
+            }
+        )
+
+        cell.bind(layout: layout, payload: payload, callbacks: callbacks)
+        return cell
+    }
+
+    private func makeLayoutKey(
+        post: TopicPostState,
+        renderContent: FireTopicPostRenderContent?,
+        replyRow: FirePreparedTopicTimelineRow,
+        replyIndex: Int
+    ) -> FirePostCellLayoutKey? {
+        guard let contentWidth, contentWidth > 0 else {
+            return nil
+        }
+
+        let contentHash = post.cooked.hashValue
+        let textContentID = "post:\(post.id)|hash:\(contentHash)|images:\(renderContent?.imageAttachments.count ?? 0)"
+        let imageSignature = renderContent?.imageAttachments.map(\.id) ?? []
+        let hasReactions = !post.reactions.isEmpty
+        let showsDivider = replyIndex != replyRows.count - 1
+
+        let trait = makeTraitSignature(for: contentWidth)
+
+        return FirePostCellLayoutKey(
+            postID: post.id,
+            depth: Int(replyRow.entry.depth),
+            showsThreadLine: showsTimelineThreadLine(in: replyRows, at: replyIndex),
+            showsDivider: showsDivider,
+            replyTargetPostNumber: replyRow.entry.parentPostNumber,
+            replyContext: Self.replyContextLabel(
+                for: post,
+                preferredPostNumber: replyRow.entry.parentPostNumber
+            ),
+            textContentID: textContentID,
+            imageSignature: imageSignature,
+            pollSignature: post.polls.map { UInt64(bitPattern: Int64($0.name.hashValue)) },
+            hasReactions: hasReactions,
+            acceptedAnswer: post.acceptedAnswer,
+            trait: trait
+        )
+    }
+
+    private func enqueueLayoutIfNeeded(
+        post: TopicPostState,
+        renderContent: FireTopicPostRenderContent,
+        replyRow: FirePreparedTopicTimelineRow,
+        replyIndex: Int
+    ) {
+        guard post.polls.isEmpty,
+              let key = makeLayoutKey(
+            post: post,
+            renderContent: renderContent,
+            replyRow: replyRow,
+            replyIndex: replyIndex
+        ) else {
+            return
+        }
+
+        guard layoutManager.layout(forKey: key) == nil else {
+            return
+        }
+
+        let trait = key.trait
+        layoutManager.enqueueCalculation(
+            key: key,
+            attributedText: renderContent.attributedText,
+            images: renderContent.imageAttachments,
+            trait: trait
+        )
+    }
+
+    private func enqueueLayoutsForAllReplies() {
+        for (index, row) in replyRows.enumerated() {
+            guard let post = postLookup[row.entry.postId],
+                  let renderContent = renderState?.contentByPostID[row.entry.postId] else {
+                continue
+            }
+            enqueueLayoutIfNeeded(
+                post: post,
+                renderContent: renderContent,
+                replyRow: row,
+                replyIndex: index
+            )
+        }
     }
 
     private func handleScrollRequestCompleted(_ item: FireTopicDetailCollectionItem) {

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -26,6 +26,7 @@
 		26E51A13E796BFEF885FBD28 /* fire_uniffi_topics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDCE76B3F360C1C5631A950C /* fire_uniffi_topics.swift */; };
 		2C5CE663E30B00720A75CD0A /* FireProfileHeaderComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E8372AD9A5A2CC34FBD3AEF /* FireProfileHeaderComponents.swift */; };
 		3330A9C7E4C8BA80778F79EB /* FireAppRouteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 299683BEDEC559B03C136C34 /* FireAppRouteTests.swift */; };
+		33DC82E96FE6606F38CC0985 /* FirePostLayoutManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D51F8B61796434E964104F72 /* FirePostLayoutManagerTests.swift */; };
 		34DC539E6C32931D4743C75F /* FireBadgeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 467E95A2109D81DB456F64A9 /* FireBadgeDetailView.swift */; };
 		355451477523656402E506B8 /* FireExportDiagnosticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1127D7C4622ADFEED430046E /* FireExportDiagnosticsView.swift */; };
 		390219653B0C0A96C81D8962 /* FireAPMEventStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 373861687BBCD8EB8E350DA4 /* FireAPMEventStore.swift */; };
@@ -46,6 +47,7 @@
 		5E556FC12993F27449D2B973 /* FireAPMManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 129694A5F35FF78B3F810049 /* FireAPMManager.swift */; };
 		5E90D968B32A1D692D9351AC /* FireDeveloperToolsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1481ACDF04D249FF61B1D0DF /* FireDeveloperToolsView.swift */; };
 		5FA66113E53795C8DC6D0563 /* FireProfileActivityTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35E67F65FB748821001726D /* FireProfileActivityTimelineView.swift */; };
+		61DA3972E51BDCEEAEC6C654 /* FirePostCellLayoutCalculatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EF6B1D638EEA75C75B2B2D5 /* FirePostCellLayoutCalculatorTests.swift */; };
 		6A8BA8AACC4ED45E311894CE /* FireTopicDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67647993BFF688FB02B71DBB /* FireTopicDetailView.swift */; };
 		6A93EC6F3D79F51A9CB66A58 /* FireAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 300B5894E4B597FC94E645D3 /* FireAppDelegate.swift */; };
 		6CD842F82A4371F3BCCCF4C5 /* FireEntityIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 33FDDDCB91B973C1115A8F6B /* FireEntityIndex.swift */; };
@@ -55,6 +57,8 @@
 		73D15598C74EA2ABE6BCC1FA /* FirePresentationIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7218ECE4CE5CE67428ADD4DD /* FirePresentationIdentity.swift */; };
 		75AFEF785571E34FC9CAFC8B /* FireNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = CEBEB262C9A5B9B7348537B8 /* FireNavigationState.swift */; };
 		768DC62B26A1D2EF4F545D35 /* FireHomeFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7384EAE1C43817CAE71D9F /* FireHomeFeedStore.swift */; };
+		772EFD83C4DEB77EAC00FD55 /* FirePostCellLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B220305F1DFD0C508260CFA9 /* FirePostCellLayout.swift */; };
+		7848D667BF692B25B4194E57 /* FirePostCellLayoutCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E7CCCA8B867D5E6B0CE198 /* FirePostCellLayoutCalculator.swift */; };
 		790B44E436B0CF137B1FD8A7 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E69013450F80AEC210D5512D /* Security.framework */; };
 		792980AB2D2B5BF56221DF47 /* FireOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD9004CEFFCDDBE2E50D71B0 /* FireOnboardingView.swift */; };
 		795E7AB547CA854593A42D91 /* FireHomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E60D1F8BA725E4D60AFBA3 /* FireHomeView.swift */; };
@@ -67,6 +71,7 @@
 		8B8629DE49FD3256333B0CF4 /* FireFollowListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AA34E2414014BD28A7AF803 /* FireFollowListView.swift */; };
 		8D3E53867C1B21D940FB765A /* FireProfileActivityRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 292A9A11D19C39A02BC00B38 /* FireProfileActivityRow.swift */; };
 		8D77430DC1266A1EDEF3A6E4 /* FireAppViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFA66CA083BF4889AE258926 /* FireAppViewModel.swift */; };
+		8DBFF3B45C163E090C28C98B /* FirePostRichTextContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97E555B5E61F0CF3811D4091 /* FirePostRichTextContainerView.swift */; };
 		8F10E1B26BE2D5FC5F2D6C1B /* FireProfileStatsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6210541C2E8219CE500CFC04 /* FireProfileStatsRow.swift */; };
 		91BA9CDF0E86830FEB1951B0 /* FireAPMMainThreadStallMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20BDF82CCD1BF22BB3C7729 /* FireAPMMainThreadStallMonitor.swift */; };
 		91D663B17D38F3869A292938 /* FireStartupPreloadCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D652EEF09E7E34B609EE2C7 /* FireStartupPreloadCoordinator.swift */; };
@@ -82,6 +87,7 @@
 		99FA187F4F32B8EEC57C7B82 /* FireTopicDetailCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF05887B9D29B713F369C6FE /* FireTopicDetailCollectionView.swift */; };
 		9B0DABDC5BA87A4CAFF3232D /* FireEntityStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADC2ED47CF65AD5BE795908 /* FireEntityStateTests.swift */; };
 		9D5F82625F6960B6A6ED10B9 /* FireNotificationsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2A86A280EED500EF3126038 /* FireNotificationsView.swift */; };
+		9E7B9F6741C79AF8E6C3D0DA /* FirePostLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1B0239607F0ABAEA1ABCE0 /* FirePostLayoutManager.swift */; };
 		9F734046F02B45409AD5F1C6 /* FireTopicListMessageBusRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859219285EC36B189AF68256 /* FireTopicListMessageBusRefreshTests.swift */; };
 		A04B275253CDF8FAAC9D8C6C /* FireSearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FD219C2BFB0727FD0D3DD2 /* FireSearchStore.swift */; };
 		A07A9808A87A0F9C08F72CC3 /* FireAccountStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF475D56C78AFC82413AED55 /* FireAccountStatusView.swift */; };
@@ -91,6 +97,7 @@
 		A37D27214981E5D36E7DFD2C /* fire_uniffi_notifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF89DCFCD77D9F81CD8DB801 /* fire_uniffi_notifications.swift */; };
 		A7657EA99808CEBE3F038176 /* CrashReporter in Frameworks */ = {isa = PBXBuildFile; productRef = 601B450FB4E87A5243FAE5F9 /* CrashReporter */; };
 		ABCB88B6D78156FB353E922B /* FireDiagnosticsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2E4063863B8521F7719DD75F /* FireDiagnosticsViewModel.swift */; };
+		ABF118C17AF4A67C93403F08 /* FirePostCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC3867D2E0094A20CE393CD5 /* FirePostCollectionViewCell.swift */; };
 		AFA0A6BA1AC5282B233D218F /* FireRecipientTokenField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73775E8E299DC2577C64DC6E /* FireRecipientTokenField.swift */; };
 		B21E0A6B519EA414B836E4BE /* FireProfileTrustLevelPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = F02D3C136EFF0589DC131FB9 /* FireProfileTrustLevelPill.swift */; };
 		B4AA77D05D86AB070BE06A93 /* FireNotificationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 502CE714A74D91C33212BF57 /* FireNotificationStore.swift */; };
@@ -150,7 +157,9 @@
 		1481ACDF04D249FF61B1D0DF /* FireDeveloperToolsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDeveloperToolsView.swift; sourceTree = "<group>"; };
 		1800DA0F94ED3D7B3099DB89 /* fire_uniffi_diagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = fire_uniffi_diagnostics.swift; sourceTree = "<group>"; };
 		19F67B40FC02230AFEC2A562 /* FirePublicProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePublicProfileView.swift; sourceTree = "<group>"; };
+		1EF6B1D638EEA75C75B2B2D5 /* FirePostCellLayoutCalculatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePostCellLayoutCalculatorTests.swift; sourceTree = "<group>"; };
 		1FC1DB73221DE5E0CE4B0BB6 /* FireDiagnosticsShared.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDiagnosticsShared.swift; sourceTree = "<group>"; };
+		24E7CCCA8B867D5E6B0CE198 /* FirePostCellLayoutCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePostCellLayoutCalculator.swift; sourceTree = "<group>"; };
 		25FD219C2BFB0727FD0D3DD2 /* FireSearchStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSearchStore.swift; sourceTree = "<group>"; };
 		27F174773C4A2B3D0A4D29DD /* FireComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireComponents.swift; sourceTree = "<group>"; };
 		292A9A11D19C39A02BC00B38 /* FireProfileActivityRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileActivityRow.swift; sourceTree = "<group>"; };
@@ -195,12 +204,14 @@
 		8675E5DED6CD306553C88CFE /* FireCategoriesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireCategoriesView.swift; sourceTree = "<group>"; };
 		8834ADE6E3ADB8A03391560C /* FireSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSessionStore.swift; sourceTree = "<group>"; };
 		8A08AB12E53EB29136A0946A /* FireSearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSearchView.swift; sourceTree = "<group>"; };
+		8A1B0239607F0ABAEA1ABCE0 /* FirePostLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePostLayoutManager.swift; sourceTree = "<group>"; };
 		8FFC5F5EA7CD05C23FBEB9A2 /* FireTheme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTheme.swift; sourceTree = "<group>"; };
 		9189433D7C9260885742A5BA /* FireTopicPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicPresentationTests.swift; sourceTree = "<group>"; };
 		9267FBC4BA4FD365E6F4E371 /* FireTopicDetailStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailStore.swift; sourceTree = "<group>"; };
 		92A16F4854521A901D87D1DD /* FireTagPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTagPickerSheet.swift; sourceTree = "<group>"; };
 		92C90A87682AF244F048541F /* FireNetworkDiagnosticsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNetworkDiagnosticsView.swift; sourceTree = "<group>"; };
 		97B0FC401C941BC8F73B959A /* Fire-Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Fire-Release.xcconfig"; sourceTree = "<group>"; };
+		97E555B5E61F0CF3811D4091 /* FirePostRichTextContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePostRichTextContainerView.swift; sourceTree = "<group>"; };
 		97FFE2A260FE7B5682493795 /* FireNetworkTraceDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNetworkTraceDetailView.swift; sourceTree = "<group>"; };
 		996D95DE48DA65385BD587F7 /* FireApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireApp.swift; sourceTree = "<group>"; };
 		9AD6D7178B2622B10A5644E2 /* FireTopicTimingTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicTimingTracker.swift; sourceTree = "<group>"; };
@@ -215,10 +226,12 @@
 		AA736A1F443337C34A6E33D6 /* Fire.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Fire.entitlements; sourceTree = "<group>"; };
 		AE6087FA4E6DF2034C9E6D77 /* FireReadHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireReadHistoryView.swift; sourceTree = "<group>"; };
 		B17BF0CB4137B71949AACC0C /* FireSearchStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSearchStoreTests.swift; sourceTree = "<group>"; };
+		B220305F1DFD0C508260CFA9 /* FirePostCellLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePostCellLayout.swift; sourceTree = "<group>"; };
 		B5E5271F93B7DF18859B101F /* FireWebViewLoginCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWebViewLoginCoordinator.swift; sourceTree = "<group>"; };
 		BABD32407FB273553E9394B3 /* FireProfileBadgeChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileBadgeChip.swift; sourceTree = "<group>"; };
 		BADC2ED47CF65AD5BE795908 /* FireEntityStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireEntityStateTests.swift; sourceTree = "<group>"; };
 		BC115AA696CF29500E0027DD /* FireHomeCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireHomeCollectionView.swift; sourceTree = "<group>"; };
+		BC3867D2E0094A20CE393CD5 /* FirePostCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePostCollectionViewCell.swift; sourceTree = "<group>"; };
 		BF328A93631D56CB94E4FA7A /* FireAppRouteDestinationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppRouteDestinationView.swift; sourceTree = "<group>"; };
 		BFA66CA083BF4889AE258926 /* FireAppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppViewModel.swift; sourceTree = "<group>"; };
 		C20BDF82CCD1BF22BB3C7729 /* FireAPMMainThreadStallMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMMainThreadStallMonitor.swift; sourceTree = "<group>"; };
@@ -229,6 +242,7 @@
 		C810E3D0B2CF415495A3D5C4 /* FireFilteredTopicListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireFilteredTopicListView.swift; sourceTree = "<group>"; };
 		CEBEB262C9A5B9B7348537B8 /* FireNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNavigationState.swift; sourceTree = "<group>"; };
 		D35E67F65FB748821001726D /* FireProfileActivityTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileActivityTimelineView.swift; sourceTree = "<group>"; };
+		D51F8B61796434E964104F72 /* FirePostLayoutManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePostLayoutManagerTests.swift; sourceTree = "<group>"; };
 		DC90B1231DCA76399CB693E2 /* FireBookmarkEditorSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireBookmarkEditorSheet.swift; sourceTree = "<group>"; };
 		DD9004CEFFCDDBE2E50D71B0 /* FireOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireOnboardingView.swift; sourceTree = "<group>"; };
 		DDCE76B3F360C1C5631A950C /* fire_uniffi_topics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = fire_uniffi_topics.swift; sourceTree = "<group>"; };
@@ -442,6 +456,8 @@
 				A67A6C835A2196246871D5FD /* FireComposerValidationTests.swift */,
 				BADC2ED47CF65AD5BE795908 /* FireEntityStateTests.swift */,
 				0F45C6AFED397DB19D9A361E /* FireMessageBusCoordinatorTests.swift */,
+				1EF6B1D638EEA75C75B2B2D5 /* FirePostCellLayoutCalculatorTests.swift */,
+				D51F8B61796434E964104F72 /* FirePostLayoutManagerTests.swift */,
 				46C35F105D036EECAAE7B93D /* FireRouteParserTests.swift */,
 				B17BF0CB4137B71949AACC0C /* FireSearchStoreTests.swift */,
 				43F4BF80B28464550781CD36 /* FireSessionStoreTests.swift */,
@@ -456,6 +472,11 @@
 		91D55969C4FC26D4640483D4 /* TopicDetail */ = {
 			isa = PBXGroup;
 			children = (
+				B220305F1DFD0C508260CFA9 /* FirePostCellLayout.swift */,
+				24E7CCCA8B867D5E6B0CE198 /* FirePostCellLayoutCalculator.swift */,
+				BC3867D2E0094A20CE393CD5 /* FirePostCollectionViewCell.swift */,
+				8A1B0239607F0ABAEA1ABCE0 /* FirePostLayoutManager.swift */,
+				97E555B5E61F0CF3811D4091 /* FirePostRichTextContainerView.swift */,
 				FF05887B9D29B713F369C6FE /* FireTopicDetailCollectionView.swift */,
 			);
 			path = TopicDetail;
@@ -692,6 +713,8 @@
 				22D6B9CAC8373C14BBFA616A /* FireComposerValidationTests.swift in Sources */,
 				9B0DABDC5BA87A4CAFF3232D /* FireEntityStateTests.swift in Sources */,
 				E11AA63F28A66090E98C2C47 /* FireMessageBusCoordinatorTests.swift in Sources */,
+				61DA3972E51BDCEEAEC6C654 /* FirePostCellLayoutCalculatorTests.swift in Sources */,
+				33DC82E96FE6606F38CC0985 /* FirePostLayoutManagerTests.swift in Sources */,
 				4F0305B9162423D8D821A304 /* FireRouteParserTests.swift in Sources */,
 				2264C8107D1350906282A04E /* FireSearchStoreTests.swift in Sources */,
 				937A11B4C74174E2B823F917 /* FireSessionStoreTests.swift in Sources */,
@@ -757,7 +780,12 @@
 				9D5F82625F6960B6A6ED10B9 /* FireNotificationsView.swift in Sources */,
 				792980AB2D2B5BF56221DF47 /* FireOnboardingView.swift in Sources */,
 				4291E89FC3D5D35AC9A06898 /* FireOrderedIDList.swift in Sources */,
+				772EFD83C4DEB77EAC00FD55 /* FirePostCellLayout.swift in Sources */,
+				7848D667BF692B25B4194E57 /* FirePostCellLayoutCalculator.swift in Sources */,
+				ABF118C17AF4A67C93403F08 /* FirePostCollectionViewCell.swift in Sources */,
 				82D925C1A3A758CB7309295E /* FirePostEditorView.swift in Sources */,
+				9E7B9F6741C79AF8E6C3D0DA /* FirePostLayoutManager.swift in Sources */,
+				8DBFF3B45C163E090C28C98B /* FirePostRichTextContainerView.swift in Sources */,
 				73D15598C74EA2ABE6BCC1FA /* FirePresentationIdentity.swift in Sources */,
 				54170A08D034A622A66D5DBD /* FirePrivateMessagesView.swift in Sources */,
 				8D3E53867C1B21D940FB765A /* FireProfileActivityRow.swift in Sources */,

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 		46C35F105D036EECAAE7B93D /* FireRouteParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireRouteParserTests.swift; sourceTree = "<group>"; };
 		46CF09F1CBAC6CFAA0E9128A /* FireAppRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppRoute.swift; sourceTree = "<group>"; };
 		48A7EA25CD5ADF94676BE48E /* fire_uniffi_session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = fire_uniffi_session.swift; sourceTree = "<group>"; };
-		48CAB0E38556929FC140E25D /* Fire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fire.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		48CAB0E38556929FC140E25D /* Fire.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Fire.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		502CE714A74D91C33212BF57 /* FireNotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNotificationStore.swift; sourceTree = "<group>"; };
 		51431D8CC0EBCA6C0E79380C /* FireBackgroundNotificationAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireBackgroundNotificationAlert.swift; sourceTree = "<group>"; };
 		52BB1F5B0970DC2504ACD989 /* FirePushRegistrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePushRegistrationCoordinator.swift; sourceTree = "<group>"; };
@@ -623,6 +623,7 @@
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					87BF3D86E2CA36A3D645AA33 = {
+						DevelopmentTeam = "$(FIRE_DEVELOPMENT_TEAM)";
 						ProvisioningStyle = "$(FIRE_CODE_SIGN_STYLE)";
 					};
 				};
@@ -855,16 +856,30 @@
 				DEVELOPMENT_TEAM = "$(FIRE_DEVELOPMENT_TEAM)";
 				FIRE_GIT_SHA = "$(FIRE_GIT_SHA)";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = "com.fire.app.ios.notification-alert-refresh";
+				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = (
+					"com.fire.app.ios.notification-alert-refresh",
+				);
 				INFOPLIST_KEY_CFBundleDisplayName = "$(FIRE_DISPLAY_NAME)";
 				INFOPLIST_KEY_CFBundleURLTypes = "[[\"CFBundleURLSchemes\": [\"fire\"], \"CFBundleURLName\": \"fire\"]]";
 				INFOPLIST_KEY_FireGitSha = "$(FIRE_GIT_SHA)";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Fire 需要把你在帖子里查看的图片保存到相册。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIBackgroundModes = "fetch remote-notification";
+				INFOPLIST_KEY_UIBackgroundModes = (
+					fetch,
+					"remote-notification",
+				);
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = (
+					UIInterfaceOrientationPortrait,
+					UIInterfaceOrientationLandscapeLeft,
+					UIInterfaceOrientationLandscapeRight,
+				);
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = (
+					UIInterfaceOrientationPortrait,
+					UIInterfaceOrientationPortraitUpsideDown,
+					UIInterfaceOrientationLandscapeLeft,
+					UIInterfaceOrientationLandscapeRight,
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -883,7 +898,10 @@
 				PRODUCT_NAME = Fire;
 				PROVISIONING_PROFILE_SPECIFIER = "$(FIRE_PROVISIONING_PROFILE_SPECIFIER)";
 				SDKROOT = iphoneos;
-				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/Generated";
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Generated",
+				);
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -900,7 +918,10 @@
 					"@loader_path/Frameworks",
 				);
 				SDKROOT = iphoneos;
-				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/Generated";
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Generated",
+				);
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Fire.app/Fire";
 			};
@@ -918,7 +939,10 @@
 					"@loader_path/Frameworks",
 				);
 				SDKROOT = iphoneos;
-				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/Generated";
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Generated",
+				);
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Fire.app/Fire";
 			};
@@ -1050,19 +1074,33 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = "$(FIRE_CODE_SIGN_STYLE)";
 				CURRENT_PROJECT_VERSION = "$(FIRE_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = YHK2G6Y994;
+				DEVELOPMENT_TEAM = "$(FIRE_DEVELOPMENT_TEAM)";
 				FIRE_GIT_SHA = "$(FIRE_GIT_SHA)";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = "com.fire.app.ios.notification-alert-refresh";
+				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = (
+					"com.fire.app.ios.notification-alert-refresh",
+				);
 				INFOPLIST_KEY_CFBundleDisplayName = "$(FIRE_DISPLAY_NAME)";
 				INFOPLIST_KEY_CFBundleURLTypes = "[[\"CFBundleURLSchemes\": [\"fire\"], \"CFBundleURLName\": \"fire\"]]";
 				INFOPLIST_KEY_FireGitSha = "$(FIRE_GIT_SHA)";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Fire 需要把你在帖子里查看的图片保存到相册。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIBackgroundModes = "fetch remote-notification";
+				INFOPLIST_KEY_UIBackgroundModes = (
+					fetch,
+					"remote-notification",
+				);
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = (
+					UIInterfaceOrientationPortrait,
+					UIInterfaceOrientationLandscapeLeft,
+					UIInterfaceOrientationLandscapeRight,
+				);
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = (
+					UIInterfaceOrientationPortrait,
+					UIInterfaceOrientationPortraitUpsideDown,
+					UIInterfaceOrientationLandscapeLeft,
+					UIInterfaceOrientationLandscapeRight,
+				);
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1081,7 +1119,10 @@
 				PRODUCT_NAME = Fire;
 				PROVISIONING_PROFILE_SPECIFIER = "$(FIRE_PROVISIONING_PROFILE_SPECIFIER)";
 				SDKROOT = iphoneos;
-				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/Generated";
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/Generated",
+				);
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -181,7 +181,7 @@
 		46C35F105D036EECAAE7B93D /* FireRouteParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireRouteParserTests.swift; sourceTree = "<group>"; };
 		46CF09F1CBAC6CFAA0E9128A /* FireAppRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppRoute.swift; sourceTree = "<group>"; };
 		48A7EA25CD5ADF94676BE48E /* fire_uniffi_session.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = fire_uniffi_session.swift; sourceTree = "<group>"; };
-		48CAB0E38556929FC140E25D /* Fire.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = Fire.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		48CAB0E38556929FC140E25D /* Fire.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Fire.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		502CE714A74D91C33212BF57 /* FireNotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNotificationStore.swift; sourceTree = "<group>"; };
 		51431D8CC0EBCA6C0E79380C /* FireBackgroundNotificationAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireBackgroundNotificationAlert.swift; sourceTree = "<group>"; };
 		52BB1F5B0970DC2504ACD989 /* FirePushRegistrationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePushRegistrationCoordinator.swift; sourceTree = "<group>"; };
@@ -623,7 +623,6 @@
 				LastUpgradeCheck = 1430;
 				TargetAttributes = {
 					87BF3D86E2CA36A3D645AA33 = {
-						DevelopmentTeam = "$(FIRE_DEVELOPMENT_TEAM)";
 						ProvisioningStyle = "$(FIRE_CODE_SIGN_STYLE)";
 					};
 				};
@@ -856,30 +855,16 @@
 				DEVELOPMENT_TEAM = "$(FIRE_DEVELOPMENT_TEAM)";
 				FIRE_GIT_SHA = "$(FIRE_GIT_SHA)";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = (
-					"com.fire.app.ios.notification-alert-refresh",
-				);
+				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = "com.fire.app.ios.notification-alert-refresh";
 				INFOPLIST_KEY_CFBundleDisplayName = "$(FIRE_DISPLAY_NAME)";
 				INFOPLIST_KEY_CFBundleURLTypes = "[[\"CFBundleURLSchemes\": [\"fire\"], \"CFBundleURLName\": \"fire\"]]";
 				INFOPLIST_KEY_FireGitSha = "$(FIRE_GIT_SHA)";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Fire 需要把你在帖子里查看的图片保存到相册。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIBackgroundModes = (
-					fetch,
-					"remote-notification",
-				);
+				INFOPLIST_KEY_UIBackgroundModes = "fetch remote-notification";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = (
-					UIInterfaceOrientationPortrait,
-					UIInterfaceOrientationLandscapeLeft,
-					UIInterfaceOrientationLandscapeRight,
-				);
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = (
-					UIInterfaceOrientationPortrait,
-					UIInterfaceOrientationPortraitUpsideDown,
-					UIInterfaceOrientationLandscapeLeft,
-					UIInterfaceOrientationLandscapeRight,
-				);
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -898,10 +883,7 @@
 				PRODUCT_NAME = Fire;
 				PROVISIONING_PROFILE_SPECIFIER = "$(FIRE_PROVISIONING_PROFILE_SPECIFIER)";
 				SDKROOT = iphoneos;
-				SWIFT_INCLUDE_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Generated",
-				);
+				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/Generated";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -918,10 +900,7 @@
 					"@loader_path/Frameworks",
 				);
 				SDKROOT = iphoneos;
-				SWIFT_INCLUDE_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Generated",
-				);
+				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/Generated";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Fire.app/Fire";
 			};
@@ -939,10 +918,7 @@
 					"@loader_path/Frameworks",
 				);
 				SDKROOT = iphoneos;
-				SWIFT_INCLUDE_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Generated",
-				);
+				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/Generated";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Fire.app/Fire";
 			};
@@ -1074,33 +1050,19 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = "$(FIRE_CODE_SIGN_STYLE)";
 				CURRENT_PROJECT_VERSION = "$(FIRE_BUILD_NUMBER)";
-				DEVELOPMENT_TEAM = "$(FIRE_DEVELOPMENT_TEAM)";
+				DEVELOPMENT_TEAM = YHK2G6Y994;
 				FIRE_GIT_SHA = "$(FIRE_GIT_SHA)";
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = (
-					"com.fire.app.ios.notification-alert-refresh",
-				);
+				INFOPLIST_KEY_BGTaskSchedulerPermittedIdentifiers = "com.fire.app.ios.notification-alert-refresh";
 				INFOPLIST_KEY_CFBundleDisplayName = "$(FIRE_DISPLAY_NAME)";
 				INFOPLIST_KEY_CFBundleURLTypes = "[[\"CFBundleURLSchemes\": [\"fire\"], \"CFBundleURLName\": \"fire\"]]";
 				INFOPLIST_KEY_FireGitSha = "$(FIRE_GIT_SHA)";
 				INFOPLIST_KEY_NSPhotoLibraryAddUsageDescription = "Fire 需要把你在帖子里查看的图片保存到相册。";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
-				INFOPLIST_KEY_UIBackgroundModes = (
-					fetch,
-					"remote-notification",
-				);
+				INFOPLIST_KEY_UIBackgroundModes = "fetch remote-notification";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
-				INFOPLIST_KEY_UISupportedInterfaceOrientations = (
-					UIInterfaceOrientationPortrait,
-					UIInterfaceOrientationLandscapeLeft,
-					UIInterfaceOrientationLandscapeRight,
-				);
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = (
-					UIInterfaceOrientationPortrait,
-					UIInterfaceOrientationPortraitUpsideDown,
-					UIInterfaceOrientationLandscapeLeft,
-					UIInterfaceOrientationLandscapeRight,
-				);
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1119,10 +1081,7 @@
 				PRODUCT_NAME = Fire;
 				PROVISIONING_PROFILE_SPECIFIER = "$(FIRE_PROVISIONING_PROFILE_SPECIFIER)";
 				SDKROOT = iphoneos;
-				SWIFT_INCLUDE_PATHS = (
-					"$(inherited)",
-					"$(SRCROOT)/Generated",
-				);
+				SWIFT_INCLUDE_PATHS = "$(inherited) $(SRCROOT)/Generated";
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;

--- a/native/ios-app/Tests/Unit/FirePostCellLayoutCalculatorTests.swift
+++ b/native/ios-app/Tests/Unit/FirePostCellLayoutCalculatorTests.swift
@@ -1,0 +1,95 @@
+import UIKit
+import XCTest
+@testable import Fire
+
+final class FirePostCellLayoutCalculatorTests: XCTestCase {
+    func testCalculateAlignsContentColumnAndDividerWithReplyRowContract() {
+        let trait = FirePostLayoutTraitSignature(
+            contentWidthPixels: 320,
+            contentSizeCategory: UIContentSizeCategory.large.rawValue
+        )
+        let key = FirePostCellLayoutKey(
+            postID: 42,
+            depth: 1,
+            showsThreadLine: true,
+            showsDivider: true,
+            replyTargetPostNumber: nil,
+            replyContext: nil,
+            textContentID: "text",
+            imageSignature: [],
+            pollSignature: [],
+            hasReactions: false,
+            acceptedAnswer: false,
+            trait: trait
+        )
+
+        let layout = FirePostCellLayoutCalculator.calculate(
+            key: key,
+            textHeight: 40,
+            imageHeights: [],
+            trait: trait
+        )
+
+        XCTAssertEqual(layout.avatarFrame.origin.x, 16, accuracy: 0.01)
+        XCTAssertEqual(layout.avatarFrame.origin.y, 0, accuracy: 0.01)
+        XCTAssertEqual(layout.avatarFrame.width, 32, accuracy: 0.01)
+        XCTAssertEqual(layout.metaFrame.minY, 8, accuracy: 0.01)
+        XCTAssertEqual(layout.textFrame?.minY ?? -.greatestFiniteMagnitude, 34, accuracy: 0.01)
+        XCTAssertEqual(layout.dividerFrame?.minX ?? -.greatestFiniteMagnitude, 16, accuracy: 0.01)
+        XCTAssertEqual(layout.dividerFrame?.width ?? -.greatestFiniteMagnitude, 288, accuracy: 0.01)
+        XCTAssertEqual(layout.totalHeight, 82.5, accuracy: 0.01)
+        XCTAssertEqual(layout.threadLineFrame?.minY ?? -.greatestFiniteMagnitude, 38, accuracy: 0.01)
+    }
+
+    func testMeasureRichTextHeightGrowsAsAvailableWidthShrinks() {
+        let attributedText = NSAttributedString(
+            string: String(repeating: "Fire native reply row ", count: 12),
+            attributes: [
+                .font: UIFont.preferredFont(forTextStyle: .subheadline),
+            ]
+        )
+
+        let wideHeight = FirePostCellLayoutCalculator.measureRichTextHeight(
+            attributedText: attributedText,
+            containerWidth: 240,
+            contentSizeCategory: .large
+        )
+        let narrowHeight = FirePostCellLayoutCalculator.measureRichTextHeight(
+            attributedText: attributedText,
+            containerWidth: 120,
+            contentSizeCategory: .large
+        )
+
+        XCTAssertNotNil(wideHeight)
+        XCTAssertNotNil(narrowHeight)
+        XCTAssertGreaterThan(narrowHeight ?? 0, wideHeight ?? 0)
+    }
+
+    func testAvailableContentWidthAccountsForIndentAvatarAndOuterPadding() {
+        let trait = FirePostLayoutTraitSignature(
+            contentWidthPixels: 360,
+            contentSizeCategory: UIContentSizeCategory.large.rawValue
+        )
+        let key = FirePostCellLayoutKey(
+            postID: 7,
+            depth: 3,
+            showsThreadLine: false,
+            showsDivider: false,
+            replyTargetPostNumber: nil,
+            replyContext: nil,
+            textContentID: "text",
+            imageSignature: [],
+            pollSignature: [],
+            hasReactions: false,
+            acceptedAnswer: false,
+            trait: trait
+        )
+
+        let availableWidth = FirePostCellLayoutCalculator.availableContentWidth(
+            for: key,
+            trait: trait
+        )
+
+        XCTAssertEqual(availableWidth, 256, accuracy: 0.01)
+    }
+}

--- a/native/ios-app/Tests/Unit/FirePostCellLayoutCalculatorTests.swift
+++ b/native/ios-app/Tests/Unit/FirePostCellLayoutCalculatorTests.swift
@@ -34,10 +34,10 @@ final class FirePostCellLayoutCalculatorTests: XCTestCase {
         XCTAssertEqual(layout.avatarFrame.origin.y, 0, accuracy: 0.01)
         XCTAssertEqual(layout.avatarFrame.width, 32, accuracy: 0.01)
         XCTAssertEqual(layout.metaFrame.minY, 8, accuracy: 0.01)
-        XCTAssertEqual(layout.textFrame?.minY ?? -.greatestFiniteMagnitude, 34, accuracy: 0.01)
+        XCTAssertEqual(layout.textFrame?.minY ?? -.greatestFiniteMagnitude, 36, accuracy: 0.01)
         XCTAssertEqual(layout.dividerFrame?.minX ?? -.greatestFiniteMagnitude, 16, accuracy: 0.01)
         XCTAssertEqual(layout.dividerFrame?.width ?? -.greatestFiniteMagnitude, 288, accuracy: 0.01)
-        XCTAssertEqual(layout.totalHeight, 82.5, accuracy: 0.01)
+        XCTAssertEqual(layout.totalHeight, 84.5, accuracy: 0.01)
         XCTAssertEqual(layout.threadLineFrame?.minY ?? -.greatestFiniteMagnitude, 38, accuracy: 0.01)
     }
 

--- a/native/ios-app/Tests/Unit/FirePostLayoutManagerTests.swift
+++ b/native/ios-app/Tests/Unit/FirePostLayoutManagerTests.swift
@@ -1,0 +1,170 @@
+import UIKit
+import XCTest
+@testable import Fire
+
+@MainActor
+final class FirePostLayoutManagerTests: XCTestCase {
+    func testEnqueueCalculationPublishesResolvedLayout() async throws {
+        let manager = FirePostLayoutManager(
+            backgroundQueue: DispatchQueue(label: "FirePostLayoutManagerTests.enqueue")
+        ) { key, _, _, _ in
+            Self.makeLayout(key: key, totalHeight: 123)
+        }
+        let key = Self.makeKey(width: 320, postID: 1)
+
+        manager.enqueueCalculation(
+            key: key,
+            attributedText: nil,
+            images: [],
+            trait: key.trait
+        )
+
+        try await waitUntil {
+            manager.layout(forKey: key)?.totalHeight == 123
+                && manager.currentSnapshotRevision > 0
+        }
+
+        XCTAssertEqual(manager.layout(forKey: key)?.totalHeight, 123)
+    }
+
+    func testInvalidateAllDropsStaleInFlightResults() async throws {
+        let gate = DispatchSemaphore(value: 0)
+        let staleKey = Self.makeKey(width: 320, postID: 2)
+        let freshKey = Self.makeKey(width: 400, postID: 2)
+        let manager = FirePostLayoutManager(
+            backgroundQueue: DispatchQueue(label: "FirePostLayoutManagerTests.invalidate")
+        ) { key, _, _, _ in
+            if key == staleKey {
+                gate.wait()
+            }
+            return Self.makeLayout(key: key, totalHeight: CGFloat(key.trait.contentWidthPixels))
+        }
+
+        manager.enqueueCalculation(
+            key: staleKey,
+            attributedText: nil,
+            images: [],
+            trait: staleKey.trait
+        )
+        manager.invalidateAll(reason: .widthChanged)
+        manager.enqueueCalculation(
+            key: freshKey,
+            attributedText: nil,
+            images: [],
+            trait: freshKey.trait
+        )
+        gate.signal()
+
+        try await waitUntil {
+            manager.layout(forKey: freshKey)?.totalHeight == 400
+                && manager.currentSnapshotRevision > 0
+        }
+
+        XCTAssertNil(manager.layout(forKey: staleKey))
+        XCTAssertEqual(manager.layout(forKey: freshKey)?.totalHeight, 400)
+    }
+
+    func testDuplicateEnqueueDoesNotScheduleDuplicateWork() async throws {
+        let counter = CounterBox()
+        let gate = DispatchSemaphore(value: 0)
+        let key = Self.makeKey(width: 360, postID: 3)
+        let manager = FirePostLayoutManager(
+            backgroundQueue: DispatchQueue(label: "FirePostLayoutManagerTests.dedup")
+        ) { key, _, _, _ in
+            counter.increment()
+            gate.wait()
+            return Self.makeLayout(key: key, totalHeight: 88)
+        }
+
+        manager.enqueueCalculation(
+            key: key,
+            attributedText: nil,
+            images: [],
+            trait: key.trait
+        )
+        manager.enqueueCalculation(
+            key: key,
+            attributedText: nil,
+            images: [],
+            trait: key.trait
+        )
+        gate.signal()
+
+        try await waitUntil {
+            manager.layout(forKey: key)?.totalHeight == 88
+        }
+
+        XCTAssertEqual(counter.value, 1)
+    }
+
+    nonisolated private static func makeKey(width: Int, postID: UInt64) -> FirePostCellLayoutKey {
+        FirePostCellLayoutKey(
+            postID: postID,
+            depth: 1,
+            showsThreadLine: true,
+            showsDivider: true,
+            replyTargetPostNumber: nil,
+            replyContext: nil,
+            textContentID: "text",
+            imageSignature: [],
+            pollSignature: [],
+            hasReactions: false,
+            acceptedAnswer: false,
+            trait: FirePostLayoutTraitSignature(
+                contentWidthPixels: width,
+                contentSizeCategory: UIContentSizeCategory.large.rawValue
+            )
+        )
+    }
+
+    nonisolated private static func makeLayout(key: FirePostCellLayoutKey, totalHeight: CGFloat) -> FirePostCellLayout {
+        FirePostCellLayout(
+            key: key,
+            totalHeight: totalHeight,
+            avatarFrame: .zero,
+            threadLineFrame: nil,
+            metaFrame: .zero,
+            textFrame: nil,
+            textContainerSize: .zero,
+            imageFrames: [],
+            reactionsFrame: nil,
+            menuFrame: nil,
+            dividerFrame: nil
+        )
+    }
+
+    private func waitUntil(
+        timeout: Duration = .seconds(2),
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ condition: @escaping @MainActor () -> Bool
+    ) async throws {
+        let clock = ContinuousClock()
+        let deadline = clock.now + timeout
+
+        while !condition() {
+            if clock.now >= deadline {
+                XCTFail("Timed out waiting for async layout work.", file: file, line: line)
+                return
+            }
+            try await Task.sleep(for: .milliseconds(10))
+        }
+    }
+}
+
+private final class CounterBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storage = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return storage
+    }
+
+    func increment() {
+        lock.lock()
+        storage += 1
+        lock.unlock()
+    }
+}


### PR DESCRIPTION
## Summary
- add the mixed hosted/native topic detail reply cell implementation, background layout cache, native cell, and fixed-frame rich text wrapper
- add focused unit tests for the layout calculator and layout manager, and regenerate the Xcode project from project.yml
- fix follow-up regressions from device validation: clipped reply-context text, hosted/native diffable route-change crashes, and metadata styling/truncation for reply context, timestamps, and post numbers

## Validation
- xcodegen generate --spec native/ios-app/project.yml
- xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire -destination "platform=iOS Simulator,id=D733CCB1-7B2A-49B5-D733CCB1-7B2A-49B5-B3F8-36CB6D0CB2BF" test