### PR TITLE
[codex] Stabilize home list refresh and startup loading

### DIFF
--- a/docs/superpowers/plans/2026-06-07-topic-detail-main-thread-and-ui-split-plan.md
+++ b/docs/superpowers/plans/2026-06-07-topic-detail-main-thread-and-ui-split-plan.md
@@ -1,0 +1,517 @@
+# Topic Detail Main-Thread and UI Split Optimization Plan
+
+> 日期: 2026-06-07
+> 状态: Plan
+> 范围: iOS topic detail 主线程卡顿、poll option 同步解析、topic tree FFI 载荷瘦身、Android 冷启动 UI 线程初始化、详情页状态拆分
+
+## Goal
+
+解决 review 指出的四类性能风险，并把详情页从“单个大状态刷新整页”推进到“按职责拆分状态域、各自刷新”的结构：
+
+- iOS 不在 `@MainActor` 上比较完整 `TopicDetailState`
+- iOS cell / layout key 路径不再同步 HTML 解析 poll option 标题
+- 双端 topic detail 不再把完整 post 在 FFI 边界来回传递多次
+- Android 首次 `FireSessionStore` / `FireAppCore` 初始化不阻塞 UI 线程
+- iOS 详情页拆成 feed、chrome、composer、sidecar、interaction 几个刷新域，避免输入框、toolbar、sidecar 状态触发整页 feed diff
+
+核心原则：不是简单把所有逻辑塞进后台线程，而是先减少主路径要做的工作，再把仍然昂贵、纯计算的派生步骤放到后台。主线程只保留状态发布、UIKit / Texture apply、导航和用户交互收口。
+
+## Direct Answers
+
+### 主线程上的内容是否可以迁移到异步线程
+
+可以，但要分层迁移：
+
+- 必须留在主线程 / MainActor：
+  - `@Published` 状态写入
+  - UIKit / Texture node apply
+  - navigation item、toolbar、quick reply bar 更新
+  - visible cell in-place 更新
+  - 生命周期和手势事件收口
+- 应迁移到后台或 Rust：
+  - `TopicDetailState` 变更判断与 signature 生成
+  - tree presentation 构建与 row metadata 生成
+  - rich text render cache / attributed string 预计算
+  - poll option HTML -> plain text
+  - snapshot item list 的纯数据构建
+  - Android `FireSessionStore` / `FireAppCore` 首次构造
+
+注意：单纯把 `topicDetails[topicId] != detail` 放到 `Task.detached` 不是最优解。它仍然需要复制完整 FFI 大对象，也会制造取消和乱序 apply 问题。更优方案是让 Rust 或后台构建阶段产出轻量 revision / signature，MainActor 只比较 token。
+
+### UI 展示部分是否可以拆分
+
+可以，而且当前代码已经有可利用的边界：
+
+- `FireTopicDetailFeedController`
+- `FireTopicDetailPaginationCoordinator`
+- `FireTopicDetailVisibilityCoordinator`
+- `FireTopicDetailToolbarCoordinator`
+- `FireTopicQuickReplyBarNode`
+- `FireTopicDetailModalRouter`
+
+当前问题不是完全没有拆组件，而是状态刷新仍然集中在 `FireTopicDetailStore` 和 `FireTopicDetailViewController.buildAndApplySnapshot()`。下一步应拆状态域，而不是重写 UI 层：
+
+- feed state: 原帖、回复、layout、render cache、pagination
+- chrome state: toolbar、bookmark、notification、topic vote、share URL
+- composer state: draft、target、validation、submitting
+- sidecar state: AI summary、presence、timings
+- interaction state: mutating post IDs、expanded text IDs、reply thread expansion
+
+## Current Evidence
+
+### iOS deep compare on MainActor
+
+`native/ios-app/App/Stores/FireTopicDetailStore.swift` 是 `@MainActor` store。当前 `setTopicDetail` 用完整对象比较：
+
+```swift
+let changed = topicDetails[topicId] != detail
+```
+
+`TopicDetailState` 包含 `postStream.posts`，每个 `TopicPostState` 又包含 `cooked` 和 `renderDocument`。大帖刷新、MessageBus refresh、返回相同数据或差异靠后时，这个比较会在主线程走深比较。
+
+### iOS render cache 已部分后台化，但 poll title 仍在 cell/layout 路径
+
+`FireTopicDetailStore.scheduleTopicRenderCacheUpdate` / `buildTopicDetailRenderUpdate` 已用 `Task.detached` 构建 `FireTopicPresentation.detailRenderCache(...)`，这是正确方向。
+
+但 `FirePostPollRenderModel.models(from:)` 仍会在 poll option cache miss 时调用：
+
+```swift
+FireRichTextParser.parse(html: html, baseURLString: "")
+```
+
+该 parser 会同步调用 `renderCookedHtml(...)` FFI。调用点包括：
+
+- cell configure: `FirePostCellNode`
+- layout precompute: `FireTopicDetailFeedController.prepareLayoutsIfNeeded`
+- layout key: `FireTopicDetailFeedController.makeLayoutKey`
+
+所以 poll-bearing posts 仍可能在滚动和 layout key 构建路径阻塞。
+
+### FFI tree payload 当前重复带完整 post
+
+当前 source snapshot:
+
+```rust
+TopicDetailSourceSnapshotState {
+  body: TopicBodyState,
+  loaded_posts: Vec<TopicPostState>,
+  ...
+}
+```
+
+当前 tree query 又把完整 post 传回 Rust：
+
+```rust
+TopicTreePresentationQueryState {
+  body_post: TopicPostState,
+  raw_stream_ids: Vec<u64>,
+  loaded_posts: Vec<TopicPostState>,
+  focused_post_number: Option<u32>,
+}
+```
+
+当前 tree result 再把完整 post 带回平台：
+
+```rust
+TopicTreeRowState {
+  post: TopicPostState,
+  ...
+}
+```
+
+因为 `TopicPostState` 包含 `cooked` 和 `render_document`，这会造成大帖 FFI 重复序列化和重复传输。
+
+### Android first store creation is synchronous at the UI call site
+
+`PreheatGateFragment.awaitPreloadedData()` 在启动页面先执行：
+
+```kotlin
+val store = FireSessionStoreRepository.get(requireContext())
+```
+
+随后才进入 coroutine。`FireSessionStoreRepository.get()` 会同步构造 `FireSessionStore`，而 `FireSessionStore.init` 里创建 `FireAppCore`、注册 observer、解析 session path。这些 IO / Rust 初始化工作应从 UI 线程移走。
+
+### iOS page state already has coarse revision but not enough state-domain isolation
+
+`FireTopicDetailViewController` 已订阅：
+
+- `topicCollectionRevisions` -> `buildAndApplySnapshot()`
+- `topicChromeRevisions` -> `buildAndApplyChromeState()`
+
+但 controller-local 事件仍有过度刷新：
+
+- quick reply draft 每次变化会调用 `buildAndApplySnapshot()`
+- composer target / validation / submitting 和 feed snapshot 混在 `FireTopicDetailPageState`
+- `FireTopicDetailSnapshotAssembler` 标注 `@MainActor`，纯 snapshot item list 构建无法后台化
+
+## Non-Goals
+
+- 不重引入 SwiftUI post row fallback。
+- 不把 topic detail 主阅读面改成 host-managed window / `getPostsByNumber(...)`。
+- 不增加 parallel rendering path。
+- 不用 tree row / root row 反向决定网络分页边界。
+- 不把 AI summary、presence、timings 塞进主详情载荷。
+
+## Target Architecture
+
+### Rust / UniFFI
+
+新增或调整为一个 combined + slim contract：
+
+```text
+fetch_topic_detail_page(query)
+  -> TopicDetailPageState {
+       source_snapshot,
+       tree_presentation
+     }
+
+load_more_topic_posts(cursor)
+  -> TopicLoadMoreOutcomeState {
+       source_snapshot,
+       tree_presentation,
+       chained_batches,
+       chained_posts,
+       stop_reason
+     }
+
+TopicTreePresentationState {
+  original_post_id,
+  reply_rows: Vec<TopicTreeRowMetaState>,
+  total_loaded_post_count,
+  visible_root_post_numbers,
+  gained_new_root_progress
+}
+
+TopicTreeRowMetaState {
+  post_id,
+  post_number,
+  root_post_number,
+  parent_post_number,
+  depth,
+  preorder_index,
+  has_children,
+  descendant_count,
+  sibling_index,
+  is_last_sibling
+}
+```
+
+Full post payload only appears in `source_snapshot.body.post` and `source_snapshot.loaded_posts`. Tree presentation references posts by id / post number only.
+
+### iOS Store / Controller
+
+Split state and refresh domains:
+
+```text
+FireTopicDetailStore
+  source state:
+    sourceSnapshots
+    treePresentations
+    postLookups
+    detailTokens
+  feed state:
+    renderCaches
+    renderStates
+    windowStates
+    collectionRevisions
+  chrome state:
+    toolbar / bookmark / notification revisions
+  sidecar state:
+    aiSummary
+    presence
+    timings
+  interaction state:
+    mutatingPostIDs
+    loadingReplyContextIDs
+```
+
+Controller should apply:
+
+- feed updates only when feed token changes
+- chrome updates only when toolbar token changes
+- quick reply bar updates only when composer token changes
+- visible post node updates only when in-place interaction token changes
+
+### Android Startup
+
+Change first initialization to a suspend IO path:
+
+```kotlin
+suspend fun FireSessionStoreRepository.get(context): FireSessionStore =
+    withContext(Dispatchers.IO) { getOrCreateBlocking(context.applicationContext) }
+```
+
+`PreheatGateFragment` should enter `lifecycleScope.launch` before calling `get(...)`. Other UI call sites should also use the suspend path or receive an already initialized store.
+
+## Implementation Plan
+
+### Phase 0: Baseline instrumentation
+
+Files:
+
+- Modify: `native/ios-app/App/Stores/FireTopicDetailStore.swift`
+- Modify: `native/ios-app/App/TopicDetail/Controller/FireTopicDetailViewController.swift`
+- Modify: `native/android-app/src/main/java/com/fire/app/ui/startup/PreheatGateFragment.kt`
+- Optional Modify: `rust/crates/fire-core/src/core/topics.rs`
+
+Steps:
+
+- [ ] Add lightweight signposts / log fields for topic detail apply:
+  - source fetch duration
+  - tree presentation duration
+  - render cache duration
+  - MainActor apply duration
+  - collection snapshot item count
+  - loaded post count and cooked byte count
+- [ ] Add startup timing around Android `FireSessionStoreRepository.get(...)`.
+- [ ] Capture before numbers on:
+  - large topic initial load
+  - MessageBus refresh with identical payload
+  - poll-bearing topic scroll
+  - Android cold start / deep link first entry
+
+Acceptance:
+
+- Logs identify whether time is spent in fetch, FFI conversion, render cache, snapshot build, or UI apply.
+- No behavior changes yet.
+
+### Phase 1: Fix P1 iOS deep compare
+
+Files:
+
+- Modify: `native/ios-app/App/Stores/FireTopicDetailStore.swift`
+- Modify: `native/ios-app/App/TopicDetail/Support/FireTopicPresentation.swift`
+- Test: `native/ios-app/Tests/Unit/FireTopicDetailStoreTests.swift`
+
+Steps:
+
+- [ ] Introduce `FireTopicDetailContentToken`.
+- [ ] Token fields should cover visible detail semantics without embedding full cooked/render tree:
+  - topic id
+  - message bus last id
+  - header counters and flags
+  - bookmark / notification fields
+  - `postStream.stream` checksum
+  - per post id, post number, updated_at, like count, reaction signature, poll signature, cooked length + stable checksum
+  - details permission / participant signature
+- [ ] Keep `topicDetailContentTokensByTopicID`.
+- [ ] Replace `topicDetails[topicId] != detail` with token comparison.
+- [ ] Build token before `MainActor` apply where possible. If token must be computed in Swift, compute in the existing detached render-cache task or a dedicated detached task and apply only latest generation.
+- [ ] Keep full `TopicDetailState` assignment only when token changed.
+- [ ] Preserve `bumpRevision` behavior exactly.
+- [ ] Add tests:
+  - identical large detail does not publish / bump collection revision
+  - changed late post does publish
+  - changed bookmark / notification chrome field updates correct revision
+  - token collision-sensitive fields are included
+
+Acceptance:
+
+- No full `TopicDetailState` equality check remains on `@MainActor`.
+- Identical refresh does O(1) main-thread comparison.
+- Store tests cover no-op and changed refresh.
+
+### Phase 2: Collapse and slim topic tree FFI
+
+Files:
+
+- Modify: `rust/crates/fire-models/src/topic_detail.rs`
+- Modify: `rust/crates/fire-core/src/core/topics.rs`
+- Modify: `rust/crates/fire-uniffi-topics/src/lib.rs`
+- Modify: `rust/crates/fire-uniffi-topics/src/records.rs`
+- Modify: `native/ios-app/Sources/FireAppSession/FireSessionStore.swift`
+- Modify: `native/ios-app/App/Stores/FireTopicDetailStore.swift`
+- Modify: `native/android-app/src/main/java/com/fire/app/session/FireSessionStore.kt`
+- Modify: `native/android-app/src/main/java/com/fire/app/data/repository/TopicRepository.kt`
+- Modify: `native/android-app/src/main/java/com/fire/app/ui/topicdetail/TopicDetailViewModel.kt`
+- Test: `rust/crates/fire-core/tests/network.rs`
+- Test: `native/ios-app/Tests/Unit/FireTopicDetailStoreTests.swift`
+- Test: `native/android-app/src/test/.../TopicDetailPostRowsTest.kt` or equivalent
+
+Steps:
+
+- [ ] Add `TopicTreeRowMeta` / `TopicTreeRowMetaState` without full `TopicPost`.
+- [ ] Add `TopicDetailPage` / `TopicDetailPageState` combined result:
+  - `source_snapshot`
+  - `tree_presentation`
+- [ ] Add Rust core method that builds source snapshot and tree presentation in one call from the same internal source session.
+- [ ] Keep `load_more_topic_posts` combined, but make returned `tree_presentation.reply_rows` slim.
+- [ ] Remove platform path that sends `bodyPost` and `loadedPosts` back to Rust just to build the tree.
+- [ ] iOS rebuild:
+  - keep `sourceSnapshots[topicId]`
+  - keep `treePresentations[topicId]`
+  - derive `postLookup` from `sourceSnapshot.body.post + sourceSnapshot.loadedPosts`
+  - synthesize `TopicDetailState` from source + slim tree metadata only when compatibility with existing UI code still needs it
+- [ ] Android rebuild:
+  - `PostRow` uses row metadata + post lookup
+  - `_detail.postStream.posts` comes from source posts only
+  - mutation patch updates source posts and post lookup, not duplicated tree row post copies
+- [ ] Delete or deprecate old `buildTopicTreePresentation(query: TopicTreePresentationQueryState)` platform wrapper after all call sites move.
+
+Acceptance:
+
+- Main detail flow crosses FFI once for source + tree on initial refresh.
+- Tree row FFI no longer carries `TopicPostState`.
+- `TopicPostState.renderDocument` is serialized once per loaded post per response, not again through tree rows.
+- Both platforms render the same row order/depth as before.
+
+### Phase 3: Move poll option title parsing out of iOS cell/layout path
+
+Files:
+
+- Modify: `rust/crates/fire-models/src/topic_detail.rs`
+- Modify: `rust/crates/fire-uniffi-topics/src/records.rs`
+- Modify: `native/ios-app/App/ListKit/TopicDetail/FirePostPollRenderer.swift`
+- Modify: `native/ios-app/App/TopicDetail/Feed/FireTopicDetailFeedController.swift`
+- Modify: `native/android-app/src/main/java/com/fire/app/ui/topicdetail/PostViewHolder.kt` if Android consumes option title directly
+- Test: `cargo test -p fire-models -p fire-uniffi-topics`
+- Test: iOS unit test for poll model title
+
+Steps:
+
+- [ ] Add `plain_text` or `title` to `PollOption` / `PollOptionState`.
+- [ ] Populate it in Rust using the existing shared plain-text rich text path.
+- [ ] Update iOS `FirePostPollRenderModel.models(from:)` to use `option.plainText` and fallback to `option.id`.
+- [ ] Remove `FirePostPollPlainTextCache` and `optionTitle(fromHTML:)` from the cell path.
+- [ ] Ensure `FireTopicDetailFeedController.makeLayoutKey` uses already materialized poll signatures only.
+- [ ] Audit all iOS references to `FireRichTextParser.parse(html:)` and confirm none are reachable from cell configure or layout key cache miss.
+
+Acceptance:
+
+- No `renderCookedHtml(...)` FFI can be triggered by poll model construction.
+- Poll-bearing rows can configure and compute layout keys without synchronous HTML parsing.
+
+### Phase 4: Move Android core initialization off UI thread
+
+Files:
+
+- Modify: `native/android-app/src/main/java/com/fire/app/session/FireSessionStoreRepository.kt`
+- Modify: `native/android-app/src/main/java/com/fire/app/ui/startup/PreheatGateFragment.kt`
+- Modify: `native/android-app/src/main/java/com/fire/app/MainActivity.kt`
+- Modify: other `FireSessionStoreRepository.get(...)` UI call sites found by `rg`
+- Test: Android unit tests if repository behavior is testable
+
+Steps:
+
+- [ ] Replace sync public `get(context)` with a suspend `get(context)` or add a clearly named `getOrCreate(context)` suspend method.
+- [ ] Keep a private blocking `getOrCreateBlocking(applicationContext)` behind `withContext(Dispatchers.IO)`.
+- [ ] Preserve singleton locking and Cloudflare challenge handler registration.
+- [ ] Update `PreheatGateFragment.awaitPreloadedData()`:
+  - enter `lifecycleScope.launch` first
+  - call repository from IO
+  - then call `prepareStartupSession`, `awaitPreloadedData`, and login probe
+- [ ] Update other UI call sites so none construct `FireSessionStore` before entering a coroutine / IO context.
+- [ ] Do not use `runBlocking` on UI thread.
+
+Acceptance:
+
+- First `FireAppCore` construction cannot happen on the Android main thread.
+- Cold start / deep link first entry keeps the UI responsive while preheat runs.
+
+### Phase 5: Split iOS topic detail state refresh domains
+
+Files:
+
+- Modify: `native/ios-app/App/TopicDetail/State/FireTopicDetailPageState.swift`
+- Modify: `native/ios-app/App/TopicDetail/State/FireTopicDetailSnapshotAssembler.swift`
+- Modify: `native/ios-app/App/TopicDetail/Controller/FireTopicDetailViewController.swift`
+- Modify: `native/ios-app/App/TopicDetail/Feed/FireTopicDetailFeedModels.swift`
+- Modify: `native/ios-app/App/TopicDetail/Feed/FireTopicDetailFeedUpdatePipeline.swift`
+- Modify: `native/ios-app/App/Stores/FireTopicDetailStore.swift`
+- Test: `native/ios-app/Tests/Unit/FireTopicDetailRuntimeTests.swift`
+
+Steps:
+
+- [ ] Split `FireTopicDetailPageState` into:
+  - `FireTopicDetailFeedState`
+  - `FireTopicDetailChromeState`
+  - `FireTopicDetailComposerState`
+  - `FireTopicDetailSidecarState`
+  - `FireTopicDetailInteractionState`
+- [ ] Split invalidation tokens:
+  - feed token: post/tree/render/layout/pagination only
+  - chrome token: title/share/bookmark/notification/topic vote only
+  - composer token: draft/target/validation/submitting only
+  - sidecar token: AI summary/presence/timing display only
+  - visible-node token: mutating/reaction/loading reply context/expanded text only
+- [ ] Change quick reply draft updates to apply only composer state:
+  - no feed snapshot rebuild on every keystroke
+  - no collection diff on validation-only changes
+- [ ] Change toolbar-only changes to call only `toolbarCoordinator.apply(...)`.
+- [ ] Change AI summary reload failure/loading to update only the summary item if present, not rebuild unrelated post items.
+- [ ] Extract a pure `FireTopicDetailSnapshotInput: Sendable` for feed item construction.
+- [ ] Move pure feed item list construction off `@MainActor` when inputs are ready and attach action callbacks only at apply time.
+- [ ] Keep Texture / collection update application on MainActor.
+- [ ] Add tests asserting:
+  - composer draft token change does not change feed invalidation token
+  - chrome token change does not change feed items
+  - expanded text affects only the relevant post item content token
+  - mutation state can use visible in-place update path
+
+Acceptance:
+
+- Typing in quick reply does not call `feedUpdatePipeline.apply(...)`.
+- Toolbar changes do not diff post rows.
+- Feed snapshot build becomes pure and eligible for background execution.
+- UI behavior remains unchanged.
+
+### Phase 6: Verification and regression gates
+
+Rust:
+
+```bash
+cargo fmt --all --check
+cargo test -p fire-models -p fire-core -p fire-uniffi-topics --all-targets
+```
+
+iOS:
+
+```bash
+xcodegen generate --spec native/ios-app/project.yml
+FIRE_SKIP_UNIFFI_BINDGEN=1 xcodebuild -project native/ios-app/Fire.xcodeproj -scheme Fire-Local-Unit -destination 'platform=iOS Simulator,name=iPhone 16' test
+```
+
+Android:
+
+```bash
+export JAVA_HOME=$(/usr/libexec/java_home -v 17)
+export ANDROID_HOME=/Users/zhangfan/Library/Android/sdk
+export ANDROID_SDK_ROOT=/Users/zhangfan/Library/Android/sdk
+cd native/android-app
+./gradlew testDebugUnitTest assembleDebug
+```
+
+Runtime checks:
+
+- iOS large topic initial load: no visible main-thread freeze during identical refresh.
+- iOS poll-bearing topic scroll: no synchronous `renderCookedHtml` from cell/layout stack.
+- iOS quick reply typing: no feed collection diff.
+- iOS MessageBus identical refresh during/after scroll: no full detail deep compare.
+- Android cold start: first `FireSessionStore` construction happens on IO dispatcher.
+
+## Suggested Commit Split
+
+1. `perf(ios): replace topic detail deep compare with content tokens`
+2. `refactor(topics): slim topic tree presentation over uniffi`
+3. `perf(ios): precompute poll option titles in rust payloads`
+4. `perf(android): initialize fire session store off main thread`
+5. `refactor(ios): split topic detail refresh domains`
+6. `docs: document topic detail performance boundaries`
+
+## Risk Notes
+
+- Token comparison must include every visible field that can affect UI. Missing fields would create stale UI.
+- Slim tree rows require careful post lookup rebuild on both platforms. Mutation updates must patch source posts, not stale row copies.
+- Moving snapshot build off-main requires separating pure data from UIKit objects and callbacks.
+- Android repository API changes may affect multiple call sites; update all `FireSessionStoreRepository.get(...)` consumers in one commit.
+- UniFFI model changes require regenerating bindings and then regenerating the iOS Xcode project if source lists change.
+
+## Documentation Follow-Up
+
+After implementation, update:
+
+- `docs/knowledge/api/03-topics.md`: source snapshot + slim tree presentation contract
+- `docs/architecture/2026-06-05-rich-text-and-state-observer-design.md`: poll option plain text and topic detail observer boundary notes
+- `docs/superpowers/plans/2026-06-06-topic-detail-api-consolidation.md`: mark combined/slim FFI decisions as the current direction or supersede stale sections
+
+Documentation should be synchronized after code lands, not before, because code remains the source of truth.

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -11,15 +11,20 @@ the shared Rust core at build time.
   Home, Notifications, and Profile. Tab selection uses Navigation saved-state
   restoration so loaded tab fragments keep their back stack and ViewModel state
   when switching between the three primary tabs.
-- `OnboardingFragment` restores the persisted Rust session and routes logged-in
-  users into Home. `LoginWebViewFragment` owns interactive login.
+- `PreheatGateFragment` is the startup authority boundary: it restores the
+  persisted Rust session, waits for preloaded data, runs Rust's login-state
+  probe, and routes to Home or Onboarding. During that check it reuses the
+  onboarding visual shell, keeps the login action hidden, and leaves failures on
+  the same screen with a retry action. `OnboardingFragment` is only the explicit
+  login entry, and `LoginWebViewFragment` owns interactive login.
 - `HomeFragment` renders the Rust-backed topic feed with feed-kind, category,
   tag filtering, pull refresh, MessageBus refresh, and visible Search/New Topic
   actions. New Topic opens `TopicComposerSheet`; successful creation opens the
   native topic detail screen. Topic compose supports Rust-backed tag
   suggestions, `@mention` suggestions, image upload insertion, and shared Rust
   draft restore/autosave/delete, and local Markdown preview with upload-image
-  preview.
+  preview. Empty initial Paging loads render topic-row skeletons in the list area
+  instead of a separate blocking spinner.
 - `SearchFragment` is a Navigation destination reachable from Home. It calls
   Rust search APIs for all/topic/post/user scopes, renders labeled result
   sections, loads additional full-page results while scrolling, and routes

--- a/native/android-app/src/main/java/com/fire/app/MainActivity.kt
+++ b/native/android-app/src/main/java/com/fire/app/MainActivity.kt
@@ -57,6 +57,7 @@ class MainActivity : AppCompatActivity() {
 
         navController.addOnDestinationChangedListener { _, destination, _ ->
             binding.bottomNav.visibility = when (destination.id) {
+                R.id.preheatGateFragment,
                 R.id.onboardingFragment,
                 R.id.loginWebViewFragment -> View.GONE
                 else -> View.VISIBLE

--- a/native/android-app/src/main/java/com/fire/app/data/paging/TopicListPagingSource.kt
+++ b/native/android-app/src/main/java/com/fire/app/data/paging/TopicListPagingSource.kt
@@ -9,7 +9,6 @@ import uniffi.fire_uniffi_types.TopicRowState
 class TopicListPagingSource(
     private val repository: TopicRepository,
     private val kind: TopicListKindState,
-    private val baseUrl: String? = null,
     private val categorySlug: String? = null,
     private val categoryId: ULong? = null,
     private val parentCategorySlug: String? = null,

--- a/native/android-app/src/main/java/com/fire/app/data/paging/TopicListPagingSource.kt
+++ b/native/android-app/src/main/java/com/fire/app/data/paging/TopicListPagingSource.kt
@@ -19,10 +19,9 @@ class TopicListPagingSource(
 ) : PagingSource<UInt, TopicRowState>() {
 
     override fun getRefreshKey(state: PagingState<UInt, TopicRowState>): UInt? {
-        return state.anchorPosition?.let { position ->
-            state.closestPageToPosition(position)?.prevKey?.plus(1u)
-                ?: state.closestPageToPosition(position)?.nextKey?.minus(1u)
-        }
+        // Home only supports forward pagination. Refreshing from an anchor page
+        // strands the list on that single page after an automatic invalidation.
+        return null
     }
 
     override suspend fun load(params: LoadParams<UInt>): LoadResult<UInt, TopicRowState> {

--- a/native/android-app/src/main/java/com/fire/app/ui/auth/OnboardingFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/auth/OnboardingFragment.kt
@@ -22,8 +22,11 @@ class OnboardingFragment : Fragment() {
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
+        view.findViewById<View>(R.id.onboarding_error).visibility = View.GONE
         val loginButton: MaterialButton = view.findViewById(R.id.login_button)
         loginButton.visibility = View.VISIBLE
+        loginButton.isEnabled = true
+        loginButton.text = getString(R.string.onboarding_login)
 
         loginButton.setOnClickListener {
             findNavController().navigate(R.id.action_onboarding_to_loginWebView)

--- a/native/android-app/src/main/java/com/fire/app/ui/home/HomeFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/home/HomeFragment.kt
@@ -4,7 +4,6 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.ProgressBar
 import android.widget.TextView
 import android.widget.Toast
 import androidx.fragment.app.Fragment
@@ -35,7 +34,7 @@ class HomeFragment : Fragment() {
     private lateinit var recyclerView: RecyclerView
     private lateinit var adapter: TopicListAdapter
     private lateinit var emptyView: TextView
-    private lateinit var loadingView: ProgressBar
+    private lateinit var loadingSkeletonView: View
     private lateinit var swipeRefresh: SwipeRefreshLayout
     private lateinit var categoryBar: RecyclerView
     private lateinit var categoryAdapter: HomeCategoryAdapter
@@ -62,7 +61,7 @@ class HomeFragment : Fragment() {
 
         recyclerView = view.findViewById(R.id.topic_list)
         emptyView = view.findViewById(R.id.empty_view)
-        loadingView = view.findViewById(R.id.loading_view)
+        loadingSkeletonView = view.findViewById(R.id.loading_skeleton_view)
         swipeRefresh = view.findViewById(R.id.swipe_refresh)
         categoryBar = view.findViewById(R.id.category_bar)
         feedKindBar = view.findViewById(R.id.feed_kind_bar)
@@ -99,7 +98,11 @@ class HomeFragment : Fragment() {
         adapter.addLoadStateListener { loadStates ->
             val refresh = loadStates.refresh
             val isInitialLoading = refresh is LoadState.Loading && adapter.itemCount == 0
-            loadingView.visibility = if (isInitialLoading) View.VISIBLE else View.GONE
+            loadingSkeletonView.visibility = if (isInitialLoading) View.VISIBLE else View.GONE
+            swipeRefresh.isEnabled = !isInitialLoading
+            if (refresh is LoadState.Loading && adapter.itemCount > 0) {
+                swipeRefresh.isRefreshing = true
+            }
             emptyView.visibility = when {
                 refresh is LoadState.Error -> {
                     emptyView.text = refresh.error.localizedMessage

--- a/native/android-app/src/main/java/com/fire/app/ui/home/HomeFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/home/HomeFragment.kt
@@ -47,6 +47,7 @@ class HomeFragment : Fragment() {
     private lateinit var createTopicButton: View
 
     private var viewModel: HomeViewModel? = null
+    private var pendingAutoRefresh = false
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -90,6 +91,11 @@ class HomeFragment : Fragment() {
         recyclerView.layoutManager = LinearLayoutManager(requireContext())
         recyclerView.adapter = adapter
         recyclerView.optimizeForPaging()
+        recyclerView.addOnScrollListener(object : RecyclerView.OnScrollListener() {
+            override fun onScrolled(recyclerView: RecyclerView, dx: Int, dy: Int) {
+                flushPendingAutoRefreshIfAtTop()
+            }
+        })
         adapter.addLoadStateListener { loadStates ->
             val refresh = loadStates.refresh
             val isInitialLoading = refresh is LoadState.Loading && adapter.itemCount == 0
@@ -108,6 +114,7 @@ class HomeFragment : Fragment() {
             }
             if (refresh !is LoadState.Loading) {
                 swipeRefresh.isRefreshing = false
+                flushPendingAutoRefreshIfAtTop()
             }
         }
 
@@ -146,7 +153,12 @@ class HomeFragment : Fragment() {
                     }
                     launch {
                         vm.topicListRefreshEvents.collect {
-                            adapter.refresh()
+                            if (isTopicListAtTop()) {
+                                pendingAutoRefresh = false
+                                adapter.refresh()
+                            } else {
+                                pendingAutoRefresh = true
+                            }
                         }
                     }
                     launch {
@@ -183,6 +195,7 @@ class HomeFragment : Fragment() {
 
     private fun setupSwipeRefresh() {
         swipeRefresh.setOnRefreshListener {
+            pendingAutoRefresh = false
             adapter.refresh()
         }
     }
@@ -222,6 +235,27 @@ class HomeFragment : Fragment() {
             }
             selectedTagsGroup.addView(chip)
         }
+    }
+
+    private fun isTopicListAtTop(): Boolean {
+        val layoutManager = recyclerView.layoutManager as? LinearLayoutManager ?: return true
+        val firstVisiblePosition = layoutManager.findFirstVisibleItemPosition()
+        if (firstVisiblePosition > 0) {
+            return false
+        }
+        val firstVisibleView = layoutManager.findViewByPosition(firstVisiblePosition)
+        return firstVisibleView == null || firstVisibleView.top >= recyclerView.paddingTop
+    }
+
+    private fun flushPendingAutoRefreshIfAtTop() {
+        if (!pendingAutoRefresh || swipeRefresh.isRefreshing) {
+            return
+        }
+        if (!isTopicListAtTop()) {
+            return
+        }
+        pendingAutoRefresh = false
+        adapter.refresh()
     }
 
     private class HomeViewModelFactory(

--- a/native/android-app/src/main/java/com/fire/app/ui/home/HomeViewModel.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/home/HomeViewModel.kt
@@ -39,7 +39,6 @@ import uniffi.fire_uniffi_types.TopicRowState
 
 private data class HomeTopicFilter(
     val kind: TopicListKindState,
-    val baseUrl: String?,
     val categoryId: ULong?,
     val categorySlug: String?,
     val parentCategorySlug: String?,
@@ -171,7 +170,6 @@ class HomeViewModel(
             }
             HomeTopicFilter(
                 kind = kind,
-                baseUrl = session?.bootstrap?.baseUrl,
                 categoryId = category?.id,
                 categorySlug = category?.slug?.takeIf { it.isNotBlank() },
                 parentCategorySlug = parentCategory?.slug?.takeIf { it.isNotBlank() },
@@ -276,7 +274,6 @@ class HomeViewModel(
                 TopicListPagingSource(
                     repository = topicRepository,
                     kind = filter.kind,
-                    baseUrl = filter.baseUrl,
                     categorySlug = filter.categorySlug,
                     categoryId = filter.categoryId,
                     parentCategorySlug = filter.parentCategorySlug,

--- a/native/android-app/src/main/java/com/fire/app/ui/home/HomeViewModel.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/home/HomeViewModel.kt
@@ -362,9 +362,10 @@ class HomeViewModel(
             stopRealtimeRefresh()
         }
 
-        if (batch == RefreshBatchState.CORE) {
-            _topicListRefreshEvents.tryEmit(Unit)
-        }
+        // Rust core refresh already fetched the current home scope. Triggering
+        // Paging.refresh() here reissues the same request and can invalidate a
+        // deep scroll position at the wrong anchor page.
+        if (batch == RefreshBatchState.CORE) return
     }
 
     private fun handleTopicListMessageBusEvent(event: MessageBusEventState) {

--- a/native/android-app/src/main/java/com/fire/app/ui/startup/PreheatGateFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/startup/PreheatGateFragment.kt
@@ -1,12 +1,9 @@
 package com.fire.app.ui.startup
 
 import android.os.Bundle
-import android.view.Gravity
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
-import android.widget.FrameLayout
-import android.widget.ProgressBar
 import android.widget.TextView
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.lifecycleScope
@@ -14,95 +11,37 @@ import androidx.navigation.fragment.findNavController
 import com.fire.app.R
 import com.fire.app.session.FireAppStateRefreshRepository
 import com.fire.app.session.FireSessionStoreRepository
+import com.google.android.material.button.MaterialButton
 import kotlinx.coroutines.launch
 import uniffi.fire_uniffi_session.LoginStateDeterminationState
 import uniffi.fire_uniffi_session.RefreshTriggerState
 
 class PreheatGateFragment : Fragment() {
 
-    private lateinit var statusText: TextView
     private lateinit var errorText: TextView
-    private lateinit var retryButton: TextView
-    private lateinit var progressBar: ProgressBar
+    private lateinit var statusButton: MaterialButton
 
     override fun onCreateView(
         inflater: LayoutInflater,
         container: ViewGroup?,
         savedInstanceState: Bundle?,
     ): View {
-        val root = FrameLayout(requireContext()).apply {
-            layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.MATCH_PARENT,
-            )
-        }
-
-        progressBar = ProgressBar(requireContext()).apply {
-            layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.WRAP_CONTENT,
-                FrameLayout.LayoutParams.WRAP_CONTENT,
-                Gravity.CENTER,
-            )
-            isIndeterminate = true
-        }
-        root.addView(progressBar)
-
-        statusText = TextView(requireContext()).apply {
-            text = "\u6b63\u5728\u52a0\u8f7d..."
-            textSize = 14f
-            gravity = Gravity.CENTER
-            layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.WRAP_CONTENT,
-                Gravity.CENTER,
-            ).apply {
-                topMargin = 120
-            }
-        }
-        root.addView(statusText)
-
-        errorText = TextView(requireContext()).apply {
-            textSize = 16f
-            gravity = Gravity.CENTER
-            visibility = View.GONE
-            layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.MATCH_PARENT,
-                FrameLayout.LayoutParams.WRAP_CONTENT,
-                Gravity.CENTER,
-            )
-        }
-        root.addView(errorText)
-
-        retryButton = TextView(requireContext()).apply {
-            text = "\u91cd\u8bd5"
-            textSize = 16f
-            gravity = Gravity.CENTER
-            visibility = View.GONE
-            setOnClickListener { awaitPreloadedData() }
-            layoutParams = FrameLayout.LayoutParams(
-                FrameLayout.LayoutParams.WRAP_CONTENT,
-                FrameLayout.LayoutParams.WRAP_CONTENT,
-                Gravity.CENTER,
-            ).apply {
-                topMargin = 200
-            }
-        }
-        root.addView(retryButton)
-
-        return root
+        return inflater.inflate(R.layout.fragment_onboarding, container, false)
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
+        errorText = view.findViewById(R.id.onboarding_error)
+        statusButton = view.findViewById(R.id.login_button)
+        statusButton.visibility = View.VISIBLE
+        statusButton.setOnClickListener { awaitPreloadedData() }
         awaitPreloadedData()
     }
 
     private fun awaitPreloadedData() {
-        progressBar.visibility = View.VISIBLE
-        statusText.visibility = View.VISIBLE
-        statusText.text = "\u6b63\u5728\u52a0\u8f7d..."
+        statusButton.isEnabled = false
+        statusButton.text = getString(R.string.onboarding_checking_login_state)
         errorText.visibility = View.GONE
-        retryButton.visibility = View.GONE
 
         val store = FireSessionStoreRepository.get(requireContext())
         viewLifecycleOwner.lifecycleScope.launch {
@@ -125,6 +64,9 @@ class PreheatGateFragment : Fragment() {
                 )
                 findNavController().navigate(R.id.action_preheatGate_to_home)
             }
+            LoginStateDeterminationState.NetworkErrorPreserveState -> {
+                showError(getString(R.string.onboarding_login_check_failed))
+            }
             else -> {
                 findNavController().navigate(R.id.action_preheatGate_to_onboarding)
             }
@@ -132,10 +74,9 @@ class PreheatGateFragment : Fragment() {
     }
 
     private fun showError(message: String) {
-        progressBar.visibility = View.GONE
-        statusText.visibility = View.GONE
         errorText.visibility = View.VISIBLE
         errorText.text = message
-        retryButton.visibility = View.VISIBLE
+        statusButton.isEnabled = true
+        statusButton.text = getString(R.string.onboarding_retry_login_check)
     }
 }

--- a/native/android-app/src/main/res/drawable/bg_onboarding_error_banner.xml
+++ b/native/android-app/src/main/res/drawable/bg_onboarding_error_banner.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/fire_background_elevated" />
+    <stroke
+        android:width="1dp"
+        android:color="@color/fire_divider" />
+    <corners android:radius="10dp" />
+</shape>

--- a/native/android-app/src/main/res/drawable/bg_topic_skeleton_primary.xml
+++ b/native/android-app/src/main/res/drawable/bg_topic_skeleton_primary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/fire_skeleton_primary" />
+    <corners android:radius="4dp" />
+</shape>

--- a/native/android-app/src/main/res/drawable/bg_topic_skeleton_secondary.xml
+++ b/native/android-app/src/main/res/drawable/bg_topic_skeleton_secondary.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/fire_skeleton_secondary" />
+    <corners android:radius="4dp" />
+</shape>

--- a/native/android-app/src/main/res/layout/fragment_home.xml
+++ b/native/android-app/src/main/res/layout/fragment_home.xml
@@ -77,35 +77,53 @@
 
     </HorizontalScrollView>
 
-    <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-        android:id="@+id/swipe_refresh"
+    <FrameLayout
+        android:id="@+id/topic_list_container"
         android:layout_width="match_parent"
         android:layout_height="0dp"
         android:layout_weight="1">
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/topic_list"
+        <androidx.swiperefreshlayout.widget.SwipeRefreshLayout
+            android:id="@+id/swipe_refresh"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/topic_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingHorizontal="12dp" />
+
+        </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+
+        <LinearLayout
+            android:id="@+id/loading_skeleton_view"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
-            android:clipToPadding="false"
-            android:paddingHorizontal="12dp" />
+            android:orientation="vertical"
+            android:paddingHorizontal="12dp"
+            android:visibility="gone">
 
-    </androidx.swiperefreshlayout.widget.SwipeRefreshLayout>
+            <include layout="@layout/item_topic_row_skeleton" />
+            <include layout="@layout/item_topic_row_skeleton" />
+            <include layout="@layout/item_topic_row_skeleton" />
+            <include layout="@layout/item_topic_row_skeleton" />
+            <include layout="@layout/item_topic_row_skeleton" />
+            <include layout="@layout/item_topic_row_skeleton" />
 
-    <ProgressBar
-        android:id="@+id/loading_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:visibility="gone" />
+        </LinearLayout>
 
-    <TextView
-        android:id="@+id/empty_view"
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:text="@string/browser_empty"
-        android:textAppearance="@style/TextAppearance.AppCompat.Body1"
-        android:visibility="gone" />
+        <TextView
+            android:id="@+id/empty_view"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:text="@string/browser_empty"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+            android:textColor="@color/fire_text_secondary"
+            android:visibility="gone" />
+
+    </FrameLayout>
 
 </LinearLayout>

--- a/native/android-app/src/main/res/layout/fragment_onboarding.xml
+++ b/native/android-app/src/main/res/layout/fragment_onboarding.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:background="@color/fire_background_canvas"
     android:gravity="center_horizontal"
     android:orientation="vertical"
     android:paddingHorizontal="24dp">
@@ -39,6 +41,19 @@
         android:layout_height="0dp"
         android:layout_weight="1" />
 
+    <TextView
+        android:id="@+id/onboarding_error"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="12dp"
+        android:background="@drawable/bg_onboarding_error_banner"
+        android:ellipsize="end"
+        android:maxLines="3"
+        android:padding="12dp"
+        android:textAppearance="@style/TextAppearance.AppCompat.Caption"
+        android:textColor="@color/fire_text_secondary"
+        android:visibility="gone" />
+
     <com.google.android.material.button.MaterialButton
         android:id="@+id/login_button"
         android:layout_width="match_parent"
@@ -47,7 +62,6 @@
         android:textAllCaps="false"
         android:visibility="gone"
         app:backgroundTint="@color/fire_accent"
-        app:cornerRadius="12dp"
-        xmlns:app="http://schemas.android.com/apk/res-auto" />
+        app:cornerRadius="12dp" />
 
 </LinearLayout>

--- a/native/android-app/src/main/res/layout/item_topic_row_skeleton.xml
+++ b/native/android-app/src/main/res/layout/item_topic_row_skeleton.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginVertical="4dp"
+    app:cardBackgroundColor="@color/fire_background_surface"
+    app:cardCornerRadius="12dp"
+    app:cardElevation="0dp"
+    app:strokeColor="@color/fire_divider"
+    app:strokeWidth="1dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="14dp">
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="16dp"
+            android:layout_marginEnd="48dp"
+            android:background="@drawable/bg_topic_skeleton_primary" />
+
+        <View
+            android:layout_width="160dp"
+            android:layout_height="10dp"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/bg_topic_skeleton_secondary" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="12dp"
+            android:layout_marginTop="12dp"
+            android:background="@drawable/bg_topic_skeleton_secondary" />
+
+        <View
+            android:layout_width="240dp"
+            android:layout_height="12dp"
+            android:layout_marginTop="6dp"
+            android:background="@drawable/bg_topic_skeleton_secondary" />
+
+    </LinearLayout>
+</com.google.android.material.card.MaterialCardView>

--- a/native/android-app/src/main/res/values-night/fire_colors.xml
+++ b/native/android-app/src/main/res/values-night/fire_colors.xml
@@ -10,6 +10,8 @@
     <color name="fire_background_canvas">#FF141516</color>
     <color name="fire_background_surface">#FF1E1F21</color>
     <color name="fire_background_elevated">#FF252629</color>
+    <color name="fire_skeleton_primary">#FF34363A</color>
+    <color name="fire_skeleton_secondary">#FF2B2D31</color>
 
     <color name="fire_code_background">#FF1E2430</color>
     <color name="fire_quote_stripe">#4D9CA3AF</color>

--- a/native/android-app/src/main/res/values/fire_colors.xml
+++ b/native/android-app/src/main/res/values/fire_colors.xml
@@ -13,6 +13,8 @@
     <color name="fire_background_canvas">#FFF5F3F0</color>
     <color name="fire_background_surface">#FFFFFFFF</color>
     <color name="fire_background_elevated">#FFFFFFFF</color>
+    <color name="fire_skeleton_primary">#FFE5E7EB</color>
+    <color name="fire_skeleton_secondary">#FFF0F1F3</color>
 
     <!-- Code / quote -->
     <color name="fire_code_background">#FFEFF3F8</color>

--- a/native/android-app/src/main/res/values/strings.xml
+++ b/native/android-app/src/main/res/values/strings.xml
@@ -387,4 +387,7 @@
     <string name="content_desc_avatar">头像</string>
     <string name="onboarding_subtitle">LinuxDo 原生客户端</string>
     <string name="onboarding_login">登录 LinuxDo</string>
+    <string name="onboarding_checking_login_state">正在校验登录态…</string>
+    <string name="onboarding_retry_login_check">重试登录态校验</string>
+    <string name="onboarding_login_check_failed">登录态校验失败，请检查网络后重试。</string>
 </resources>

--- a/native/ios-app/App/Startup/FirePreheatGateViewController.swift
+++ b/native/ios-app/App/Startup/FirePreheatGateViewController.swift
@@ -1,12 +1,7 @@
 import UIKit
 
 final class FirePreheatGateViewController: UIViewController {
-    private let loadingIndicator = UIActivityIndicatorView(style: .large)
-    private let statusLabel = UILabel()
-    private let errorContainer = UIView()
-    private let errorLabel = UILabel()
-    private let retryButton = UIButton(type: .system)
-    private let logoutButton = UIButton(type: .system)
+    private let statusView = FireStartupOnboardingStatusView()
 
     private let sessionStore: FireSessionStore
     private var isLoaded = false
@@ -25,70 +20,22 @@ final class FirePreheatGateViewController: UIViewController {
     }
 
     private func setupUI() {
-        view.backgroundColor = .systemBackground
-
-        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
-        loadingIndicator.startAnimating()
-        view.addSubview(loadingIndicator)
-
-        statusLabel.translatesAutoresizingMaskIntoConstraints = false
-        statusLabel.text = "正在加载..."
-        statusLabel.textColor = .secondaryLabel
-        statusLabel.font = .systemFont(ofSize: 14)
-        statusLabel.textAlignment = .center
-        view.addSubview(statusLabel)
-
-        errorContainer.translatesAutoresizingMaskIntoConstraints = false
-        errorContainer.isHidden = true
-        view.addSubview(errorContainer)
-
-        errorLabel.translatesAutoresizingMaskIntoConstraints = false
-        errorLabel.textColor = .label
-        errorLabel.font = .systemFont(ofSize: 16)
-        errorLabel.textAlignment = .center
-        errorLabel.numberOfLines = 0
-        errorContainer.addSubview(errorLabel)
-
-        retryButton.translatesAutoresizingMaskIntoConstraints = false
-        retryButton.setTitle("重试", for: .normal)
-        retryButton.addTarget(self, action: #selector(retryTapped), for: .touchUpInside)
-        errorContainer.addSubview(retryButton)
-
-        logoutButton.translatesAutoresizingMaskIntoConstraints = false
-        logoutButton.setTitle("退出登录", for: .normal)
-        logoutButton.addTarget(self, action: #selector(logoutTapped), for: .touchUpInside)
-        errorContainer.addSubview(logoutButton)
+        view.backgroundColor = FireStartupOnboardingPalette.background
+        statusView.translatesAutoresizingMaskIntoConstraints = false
+        statusView.showLoading("正在校验登录态…")
+        view.addSubview(statusView)
 
         NSLayoutConstraint.activate([
-            loadingIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            loadingIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            statusLabel.topAnchor.constraint(equalTo: loadingIndicator.bottomAnchor, constant: 12),
-            statusLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-
-            errorContainer.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            errorContainer.centerYAnchor.constraint(equalTo: view.centerYAnchor),
-            errorContainer.leadingAnchor.constraint(greaterThanOrEqualTo: view.leadingAnchor, constant: 40),
-            errorContainer.trailingAnchor.constraint(lessThanOrEqualTo: view.trailingAnchor, constant: -40),
-
-            errorLabel.topAnchor.constraint(equalTo: errorContainer.topAnchor),
-            errorLabel.leadingAnchor.constraint(equalTo: errorContainer.leadingAnchor),
-            errorLabel.trailingAnchor.constraint(equalTo: errorContainer.trailingAnchor),
-
-            retryButton.topAnchor.constraint(equalTo: errorLabel.bottomAnchor, constant: 20),
-            retryButton.centerXAnchor.constraint(equalTo: errorContainer.centerXAnchor),
-
-            logoutButton.topAnchor.constraint(equalTo: retryButton.bottomAnchor, constant: 12),
-            logoutButton.centerXAnchor.constraint(equalTo: errorContainer.centerXAnchor),
-            logoutButton.bottomAnchor.constraint(equalTo: errorContainer.bottomAnchor),
+            statusView.topAnchor.constraint(equalTo: view.topAnchor),
+            statusView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            statusView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            statusView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
     }
 
     private func awaitPreloadedData() {
         Task { @MainActor in
-            loadingIndicator.startAnimating()
-            loadingIndicator.isHidden = false
-            statusLabel.isHidden = false
-            errorContainer.isHidden = true
+            statusView.showLoading("正在校验登录态…")
 
             do {
                 _ = try await sessionStore.prepareStartupSession()
@@ -102,28 +49,167 @@ final class FirePreheatGateViewController: UIViewController {
 
     private func onPreloadedDataReady() {
         isLoaded = true
-        loadingIndicator.stopAnimating()
         NotificationCenter.default.post(name: .firePreheatGateDidComplete, object: nil)
     }
 
     private func showErrorPage(_ message: String) {
-        loadingIndicator.stopAnimating()
-        loadingIndicator.isHidden = true
-        statusLabel.isHidden = true
-        errorContainer.isHidden = false
-        errorLabel.text = message
-    }
-
-    @objc private func retryTapped() {
-        awaitPreloadedData()
-    }
-
-    @objc private func logoutTapped() {
-        NotificationCenter.default.post(name: .firePreheatGateRequestsLogout, object: nil)
+        statusView.showError(message, onRetry: { [weak self] in
+            self?.awaitPreloadedData()
+        })
     }
 }
 
 extension Notification.Name {
     static let firePreheatGateDidComplete = Notification.Name("firePreheatGateDidComplete")
-    static let firePreheatGateRequestsLogout = Notification.Name("firePreheatGateRequestsLogout")
+}
+
+enum FireStartupOnboardingPalette {
+    static let accent = UIColor { traits in
+        traits.userInterfaceStyle == .dark
+            ? UIColor(red: 0.961, green: 0.451, blue: 0.212, alpha: 1)
+            : UIColor(red: 0.91, green: 0.388, blue: 0.18, alpha: 1)
+    }
+
+    static let background = UIColor.systemBackground
+}
+
+final class FireStartupOnboardingStatusView: UIView {
+    private let heroStack = UIStackView()
+    private let logoView = UIImageView()
+    private let titleLabel = UILabel()
+    private let subtitleLabel = UILabel()
+    private let actionStack = UIStackView()
+    private let errorBanner = UIView()
+    private let errorLabel = UILabel()
+    private let actionButton = UIButton(type: .system)
+    private var onRetry: (() -> Void)?
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupUI()
+    }
+
+    required init?(coder: NSCoder) { fatalError() }
+
+    func showLoading(_ message: String) {
+        onRetry = nil
+        errorBanner.isHidden = true
+        actionButton.isEnabled = false
+        actionButton.removeTarget(self, action: #selector(retryTapped), for: .touchUpInside)
+
+        var configuration = UIButton.Configuration.filled()
+        configuration.title = message
+        configuration.showsActivityIndicator = true
+        configuration.baseBackgroundColor = FireStartupOnboardingPalette.accent
+        configuration.baseForegroundColor = .white
+        configuration.cornerStyle = .fixed
+        configuration.background.cornerRadius = 12
+        configuration.contentInsets = NSDirectionalEdgeInsets(
+            top: 14,
+            leading: 16,
+            bottom: 14,
+            trailing: 16
+        )
+        actionButton.configuration = configuration
+    }
+
+    func showError(_ message: String, onRetry: @escaping () -> Void) {
+        self.onRetry = onRetry
+        errorLabel.text = message
+        errorBanner.isHidden = false
+        actionButton.isEnabled = true
+        actionButton.removeTarget(self, action: #selector(retryTapped), for: .touchUpInside)
+        actionButton.addTarget(self, action: #selector(retryTapped), for: .touchUpInside)
+
+        var configuration = UIButton.Configuration.filled()
+        configuration.title = "重试登录态校验"
+        configuration.image = UIImage(systemName: "arrow.clockwise")
+        configuration.imagePadding = 8
+        configuration.baseBackgroundColor = FireStartupOnboardingPalette.accent
+        configuration.baseForegroundColor = .white
+        configuration.cornerStyle = .fixed
+        configuration.background.cornerRadius = 12
+        configuration.contentInsets = NSDirectionalEdgeInsets(
+            top: 14,
+            leading: 16,
+            bottom: 14,
+            trailing: 16
+        )
+        actionButton.configuration = configuration
+    }
+
+    private func setupUI() {
+        backgroundColor = FireStartupOnboardingPalette.background
+
+        heroStack.translatesAutoresizingMaskIntoConstraints = false
+        heroStack.axis = .vertical
+        heroStack.alignment = .center
+        heroStack.spacing = 20
+        addSubview(heroStack)
+
+        let logoConfiguration = UIImage.SymbolConfiguration(pointSize: 56, weight: .regular)
+        logoView.image = UIImage(systemName: "flame.fill", withConfiguration: logoConfiguration)
+        logoView.tintColor = FireStartupOnboardingPalette.accent
+        logoView.contentMode = .scaleAspectFit
+        logoView.setContentHuggingPriority(.required, for: .vertical)
+        heroStack.addArrangedSubview(logoView)
+
+        let titleStack = UIStackView()
+        titleStack.axis = .vertical
+        titleStack.alignment = .center
+        titleStack.spacing = 8
+        heroStack.addArrangedSubview(titleStack)
+
+        titleLabel.text = "Fire"
+        titleLabel.font = .systemFont(ofSize: 34, weight: .bold)
+        titleLabel.textColor = .label
+        titleStack.addArrangedSubview(titleLabel)
+
+        subtitleLabel.text = "LinuxDo 原生客户端"
+        subtitleLabel.font = .preferredFont(forTextStyle: .subheadline)
+        subtitleLabel.textColor = .secondaryLabel
+        titleStack.addArrangedSubview(subtitleLabel)
+
+        actionStack.translatesAutoresizingMaskIntoConstraints = false
+        actionStack.axis = .vertical
+        actionStack.spacing = 12
+        addSubview(actionStack)
+
+        errorBanner.isHidden = true
+        errorBanner.backgroundColor = .tertiarySystemFill
+        errorBanner.layer.cornerRadius = 10
+        errorBanner.layer.cornerCurve = .continuous
+        actionStack.addArrangedSubview(errorBanner)
+
+        errorLabel.translatesAutoresizingMaskIntoConstraints = false
+        errorLabel.font = .preferredFont(forTextStyle: .caption1)
+        errorLabel.textColor = .secondaryLabel
+        errorLabel.numberOfLines = 3
+        errorBanner.addSubview(errorLabel)
+
+        actionButton.titleLabel?.font = .preferredFont(forTextStyle: .headline)
+        actionStack.addArrangedSubview(actionButton)
+
+        NSLayoutConstraint.activate([
+            heroStack.centerXAnchor.constraint(equalTo: centerXAnchor),
+            heroStack.centerYAnchor.constraint(equalTo: centerYAnchor, constant: -52),
+            heroStack.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 24),
+            heroStack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -24),
+
+            actionStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 24),
+            actionStack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -24),
+            actionStack.bottomAnchor.constraint(equalTo: safeAreaLayoutGuide.bottomAnchor, constant: -40),
+
+            errorLabel.topAnchor.constraint(equalTo: errorBanner.topAnchor, constant: 12),
+            errorLabel.bottomAnchor.constraint(equalTo: errorBanner.bottomAnchor, constant: -12),
+            errorLabel.leadingAnchor.constraint(equalTo: errorBanner.leadingAnchor, constant: 12),
+            errorLabel.trailingAnchor.constraint(equalTo: errorBanner.trailingAnchor, constant: -12),
+
+            actionButton.heightAnchor.constraint(greaterThanOrEqualToConstant: 46),
+        ])
+    }
+
+    @objc private func retryTapped() {
+        onRetry?()
+    }
 }

--- a/native/ios-app/App/Views/Other/FireTabRoot.swift
+++ b/native/ios-app/App/Views/Other/FireTabRoot.swift
@@ -92,10 +92,6 @@ struct FireTabRoot: View {
                 preheatComplete = true
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: .firePreheatGateRequestsLogout)) { _ in
-            preheatComplete = true
-            viewModel.logout()
-        }
         .fullScreenCover(item: $viewModel.authPresentationState) { presentationState in
             FireAuthScreen(
                 viewModel: viewModel,
@@ -232,7 +228,7 @@ struct FirePreheatGateRepresentable: UIViewControllerRepresentable {
 final class FirePreheatGateWaitingViewController: UIViewController {
     private(set) var sessionStore: FireSessionStore?
     private var gateViewController: FirePreheatGateViewController?
-    private let loadingIndicator = UIActivityIndicatorView(style: .large)
+    private let statusView = FireStartupOnboardingStatusView()
 
     init(sessionStore: FireSessionStore?) {
         self.sessionStore = sessionStore
@@ -243,14 +239,16 @@ final class FirePreheatGateWaitingViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        view.backgroundColor = .systemBackground
+        view.backgroundColor = FireStartupOnboardingPalette.background
 
-        loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
-        loadingIndicator.startAnimating()
-        view.addSubview(loadingIndicator)
+        statusView.translatesAutoresizingMaskIntoConstraints = false
+        statusView.showLoading("正在准备登录态…")
+        view.addSubview(statusView)
         NSLayoutConstraint.activate([
-            loadingIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            loadingIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor),
+            statusView.topAnchor.constraint(equalTo: view.topAnchor),
+            statusView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            statusView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            statusView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
         ])
 
         if let store = sessionStore {
@@ -267,8 +265,7 @@ final class FirePreheatGateWaitingViewController: UIViewController {
 
     private func installGate(with store: FireSessionStore) {
         guard gateViewController == nil else { return }
-        loadingIndicator.stopAnimating()
-        loadingIndicator.removeFromSuperview()
+        statusView.removeFromSuperview()
         let gate = FirePreheatGateViewController(sessionStore: store)
         gateViewController = gate
         addChild(gate)

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -89,7 +89,7 @@ Current host-side app wiring lives under `Sources/FireAppSession/` plus `App/`:
   - presents the login browser immediately, then runs a lightweight best-effort network warm-up in the background
   - still tries to move the first system-level network prompt, when one appears on-device, out of the in-page login interaction itself, without blocking WebView presentation
   - restores the persisted session cache, replays Keychain cookies through Rust on cold start, repairs incomplete authenticated session identity through bootstrap refresh when needed, and leaves CSRF repair to the shared authenticated-write preflight
-  - holds the onboarding screen in a bootstrap state while cold-start auto-login runs, hiding login actions during restore and only revealing a loading indicator if that bootstrap takes longer than 500ms
+  - keeps startup login-state verification on an onboarding-style screen: the brand shell stays visible, the login action is hidden, and the button slot shows the current verification state until PreheatGate finishes or exposes a retryable failure
   - now builds `FireSessionStore` lazily on a detached task so Rust/logging initialization does not block the first SwiftUI render on the main actor
   - syncs authenticated LinuxDo cookies into native `HTTPCookieStorage` so inline media/image requests can reuse the restored session, while leaving the persistent WebKit cookie store as the authoritative browser session owned by login and Cloudflare WebViews
   - now also owns native private-message inbox/sent loading plus private-message creation on top of the shared Rust mailbox and `/posts.json` PM surfaces
@@ -242,7 +242,8 @@ Workspace note:
 Current UX note:
 
 - The app now opens login as a full-screen browser instead of a partial sheet.
-- The app now keeps the same onboarding page visible during cold-start auto-login, hiding login actions until restore fails and only showing loading if bootstrap takes longer than 500ms.
+- The app now keeps the same onboarding visual shell visible during cold-start login-state verification. The login button is hidden during PreheatGate, the button slot shows the verification state, and startup failures stay on that screen with a retry action.
+- Once startup or login reaches the authenticated shell, the Home list owns its data-loading presentation and renders topic-row skeletons for the initial empty load instead of showing another full-screen gate.
 - The login browser can navigate back from Google or other intermediate pages without forcing the user to close and reopen login.
 - The login browser now auto-probes whether sync would actually succeed, re-checking on navigation, scene resume, debounced WebKit auth-cookie changes, and loading-state transitions. `完成登录` stays disabled until username, auth cookies, reusable bootstrap HTML, and an idle WebView are all present.
 - The login shell and reading workspace now adapt to both light and dark system appearance while preserving the same hierarchy and contrast model.

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -249,9 +249,7 @@ pub(crate) struct TracedRequest {
     pub(crate) request: Request<RequestBody>,
 }
 
-fn clone_request_for_retry(
-    request: &Request<RequestBody>,
-) -> Option<Request<RequestBody>> {
+fn clone_request_for_retry(request: &Request<RequestBody>) -> Option<Request<RequestBody>> {
     let cloned_body = request.body().try_clone()?;
     let request_profile = request.extensions().get::<FireRequestProfile>().copied();
     let request_epoch = request.extensions().get::<FireRequestEpoch>().copied();
@@ -1588,9 +1586,7 @@ mod tests {
             .uri("https://example.com/latest.json")
             .body(RequestBody::empty())
             .expect("request");
-        request
-            .extensions_mut()
-            .insert(FireRequestProfile::JsonApi);
+        request.extensions_mut().insert(FireRequestProfile::JsonApi);
         request.extensions_mut().insert(FireRequestEpoch(7));
         let original_trace_id = diagnostics.prepare_request_trace("fetch topic list", &mut request);
 
@@ -1603,11 +1599,17 @@ mod tests {
             .get::<crate::diagnostics::FireRequestTraceMetadata>()
             .is_none());
         assert!(matches!(
-            retry_request.extensions().get::<FireRequestProfile>().copied(),
+            retry_request
+                .extensions()
+                .get::<FireRequestProfile>()
+                .copied(),
             Some(FireRequestProfile::JsonApi)
         ));
         assert!(matches!(
-            retry_request.extensions().get::<FireRequestEpoch>().copied(),
+            retry_request
+                .extensions()
+                .get::<FireRequestEpoch>()
+                .copied(),
             Some(FireRequestEpoch(7))
         ));
     }

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -250,10 +250,8 @@ pub(crate) struct TracedRequest {
 }
 
 fn clone_request_for_retry(
-    diagnostics: &Arc<FireDiagnosticsStore>,
-    operation: &'static str,
     request: &Request<RequestBody>,
-) -> Option<TracedRequest> {
+) -> Option<Request<RequestBody>> {
     let cloned_body = request.body().try_clone()?;
     let request_profile = request.extensions().get::<FireRequestProfile>().copied();
     let request_epoch = request.extensions().get::<FireRequestEpoch>().copied();
@@ -271,12 +269,20 @@ fn clone_request_for_retry(
     if let Some(epoch) = request_epoch {
         request.extensions_mut().insert(epoch);
     }
+    Some(request)
+}
+
+fn trace_request(
+    diagnostics: &Arc<FireDiagnosticsStore>,
+    operation: &'static str,
+    mut request: Request<RequestBody>,
+) -> TracedRequest {
     let trace_id = diagnostics.prepare_request_trace(operation, &mut request);
-    Some(TracedRequest {
+    TracedRequest {
         trace_id,
         operation,
         request,
-    })
+    }
 }
 
 fn response_from_parts<B>(parts: http::response::Parts, body: B) -> Response<ResponseBody>
@@ -721,7 +727,7 @@ impl FireCore {
     ) -> Result<(u64, Response<ResponseBody>), FireCoreError> {
         let has_challenge_handler = self.cloudflare_challenge_handler.get().is_some();
         let retry_request = if has_challenge_handler {
-            clone_request_for_retry(&self.diagnostics, traced.operation, &traced.request)
+            clone_request_for_retry(&traced.request)
         } else {
             None
         };
@@ -800,11 +806,11 @@ impl FireCore {
                 && session.cookies.has_cloudflare_clearance();
             if !has_new_clearance {
                 Err(FireCoreError::CloudflareChallenge { operation })
-            } else if let Some(mut retry) = retry_request {
-                retry
-                    .request
+            } else if let Some(mut retry_request) = retry_request {
+                retry_request
                     .extensions_mut()
                     .insert(FireRequestEpoch(self.current_session_epoch()));
+                let retry = trace_request(&self.diagnostics, operation, retry_request);
                 self.network
                     .execute_traced(retry, FireCallProfile::DefaultApi)
                     .await
@@ -1572,5 +1578,37 @@ mod tests {
             .get("X-CSRF-Token")
             .and_then(|value| value.to_str().ok());
         assert_eq!(csrf_header, Some("real-csrf"));
+    }
+
+    #[test]
+    fn clone_request_for_retry_does_not_create_a_second_trace_until_replayed() {
+        let diagnostics = Arc::new(FireDiagnosticsStore::new());
+        let mut request = Request::builder()
+            .method(Method::GET)
+            .uri("https://example.com/latest.json")
+            .body(RequestBody::empty())
+            .expect("request");
+        request
+            .extensions_mut()
+            .insert(FireRequestProfile::JsonApi);
+        request.extensions_mut().insert(FireRequestEpoch(7));
+        let original_trace_id = diagnostics.prepare_request_trace("fetch topic list", &mut request);
+
+        let retry_request = clone_request_for_retry(&request).expect("retry request");
+
+        assert_eq!(diagnostics.summaries(10).len(), 1);
+        assert_eq!(diagnostics.summaries(10)[0].id, original_trace_id);
+        assert!(retry_request
+            .extensions()
+            .get::<crate::diagnostics::FireRequestTraceMetadata>()
+            .is_none());
+        assert!(matches!(
+            retry_request.extensions().get::<FireRequestProfile>().copied(),
+            Some(FireRequestProfile::JsonApi)
+        ));
+        assert!(matches!(
+            retry_request.extensions().get::<FireRequestEpoch>().copied(),
+            Some(FireRequestEpoch(7))
+        ));
     }
 }

--- a/rust/crates/fire-uniffi-topics/src/lib.rs
+++ b/rust/crates/fire-uniffi-topics/src/lib.rs
@@ -44,10 +44,9 @@ impl FireTopicsHandle {
             inner.fetch_topic_list(query.into()).await
         })
         .await?;
-        self.shared
-            .core
-            .state_observers()
-            .notify_topic_list(response.clone());
+        // Hosts apply direct topic-list fetch results themselves. Broadcasting
+        // every page through the global observer causes home feeds to treat
+        // paginated slices as authoritative full-list snapshots.
         Ok(response.into())
     }
 


### PR DESCRIPTION
## Summary
- stop duplicate home trace and topic-list snapshot emissions in the Rust topic list path
- stabilize Android home auto-refresh behavior and startup/loading UI states
- polish iOS startup preheat loading behavior
- add the topic detail main-thread and UI split optimization plan for the follow-up branch

## Validation
- git diff --cached --check
- git diff --check origin/main..HEAD

Full cross-platform gates will be run on the follow-up implementation branch after the topic-detail performance work lands.