### PR TITLE
feat: list metrics, display_segments, and main-thread store offload

### DIFF
--- a/docs/architecture/2026-06-17-unified-onboarding-launch-design.md
+++ b/docs/architecture/2026-06-17-unified-onboarding-launch-design.md
@@ -172,19 +172,21 @@ func performStartupValidation() async {
    - 从现有 `FireStartupOnboardingStatusView.showLoading` 抽取，纯展示。
 
 2. **`FireOnboardingCredentialFormView`**（从 `FireLoginViewController` 迁移，持续迭代）
-   - 包含：用户名输入、密码输入（右侧 eye 明文切换）、记住密码圆形勾选（`circle` / `checkmark.circle.fill`，字号 13）、登录按钮、忘记密码、其他方式登录。
+   - 包含：用户名输入、密码输入（右侧 eye 明文切换）、记住密码圆形勾选（`circle` / `checkmark.circle.fill`，字号 13，与右侧蓝色「忘记密码?」链接同一行）、登录按钮、官方第三方登录 icon 行（Google / GitHub / X / Discord / Apple / Passkey）。
    - **保留 `UIScrollView` + `contentView` 容器结构**，以适配小屏键盘遮挡：`scrollView.keyboardDismissMode = .interactive`、`contentView.widthAnchor == scrollView.frameLayoutGuide.widthAnchor` 保证竖向滚动 + 横向不溢出。
    - 外层 onboarding VC 将品牌区固定在 safe area 顶部的紧凑头部，`phaseContainerView` 占满品牌下方到 safe area / 键盘上方的可用空间，避免 logo 居中挤压账号密码和其他登录方式。
    - 监听键盘 `willChangeFrame` / `willHide` 通知，外层移动表单容器到键盘上方，表单内部按本地坐标补充 `scrollView.contentInset.bottom`，并支持点空白、拖动、Return/Go、输入工具栏"完成"关闭键盘。
-   - 不持有 viewModel，通过闭包回调：`onLoginTapped(identifier:password:remember:)`、`onForgotPassword`、`onOtherMethods`。
+   - 不持有 viewModel，通过闭包回调：`onLoginTapped(identifier:password:remember:)`、`onForgotPassword`、`onExternalLogin(FireExternalLoginMethod)`。
+   - 第三方登录不在 App 内自建 OAuth Client：icon 点击后由 onboarding VC present `FireWebViewBrowserViewController(url: /login, autoStartExternalLogin:)`，页面 `didFinish` 后注入脚本点击 Discourse `#login-buttons` 中对应 `button.btn-social.{provider}` 或 `button.passkey-login-button`，形成 native 入口 + WebView 完成 IdP 的效果。
+   - 登录成功后本地记录 `FireLastLoginMethod`（Keychain，host-scoped）：密码路径写 `.password`，第三方 WebView 路径写对应 provider；`prepareLoginForm()` 读回并通过 `applyLastLoginMethod` 高亮上次使用的 icon。
    - 暴露 `applySavedCredential(_:)`：仅在对应输入框为空时回填 Keychain 凭据；`nil` 绝不清空当前输入（人机验证失败 / 密码错误后需保留可改内容）。
    - 暴露 `setLoggingIn(_:)` 用于 disable/enable 表单。
    - 登录失败（含 captcha panel 失败、invalid credentials）不清理已输入账号密码。
    - **不包含 error banner**（见下方"error banner 职责统一"）。
 
-3. **`FireOnboardingLoggingInView`**（新建，约 30 行）
-   - 全屏半透明遮罩 + `UIActivityIndicatorView`（large）+ "正在登录…"。
-   - 覆盖在 credential form 之上。
+3. **`.loggingIn` phase（无独立 overlay 视图）**
+   - 保留 `FireOnboardingCredentialFormView`，仅 `setLoggingIn(true)`：禁用输入并在登录按钮上显示 spinner /「登录中…」。
+   - 不再使用半透明灰色遮罩（避免闪一下灰 container）；安全验证 sheet 弹出后回到 `.credential`。
 
 #### PhaseContainerView 切换逻辑
 
@@ -194,7 +196,7 @@ onboarding VC 持有 `phaseContainerView`，根据 phase 切换子视图：
 |---|---|
 | `.validating` | `FireOnboardingValidatingView` |
 | `.credential` | `FireOnboardingCredentialFormView` |
-| `.loggingIn` | `FireOnboardingCredentialFormView`（disabled）+ `FireOnboardingLoggingInView`（overlay） |
+| `.loggingIn` | `FireOnboardingCredentialFormView`（disabled + 按钮 spinner） |
 
 切换用 `UIView.transition` crossDissolve，duration 0.22（与 root 切换一致）。
 
@@ -289,7 +291,7 @@ func start() {
 - `completeLoginFromDialog()` — `viewModel.completeMinimalLogin(...)`
 - `showSecondFactorPrompt(requirement:)` — `UIAlertController` 6 位验证码
 - `recoverCloudflare()` — `cfRetryUsed` 单次重试
-- `presentWebViewBrowser(url:)` — 忘记密码 / 其他方式登录的 WKWebView 兜底
+- `presentWebViewBrowser(url:autoStartExternalLogin:)` — 忘记密码 / 第三方登录的 WKWebView 兜底；第三方入口会携带 `FireExternalLoginMethod` 以自动点击官方按钮
 - `setLoginLoading(_:)` / `showErrorBanner(_:)` / `hideErrorBanner()` / `dismissCaptchaDialog()`
 
 所有 viewModel 调用的方法签名不变。

--- a/docs/architecture/2026-07-21-ios-uikit-ux-modernization.md
+++ b/docs/architecture/2026-07-21-ios-uikit-ux-modernization.md
@@ -10,9 +10,11 @@ Reference style (consumer iOS dark settings / profile cards) is adopted **app-wi
 
 - **Canvas:** pure black in dark / OLED (`FireTheme.uiCanvas`)
 - **Cards / grouped rows:** elevated charcoal (`uiSurface` ~`#1C1C1E`, `uiSurfaceSecondary` ~`#2C2C2E`)
-- **Icon language:** monochrome SF Symbols on dark wells; brand accent remains Fire orange
+- **Icon language:** colored rounded icon wells + white SF Symbols on profile/settings rows; brand accent remains Fire orange
+- **Corners:** tighter continuous radii (`cornerRadius` 14 / `medium` 12 / `small` 10) — direct and clear, not overly bubbly
 - **Chrome:** nav/tab use theme canvas + material via `FireTheme.applyGlobalAppearances()`
-- **Profile / Settings:** closer visual replica of the reference (section labels, capsule appearance control, independent sign-out card, footer version)
+- **Profile / Settings:** reference-style cards with colored wells, compact top inset, capsule appearance control, independent sign-out card, footer version
+- **Home topic rows:** metric chips stay muted by default; notable/high values lift color weight (likes use the same 3-tier ladder as replies — not more); view *surge* (young + high velocity) shows a static 🔥/🚀 badge plus a short finite pulse; high likes can emit a one-shot 2-heart balloon. Micro-animations only run after the list is **settled** (~220ms after scroll stop / first paint) and **once per topic ID per session** via `FireTopicListMetricEffectCoordinator` (scrolling back does not replay). Reduce Motion disables motion entirely.
 
 Shared helpers live in `App/Core/UIKit/FireUIKitDesignLanguage.swift`.
 
@@ -55,8 +57,8 @@ System APIs remain authoritative for: `UIRefreshControl`, `UIVisualEffectView` /
 1. Theme + toast + skeleton facades on existing UIKit lists — **done**
 2. Filtered topic list → ListKit UIKit VC (`FireFilteredTopicListViewController`) — **done**
 3. Profile tab + public profile → UIKit VCs (`FireProfileViewController`, `FirePublicProfileViewController`) — **done**
-   - Profile menu rows use `FireProfileMenuRowCell`: original monochrome SF Symbols (no color wells), 44pt compact single-line rows, trailing count left of chevron (e.g. `15条`)
-   - Header shows three equal stat columns (粉丝 / 获赞 / 关注) on a soft secondary strip
+   - Profile menu rows use `FireProfileMenuRowCell`: colored icon wells + white SF Symbols, 48pt single-line rows, trailing count left of chevron (e.g. `15条`)
+   - Header sits tight under the nav bar; three equal stat columns (粉丝 / 获赞 / 关注) on a soft secondary strip
 4. Topic detail chrome polish (nav material, theme colors, reaction haptics; Texture cells untouched) — **done**
 5. Topic detail quick-reply bar: WeChat-style opaque full-width bottom strip — **done**
    - **Pure UIKit** bar (`FireTopicQuickReplyBarView`) layered above Texture feed — not a Texture overlay
@@ -64,6 +66,12 @@ System APIs remain authoritative for: `UIRefreshControl`, `UIVisualEffectView` /
    - Solid opaque black chrome; resting pad = home indicator; keyboard pad = 8pt flush above keyboard
    - Keyboard lifts via bottom Auto Layout constraint; feed `contentInset.bottom = barHeight + keyboardOverlap`
 6. Residual SwiftUI cleanup + docs — **in progress / progressive**
+7. Topic detail interaction polish — **done**
+   - Shared press bounce: `UIControl.fireBindPressBounce` / `ASButtonNode.fireBindPressBounce` (`.button` / `.compact` / `.chip`) used on login, send, submit, empty-state, composer, feed chips, reactions, polls, etc.
+   - Reaction chips: press bounce + optimistic local update with network rollback on failure; chips stay tappable while request is in-flight
+   - Topic detail nav bar uses **opaque** canvas chrome so light-mode image content cannot bleed through as a black bar
+   - Boost chips redesigned as compact continuous pills (`bolt` + `@user` + plain body), no rich-link soup
+   - Collapsed post body: blank-line runs (`\n\n`) are normalized before ASTextNode truncation so empty lines no longer burn the 4-line budget / look like huge row gaps; collapsed height is measured with the same ASTextNode max-lines path
 
 ### Residual SwiftUI (allowed)
 

--- a/docs/architecture/2026-07-25-main-thread-and-threading-audit.md
+++ b/docs/architecture/2026-07-25-main-thread-and-threading-audit.md
@@ -1,0 +1,85 @@
+# Main-thread / background threading audit (iOS)
+
+Date: 2026-07-25  
+Scope: Fire iOS host (`native/ios-app`), with Rust/UniFFI ownership notes.
+
+## Goal
+
+- Main thread: UI only (view hierarchy, gesture, Texture layout application, snapshot apply).
+- Background: parsing, measurement, merge/dedup, render-cache build, FFI-adjacent transforms.
+- Rust: protocol orchestration, tree presentation, list models, session authority — keep expanding this surface instead of growing Swift business logic.
+
+## Already in good shape
+
+| Area | Pattern |
+|------|---------|
+| Topic cooked → render cache | `FireTopicPresentation.detailRenderCache` via `Task.detached` in `FireTopicDetailStore` |
+| Post cell layout height | `FirePostLayoutManager` background queue + main publication |
+| Topic detail feed snapshot items | `FireTopicDetailSnapshotAssembler.buildSnapshot` in `Task.detached` from VC |
+| Topic tree / page fetch | Rust `fetchTopicDetailPage` returns `sourceSnapshot` + `treePresentation` |
+| Home topic rows | Mostly Rust-generated row models; host formats timestamps |
+| UniFFI session/network | `async` boundary; not blocking UI runloop with sync FFI |
+| Texture node-block UIKit | Hardened 2026-07-25: no `.view`/layer in off-main configure |
+
+## Residual main-thread work (by severity)
+
+### P1 — completed / remaining
+
+1. **`FireTopicDetailStore` page apply** ✅  
+   `prepareTopicDetailPagePayload` runs tree dedupe + detail synthesis + post lookup in `Task.detached`; main only commits maps and kicks render.
+
+2. **Cooked display-segment IR** ✅ (2026-07-25 follow-up)  
+   Rust `fire_rich_text::display_segments` + UniFFI `displaySegmentsFromRenderDocument` owns image/text segment splitting.  
+   Swift deleted `rawRenderSegments` / container walk; host only maps rich mini-docs → `NSAttributedString` and images → cells.  
+   Checksum no longer uses `String(reflecting:)`.
+
+3. **Home feed dirty-row token rebuild** ✅  
+   `FireHomeFeedStore.prepareTopicRowsMerge` snapshots indexes then merges + rebuilds content tokens in `Task.detached`.  
+   Main only assigns `topicRows` / tokens / visibility. Single-row `patchTopicCounts` stays sync (cheap).
+
+### P2 — acceptable on main for now
+
+| Area | Why OK |
+|------|--------|
+| Diffable / Texture snapshot apply | Must be main; keep diffs small via content tokens |
+| Captcha sheet detent animation | UIKit sheet API is main-only; height measure is JS → main debounced |
+| Quick-reply / toolbar chrome | Thin UIKit |
+| Login form / onboarding | UI-bound |
+| Keychain credential load | Short; already in async prepareLoginForm |
+
+### P3 — watch / measure
+
+- `FireDiffableListController` large `reconfigureItems` batches during scroll idle.
+- Message-bus fan-in onto MainActor stores (debounce already present for some paths).
+- Image decode is generally off main; keep UIImage assignment on main only.
+
+## Threading rules (host)
+
+1. **Texture `nodeBlock` / `configure`:** node properties only. Any `UIView` / `CALayer` / gesture attach → `didLoad` or `performOnMain`.
+2. **Never** `DispatchQueue.main.sync` from Texture workers (deadlock risk).
+3. **Pure transforms** (`unique*`, merge posts, synthesize detail, render cache) → `nonisolated` / `Task.detached` / dedicated queue.
+4. **Rust owns** pagination cursors, tree presentation, missing-post windows, session classification — do not reimplement in Swift “for convenience”.
+5. **Main actor stores** may *orchestrate* async work but should not *compute* large collections inline.
+
+## Concrete changes
+
+### Pass 1
+- `FireTopicDetailStore.applyTopicDetailPagePayload` off-main prepare.
+
+### Pass 2
+- **Home feed:** `mergeTopicRows` + content-token rebuild are `nonisolated static`; list load/apply paths await `prepareTopicRowsMerge` on a detached task.
+- **Cooked IR:** Rust `RenderDisplaySegment` + `display_segments`; UniFFI export; Swift presentation uses it and drops the old segment walker.
+- **Sendable indexes:** `FireEntityIndex` / `FireOrderedIDList` require `Sendable` entity/id.
+
+## Suggested follow-ups (ordered)
+
+1. Instrument detached prepare ms vs main commit ms for topic detail + home feed.
+2. Split remaining `FireTopicDetailStore` pure helpers into a Sendable reducer module.
+3. Further thin Swift attributed-string builder once Android shares the same display-segment IR.
+4. Optional: main-thread hang detector in DEBUG (os_signpost / MetricKit) behind developer tools.
+
+## Related fixes (same day)
+
+- Off-main UIKit in `FirePostCellNode` (hang root cause during topic open).
+- Captcha sheet height debounce / phase-1 hide on challenge open.
+- Login loading: button spinner only (no dim overlay).

--- a/docs/architecture/fire-native-architecture.md
+++ b/docs/architecture/fire-native-architecture.md
@@ -311,8 +311,10 @@ native/ios-app/
 
     Startup/
       FireOnboardingValidatingView.swift      # .validating phase loading view
-      FireOnboardingCredentialFormView.swift  # .credential phase form (UIScrollView-backed, migrated from the former FireLoginViewController)
-      FireOnboardingLoggingInView.swift       # .loggingIn phase overlay
+      FireOnboardingCredentialFormView.swift  # .credential phase form (UIScrollView-backed; remember+forgot same row; external login icons)
+      FireExternalLoginMethod.swift           # Google/GitHub/X/Discord/Apple/Passkey native icon entries
+      # last successful method persisted as FireLastLoginMethod in Keychain via FireAuthCookieKeychainStore
+      # .loggingIn keeps the credential form and uses the login-button spinner (no dim overlay)
 
   Shared/                                # Cross-screen shared components
     Render/
@@ -1001,7 +1003,7 @@ Advantages:
 - Drafts → UIKit `FireDraftsViewController` on `FireListViewController`; the former SwiftUI production page has been removed and draft continuation opens the UIKit Composer runtime
 - Messages → UIKit `FirePrivateMessagesViewController` on `FireListViewController`; Profile keeps only a thin SwiftUI-to-UIKit host until Profile itself migrates
 - Search → UIKit `FireSearchViewController` on `FireListViewController`; the former SwiftUI production page and SwiftUI result rows have been removed while bookmark editing remains a tracked transitional SwiftUI presentation
-- Login / Cloudflare auth → UIKit `FireOnboardingViewController` (unified launch/login page with validating→credential→loggingIn phases), `FireOnboardingCredentialFormView`, `FireCaptchaLoginDialogController`, `FireWebViewBrowserViewController`, and `FireCloudflareChallengeViewController`; the former separate `FireLoginViewController`, the standalone PreheatGate controllers (`FirePreheatGateViewController` / `FirePreheatGateWaitingViewController`), the monolithic login WebView controller, the SwiftUI auth screen, and the `UIViewRepresentable` login bridge have all been removed in favor of the single onboarding page
+- Login / Cloudflare auth → UIKit `FireOnboardingViewController` (unified launch/login page with validating→credential→loggingIn phases), `FireOnboardingCredentialFormView`, `FireExternalLoginMethod`, `FireCaptchaLoginDialogController`, `FireWebViewBrowserViewController` (optional auto-start of Discourse OAuth/Passkey buttons), and `FireCloudflareChallengeViewController`; the former separate `FireLoginViewController`, the standalone PreheatGate controllers (`FirePreheatGateViewController` / `FirePreheatGateWaitingViewController`), the monolithic login WebView controller, the SwiftUI auth screen, and the `UIViewRepresentable` login bridge have all been removed in favor of the single onboarding page
 - Onboarding → UIKit `FireOnboardingViewController`; the former SwiftUI onboarding root has been removed, with Developer Tools remaining an explicit SwiftUI exception
 - Composer → UIKit `FireComposerViewController`; the former SwiftUI `FireComposerView` page has been removed. Home, Messages, Drafts, Topic detail, and Public Profile open the UIKit runtime, with Public Profile using only a temporary SwiftUI-to-UIKit host until Profile itself migrates
 - Profile → UIKit

--- a/docs/superpowers/specs/2026-06-08-fire-v2-roadmap-design.md
+++ b/docs/superpowers/specs/2026-06-08-fire-v2-roadmap-design.md
@@ -70,8 +70,8 @@
 
 | Token | 值 | 用途 |
 |-------|----|------|
-| `FireTheme.cornerRadius` | 20 | 大卡片、面板、Sheet |
-| `FireTheme.mediumCornerRadius` | 14 | 行级组件、状态芯片、分类标签 |
+| `FireTheme.cornerRadius` | 14 | 大卡片、面板、Sheet（收紧，避免过度圆润） |
+| `FireTheme.mediumCornerRadius` | 12 | 行级组件、状态芯片、分类标签 |
 | `FireTheme.smallCornerRadius` | 10 | 输入框、搜索栏、小按钮 |
 | `FireTheme.pillRadius` | .infinity | 胶囊形标签、信任等级药丸 |
 

--- a/docs/superpowers/specs/2026-06-16-native-login-page-redesign-design.md
+++ b/docs/superpowers/specs/2026-06-16-native-login-page-redesign-design.md
@@ -146,11 +146,12 @@ FireRootCoordinator
 ┌─────────────────────────────┐
 │  安全验证              [×]  │  标题栏
 ├─────────────────────────────┤
-│                             │
-│    [ hCaptcha Widget ]      │  WKWebView 渲染
-│                             │
+│  [状态文字 / 错误信息]      │  顶部状态区（文案如「请完成下方验证」）
+│  [spinner，加载时显示]      │
 ├─────────────────────────────┤
-│  [状态文字 / 错误信息]      │  底部状态区
+│                             │
+│    [ hCaptcha Widget ]      │  WKWebView 渲染（状态区下方）
+│                             │
 └─────────────────────────────┘
 ```
 
@@ -340,7 +341,7 @@ Keychain/Session → ViewModel.primeCookiesForLogin() → cookie payload
 | 文件 | 操作 |
 |------|------|
 | 修改 `FireLoginViewController.swift` | 内联 error banner 组件 |
-| 修改 `FireCaptchaLoginDialogController.swift` | 底部状态区错误展示 + 重试提示 |
+| 修改 `FireCaptchaLoginDialogController.swift` | 顶部状态区错误展示 + 重试提示 |
 
 ## File Change Summary
 

--- a/native/ios-app/App/Core/FireComponents.swift
+++ b/native/ios-app/App/Core/FireComponents.swift
@@ -819,6 +819,7 @@ struct FireToolbarIcon: View {
 
 struct FirePrimaryButtonStyle: ButtonStyle {
     @Environment(\.isEnabled) private var isEnabled
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
@@ -836,14 +837,19 @@ struct FirePrimaryButtonStyle: ButtonStyle {
                         )
                     )
             )
-            .opacity(isEnabled ? 1 : 0.55)
-            .scaleEffect(configuration.isPressed ? 0.97 : 1)
-            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+            .opacity(isEnabled ? (configuration.isPressed ? 0.92 : 1) : 0.55)
+            .scaleEffect(configuration.isPressed && !reduceMotion ? 0.94 : 1)
+            .animation(
+                .spring(response: 0.28, dampingFraction: 0.55),
+                value: configuration.isPressed
+            )
             .animation(.easeOut(duration: 0.15), value: isEnabled)
     }
 }
 
 struct FireSecondaryButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
             .font(.subheadline.weight(.semibold))
@@ -858,8 +864,12 @@ struct FireSecondaryButtonStyle: ButtonStyle {
                             .strokeBorder(FireTheme.divider, lineWidth: 1)
                     )
             )
-            .scaleEffect(configuration.isPressed ? 0.97 : 1)
-            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+            .opacity(configuration.isPressed ? 0.92 : 1)
+            .scaleEffect(configuration.isPressed && !reduceMotion ? 0.94 : 1)
+            .animation(
+                .spring(response: 0.28, dampingFraction: 0.55),
+                value: configuration.isPressed
+            )
     }
 }
 

--- a/native/ios-app/App/Core/FireTheme.swift
+++ b/native/ios-app/App/Core/FireTheme.swift
@@ -364,19 +364,20 @@ enum FireTheme {
 
 extension FireTheme {
     /// Large floating cards (settings groups, profile blocks).
-    static let cornerRadius: CGFloat = 22
+    /// Kept deliberately tighter than iOS default inset-grouped bubbles so pages feel direct.
+    static let cornerRadius: CGFloat = 14
     /// Medium cards / chips containers.
-    static let mediumCornerRadius: CGFloat = 16
+    static let mediumCornerRadius: CGFloat = 12
     /// Small controls, inputs.
-    static let smallCornerRadius: CGFloat = 12
+    static let smallCornerRadius: CGFloat = 10
     /// Icon wells behind list-row symbols.
-    static let iconWellCornerRadius: CGFloat = 10
-    static let iconWellSize: CGFloat = 36
+    static let iconWellCornerRadius: CGFloat = 8
+    static let iconWellSize: CGFloat = 30
     static let chipCornerRadius: CGFloat = 100
-    static let panelShadowRadius: CGFloat = 16
-    static let panelShadowY: CGFloat = 8
+    static let panelShadowRadius: CGFloat = 12
+    static let panelShadowY: CGFloat = 6
     /// Horizontal inset for page content / cards.
     static let pageHorizontalInset: CGFloat = 16
     /// Vertical gap between grouped cards.
-    static let sectionSpacing: CGFloat = 22
+    static let sectionSpacing: CGFloat = 16
 }

--- a/native/ios-app/App/Core/FireTopicListMetricEffectCoordinator.swift
+++ b/native/ios-app/App/Core/FireTopicListMetricEffectCoordinator.swift
@@ -1,0 +1,103 @@
+import UIKit
+
+/// Session gate for topic-list metric micro-animations.
+///
+/// Rules:
+/// 1. Effects only run while the host list is **settled** (not dragging / decelerating).
+/// 2. Each topic plays each effect **at most once** per app session — scrolling back
+///    must not re-trigger balloons / surge pulses and clutter the feed.
+@MainActor
+final class FireTopicListMetricEffectCoordinator {
+    static let shared = FireTopicListMetricEffectCoordinator()
+
+    enum EffectKind: Hashable {
+        case heartBalloon
+        case viewSurgePulse
+    }
+
+    /// Debounce after the finger stops so the eye can rest on the row first.
+    static let settleDelay: TimeInterval = 0.22
+
+    /// Starts unsettled so the first paint waits a beat (same path as scroll-stop).
+    private(set) var isSettled = false
+    private var played = Set<PlayedKey>()
+    private var settleWorkItem: DispatchWorkItem?
+    private let pendingCells = NSHashTable<FireTopicListTopicCell>.weakObjects()
+
+    private init() {}
+
+    /// Host lists call this from scroll begin / end callbacks.
+    func setScrolling(_ scrolling: Bool) {
+        settleWorkItem?.cancel()
+        settleWorkItem = nil
+
+        if scrolling {
+            isSettled = false
+            return
+        }
+
+        scheduleSettle()
+    }
+
+    /// Register a configured topic cell. Effects play once the list is settled.
+    func track(_ cell: FireTopicListTopicCell) {
+        pendingCells.add(cell)
+        if isSettled {
+            cell.playPendingMetricEffectsIfNeeded()
+        } else if settleWorkItem == nil {
+            // First visible rows after launch / tab switch: settle without a scroll event.
+            scheduleSettle()
+        }
+    }
+
+    private func scheduleSettle() {
+        settleWorkItem?.cancel()
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            self.isSettled = true
+            self.settleWorkItem = nil
+            self.flushPendingCells()
+        }
+        settleWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.settleDelay, execute: work)
+    }
+
+    func untrack(_ cell: FireTopicListTopicCell) {
+        pendingCells.remove(cell)
+    }
+
+    /// Returns `true` only the first time this topic claims the effect.
+    @discardableResult
+    func claim(_ kind: EffectKind, topicID: UInt64) -> Bool {
+        let key = PlayedKey(topicID: topicID, kind: kind)
+        if played.contains(key) {
+            return false
+        }
+        played.insert(key)
+        return true
+    }
+
+    func hasPlayed(_ kind: EffectKind, topicID: UInt64) -> Bool {
+        played.contains(PlayedKey(topicID: topicID, kind: kind))
+    }
+
+    /// Test / logout hook.
+    func resetSessionStateForTesting() {
+        settleWorkItem?.cancel()
+        settleWorkItem = nil
+        isSettled = false
+        played.removeAll()
+        pendingCells.removeAllObjects()
+    }
+
+    private func flushPendingCells() {
+        for cell in pendingCells.allObjects {
+            cell.playPendingMetricEffectsIfNeeded()
+        }
+    }
+
+    private struct PlayedKey: Hashable {
+        let topicID: UInt64
+        let kind: EffectKind
+    }
+}

--- a/native/ios-app/App/Core/UIKit/FireUIKitDesignLanguage.swift
+++ b/native/ios-app/App/Core/UIKit/FireUIKitDesignLanguage.swift
@@ -26,7 +26,7 @@ enum FireHosting {
 // MARK: - Card styling
 
 extension UIView {
-    /// Floating card used across settings / profile (reference: ~22pt continuous corners).
+    /// Floating card used across settings / profile (tight continuous corners).
     func fireApplyCardStyle(
         cornerRadius: CGFloat = FireTheme.cornerRadius,
         fill: UIColor = FireTheme.uiSurface
@@ -80,7 +80,10 @@ final class FireUIKitListRowView: UIControl {
         var subtitle: String? = nil
         var value: String? = nil
         var showsChevron: Bool = true
+        /// Symbol color inside the well. Defaults to white when a well color is provided.
         var iconTint: UIColor? = nil
+        /// Colored rounded square behind the symbol (reference-style accent well).
+        var iconWellColor: UIColor? = nil
     }
 
     private let iconWell = UIView()
@@ -112,7 +115,15 @@ final class FireUIKitListRowView: UIControl {
     func apply(_ content: Content) {
         let config = UIImage.SymbolConfiguration(pointSize: 14, weight: .semibold)
         iconView.image = UIImage(systemName: content.systemImage, withConfiguration: config)
-        iconView.tintColor = content.iconTint ?? UIColor.white
+
+        if let wellColor = content.iconWellColor {
+            iconWell.backgroundColor = wellColor
+            iconView.tintColor = content.iconTint ?? .white
+        } else {
+            iconWell.backgroundColor = FireTheme.uiIconWell
+            iconView.tintColor = content.iconTint ?? FireTheme.uiInk
+        }
+
         titleLabel.text = content.title
 
         let subtitle = content.subtitle?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
@@ -141,21 +152,15 @@ final class FireUIKitListRowView: UIControl {
             make.edges.equalToSuperview()
         }
 
-        iconWell.fireApplyIconWellStyle(cornerRadius: 10)
-        // Reference wells are near-black squares inside charcoal cards.
-        iconWell.backgroundColor = UIColor { traits in
-            traits.userInterfaceStyle == .dark
-                ? UIColor(white: 0.06, alpha: 1)
-                : FireTheme.uiIconWell
-        }
+        iconWell.fireApplyIconWellStyle()
         iconView.contentMode = .scaleAspectFit
         iconWell.addSubview(iconView)
         iconWell.snp.makeConstraints { make in
-            make.width.height.equalTo(36)
+            make.width.height.equalTo(FireTheme.iconWellSize)
         }
         iconView.snp.makeConstraints { make in
             make.center.equalToSuperview()
-            make.width.height.equalTo(16)
+            make.width.height.equalTo(15)
         }
 
         titleLabel.font = .systemFont(ofSize: 16, weight: .regular)
@@ -246,8 +251,8 @@ final class FireUIKitSettingsCardView: UIView {
                 line.backgroundColor = FireTheme.uiDivider
                 separatorHost.addSubview(line)
                 line.snp.makeConstraints { make in
-                    // Inset past icon well (14 + 36 + 14) like reference
-                    make.leading.equalToSuperview().offset(14 + 36 + 14)
+                    // Inset past icon well (leading + well + gap).
+                    make.leading.equalToSuperview().offset(14 + FireTheme.iconWellSize + 14)
                     make.trailing.equalToSuperview()
                     make.top.bottom.equalToSuperview()
                     make.height.equalTo(1.0 / UIScreen.main.scale)
@@ -259,6 +264,7 @@ final class FireUIKitSettingsCardView: UIView {
             row.apply(item.0)
             row.tag = index
             row.addTarget(self, action: #selector(handleRowTap(_:)), for: .touchUpInside)
+            row.fireBindPressBounce(.compact)
             row.isEnabled = item.1 != nil
             if item.1 == nil {
                 row.accessibilityTraits = .staticText

--- a/native/ios-app/App/Core/UIKit/FireUIKitEmptyStateView.swift
+++ b/native/ios-app/App/Core/UIKit/FireUIKitEmptyStateView.swift
@@ -72,6 +72,7 @@ final class FireUIKitEmptyStateView: UIView {
         actionButton.titleLabel?.adjustsFontForContentSizeCategory = true
         actionButton.tintColor = FireTheme.uiAccent
         actionButton.addTarget(self, action: #selector(handleAction), for: .touchUpInside)
+        actionButton.fireBindPressBounce(.button)
 
         stack.axis = .vertical
         stack.alignment = .center

--- a/native/ios-app/App/ListKit/FireDiffableListController.swift
+++ b/native/ios-app/App/ListKit/FireDiffableListController.swift
@@ -148,6 +148,8 @@ class FireListViewController<SectionID: Hashable, ItemID: Hashable>: UIViewContr
     private let onVisibleItemsChanged: (([ItemID]) -> Void)?
     private let onPrefetchItems: (([ItemID]) -> Void)?
     private let onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)?
+    /// `true` while the user is dragging or the list is decelerating; `false` when settled.
+    private let onScrollActivityChanged: ((Bool) -> Void)?
     private let onRefresh: (() async -> Void)?
     private var contextMenuConfigurationProvider: FireListContextMenuProvider<ItemID>?
     private var onContentWidthChanged: ((CGFloat) -> Void)?
@@ -192,6 +194,7 @@ class FireListViewController<SectionID: Hashable, ItemID: Hashable>: UIViewContr
         onVisibleItemsChanged: (([ItemID]) -> Void)? = nil,
         onPrefetchItems: (([ItemID]) -> Void)? = nil,
         onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)? = nil,
+        onScrollActivityChanged: ((Bool) -> Void)? = nil,
         onRefresh: (() async -> Void)? = nil,
         contextMenuConfigurationProvider: FireListContextMenuProvider<ItemID>? = nil,
         onContentWidthChanged: ((CGFloat) -> Void)? = nil,
@@ -211,6 +214,7 @@ class FireListViewController<SectionID: Hashable, ItemID: Hashable>: UIViewContr
         self.onVisibleItemsChanged = onVisibleItemsChanged
         self.onPrefetchItems = onPrefetchItems
         self.onScrollMetricsChanged = onScrollMetricsChanged
+        self.onScrollActivityChanged = onScrollActivityChanged
         self.onRefresh = onRefresh
         self.contextMenuConfigurationProvider = contextMenuConfigurationProvider
         self.onContentWidthChanged = onContentWidthChanged
@@ -551,6 +555,7 @@ class FireListViewController<SectionID: Hashable, ItemID: Hashable>: UIViewContr
         // longer meaningful. Clearing it here keeps subsequent snapshot
         // applies from over-deferring anchor restoration during a real scroll.
         endPostRefreshSettling()
+        onScrollActivityChanged?(true)
     }
 
     func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
@@ -564,6 +569,7 @@ class FireListViewController<SectionID: Hashable, ItemID: Hashable>: UIViewContr
             applyPendingSectionUpdateIfNeeded()
             publishVisibleItems()
             publishScrollMetrics()
+            onScrollActivityChanged?(false)
         }
     }
 
@@ -577,6 +583,7 @@ class FireListViewController<SectionID: Hashable, ItemID: Hashable>: UIViewContr
         applyPendingSectionUpdateIfNeeded()
         publishVisibleItems()
         publishScrollMetrics()
+        onScrollActivityChanged?(false)
     }
 
     func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
@@ -585,6 +592,7 @@ class FireListViewController<SectionID: Hashable, ItemID: Hashable>: UIViewContr
         publishVisibleItems()
         publishScrollMetrics()
         completeAnimatedScrollRequestIfNeeded()
+        onScrollActivityChanged?(false)
     }
 
     private func publishVisibleItems() {
@@ -866,6 +874,7 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
         onVisibleItemsChanged: (([ItemID]) -> Void)? = nil,
         onPrefetchItems: (([ItemID]) -> Void)? = nil,
         onScrollMetricsChanged: ((FireCollectionScrollMetrics) -> Void)? = nil,
+        onScrollActivityChanged: ((Bool) -> Void)? = nil,
         onRefresh: (() async -> Void)? = nil,
         contextMenuConfigurationProvider: FireListContextMenuProvider<ItemID>? = nil,
         onContentWidthChanged: ((CGFloat) -> Void)? = nil,
@@ -891,6 +900,7 @@ final class FireDiffableListController<SectionID: Hashable, ItemID: Hashable, Ro
             onVisibleItemsChanged: onVisibleItemsChanged,
             onPrefetchItems: onPrefetchItems,
             onScrollMetricsChanged: onScrollMetricsChanged,
+            onScrollActivityChanged: onScrollActivityChanged,
             onRefresh: onRefresh,
             contextMenuConfigurationProvider: contextMenuConfigurationProvider,
             onContentWidthChanged: onContentWidthChanged,

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostCellLayout.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostCellLayout.swift
@@ -182,6 +182,48 @@ enum FirePostBoostDisplay {
         return NSAttributedString()
     }
 
+    /// Compact single-line chip content: plain text only (no rich-link soup).
+    static func compactChipContent(
+        for boost: TopicPostBoostState,
+        textColor: UIColor,
+        usernameColor: UIColor
+    ) -> NSAttributedString {
+        let bodyFont = UIFont.preferredFont(forTextStyle: .caption2)
+        let nameFont = UIFontMetrics(forTextStyle: .caption2).scaledFont(
+            for: .systemFont(ofSize: bodyFont.pointSize, weight: .semibold)
+        )
+        let body = strippedDisplayText(for: boost)
+            ?? cleaned(boost.displayText)
+            ?? ""
+        let username = cleaned(boost.user.username)
+        let result = NSMutableAttributedString()
+        if let username {
+            result.append(NSAttributedString(
+                string: "@\(username)",
+                attributes: [
+                    .font: nameFont,
+                    .foregroundColor: usernameColor,
+                ]
+            ))
+            if !body.isEmpty {
+                result.append(NSAttributedString(
+                    string: "  ",
+                    attributes: [.font: bodyFont, .foregroundColor: textColor]
+                ))
+            }
+        }
+        if !body.isEmpty {
+            result.append(NSAttributedString(
+                string: body,
+                attributes: [
+                    .font: bodyFont,
+                    .foregroundColor: textColor,
+                ]
+            ))
+        }
+        return result
+    }
+
     static func contentToken(for boosts: [TopicPostBoostState]) -> String {
         boosts.map { boost in
             [
@@ -345,6 +387,74 @@ struct FirePostTextExpansionState: Hashable, Sendable {
 
     var isCollapsed: Bool {
         isCollapsible && !isExpanded
+    }
+}
+
+/// Collapsed ASTextNode treats blank lines (`\n\n`) as full visual lines, which
+/// burns the 4-line budget and looks like huge row gaps. Normalize blank runs
+/// to a single newline + paragraph spacing for collapsed display/measurement only.
+enum FirePostCollapsedTextNormalizer {
+    static func attributedTextForCollapsedDisplay(
+        _ attributedText: NSAttributedString
+    ) -> NSAttributedString {
+        guard attributedText.length > 0 else { return attributedText }
+
+        let mutable = NSMutableAttributedString(attributedString: attributedText)
+        // Walk backwards on the live string so ranges stay valid while editing.
+        var index = mutable.length - 1
+        while index >= 0 {
+            let live = mutable.string as NSString
+            guard live.character(at: index) == 10 else {
+                index -= 1
+                continue
+            }
+            var runStart = index
+            while runStart > 0, live.character(at: runStart - 1) == 10 {
+                runStart -= 1
+            }
+            let runLength = index - runStart + 1
+            if runLength > 1 {
+                // Keep one newline; blank-line visual spacing becomes paragraphSpacing.
+                mutable.replaceCharacters(
+                    in: NSRange(location: runStart, length: runLength),
+                    with: "\n"
+                )
+                let styleLocation = max(runStart - 1, 0)
+                if styleLocation < mutable.length {
+                    let existing = mutable.attribute(
+                        .paragraphStyle,
+                        at: styleLocation,
+                        effectiveRange: nil
+                    ) as? NSParagraphStyle
+                    let paragraph = (existing?.mutableCopy() as? NSMutableParagraphStyle)
+                        ?? NSMutableParagraphStyle()
+                    paragraph.paragraphSpacing = max(paragraph.paragraphSpacing, 6)
+                    paragraph.lineBreakMode = .byWordWrapping
+                    mutable.addAttribute(
+                        .paragraphStyle,
+                        value: paragraph,
+                        range: NSRange(location: styleLocation, length: 1)
+                    )
+                }
+            }
+            index = runStart - 1
+        }
+        return mutable
+    }
+
+    static func expansionTruncationToken(
+        accentColor: UIColor = FireTheme.uiAccent
+    ) -> NSAttributedString {
+        let font = UIFont.preferredFont(forTextStyle: .subheadline)
+        let result = NSMutableAttributedString(
+            string: "... ",
+            attributes: [.font: font, .foregroundColor: UIColor.label]
+        )
+        result.append(NSAttributedString(
+            string: "展开",
+            attributes: [.font: font, .foregroundColor: accentColor]
+        ))
+        return result
     }
 }
 

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostCellLayoutCalculator.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostCellLayoutCalculator.swift
@@ -82,7 +82,8 @@ enum FirePostCellLayoutCalculator {
         imageSizes: [CGSize],
         pollHeights: [CGFloat] = [],
         boostLines: [String] = [],
-        trait: FirePostLayoutTraitSignature
+        trait: FirePostLayoutTraitSignature,
+        collapsedTextHeightOverride: CGFloat? = nil
     ) -> FirePostCellLayout {
         let indent = indentWidth(for: key.depth)
         let avatarSz = avatarSize(for: key.depth)
@@ -144,13 +145,15 @@ enum FirePostCellLayoutCalculator {
         let shouldCollapseText: Bool
         let textExpansionFrame: CGRect?
         if let textHeight, textHeight > 0 {
-            let collapsedTextHeight = collapsedTextHeight(
+            let fallbackCollapsedHeight = collapsedTextHeight(
                 contentSizeCategory: UIContentSizeCategory(rawValue: trait.contentSizeCategory)
             )
+            // Prefer ASTextNode-measured collapsed height (matches cell display).
+            let resolvedCollapsedHeight = collapsedTextHeightOverride ?? fallbackCollapsedHeight
             shouldCollapseText = key.textExpansionState.isCollapsed
-                && textHeight > collapsedTextHeight
+                && textHeight > resolvedCollapsedHeight + 0.5
             let displayedTextHeight = shouldCollapseText
-                ? collapsedTextHeight
+                ? resolvedCollapsedHeight
                 : textHeight
             textContainerSize = CGSize(width: bodyAvailableWidth, height: displayedTextHeight)
             textFrame = CGRect(
@@ -354,6 +357,30 @@ enum FirePostCellLayoutCalculator {
         return ceil(layout.size.height)
     }
 
+    /// Collapsed body height must use the same ASTextNode path as the cell
+    /// (max lines + truncation + blank-line collapse). `font.lineHeight * N`
+    /// under-counts emoji/paragraph metrics and over-counts empty lines.
+    static func measureCollapsedRichTextHeight(
+        attributedText: NSAttributedString?,
+        containerWidth: CGFloat,
+        truncationToken: NSAttributedString?
+    ) -> CGFloat? {
+        guard let attributedText, attributedText.length > 0 else {
+            return nil
+        }
+        let displayText = FirePostCollapsedTextNormalizer.attributedTextForCollapsedDisplay(attributedText)
+        let textNode = ASTextNode()
+        textNode.attributedText = displayText
+        textNode.maximumNumberOfLines = UInt(FirePostTextExpansionState.collapsedLineLimit)
+        textNode.truncationAttributedText = truncationToken
+        let width = max(containerWidth, 1)
+        let layout = textNode.layoutThatFits(ASSizeRange(
+            min: CGSize(width: width, height: 0),
+            max: CGSize(width: width, height: .greatestFiniteMagnitude)
+        ))
+        return max(ceil(layout.size.height), 1)
+    }
+
     static func estimatedRichTextHeight(
         plainText: String,
         hasAttributedText: Bool,
@@ -372,7 +399,13 @@ enum FirePostCellLayoutCalculator {
         let lineHeight = max(font.lineHeight, 1)
         let averageGlyphWidth = max(font.pointSize * 0.56, 1)
         let charactersPerLine = max(Int((max(containerWidth, 1) / averageGlyphWidth).rounded(.down)), 1)
-        let logicalLineCount = plainText
+        // Match collapsed display: blank lines are collapsed so they don't inflate line count.
+        let normalizedPlain = plainText.replacingOccurrences(
+            of: "\n{2,}",
+            with: "\n",
+            options: .regularExpression
+        )
+        let logicalLineCount = normalizedPlain
             .split(separator: "\n", omittingEmptySubsequences: false)
             .reduce(0) { partialResult, line in
                 partialResult + max(Int(ceil(Double(line.count) / Double(charactersPerLine))), 1)

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostCellNode.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostCellNode.swift
@@ -66,6 +66,9 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
     private var currentLayoutWidth: CGFloat = 0
     private var currentResolvedLayout: FirePostCellLayout?
     private var currentContentSizeCategory: UIContentSizeCategory = .large
+    /// Captured on main in `didLoad`; safe for Texture background configure paths.
+    private var cachedDisplayScale: CGFloat = 3
+    private static var lastKnownContentSizeCategory: UIContentSizeCategory = .large
     private var renderedContentID: String?
     private var avatarSignature: String?
     private var avatarLoadTask: Task<Void, Never>?
@@ -124,6 +127,9 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
 
     override func didLoad() {
         super.didLoad()
+        cachedDisplayScale = UIScreen.main.scale
+        Self.lastKnownContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        currentContentSizeCategory = Self.lastKnownContentSizeCategory
         swipeGestureRecognizer.cancelsTouchesInView = false
         swipeGestureRecognizer.delegate = self
         view.addGestureRecognizer(swipeGestureRecognizer)
@@ -197,6 +203,7 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
         replyContextNode.titleNode.truncationMode = .byTruncatingTail
         replyContextNode.contentEdgeInsets = .zero
         replyContextNode.addTarget(self, action: #selector(handleReplyContextTap), forControlEvents: .touchUpInside)
+        replyContextNode.fireBindPressBounce(.compact)
         replyContextNode.isHidden = true
         replyContextNode.style.flexShrink = 1.0
 
@@ -208,6 +215,7 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
         menuNode.isHidden = true
         menuNode.setImage(UIImage(systemName: "ellipsis"), for: .normal)
         menuNode.addTarget(self, action: #selector(handleMenuTap), forControlEvents: .touchUpInside)
+        menuNode.fireBindPressBounce(.compact)
         menuNode.accessibilityLabel = "帖子操作"
 
         // Body text
@@ -252,14 +260,27 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
         // Reply shortcut
         replyShortcutNode.isHidden = true
         replyShortcutNode.addTarget(self, action: #selector(handleReplyShortcutTap), forControlEvents: .touchUpInside)
+        replyShortcutNode.fireBindPressBounce(.compact)
         replyShortcutNode.accessibilityLabel = "查看更多回复"
 
-        // Reactions
+        // Reactions — keep bounce overshoot visible at the container level.
+        // Never touch `.view` here: setupNodes runs inside Texture node-blocks off-main.
         reactionContainerNode.isHidden = true
+        reactionContainerNode.clipsToBounds = false
 
         // Divider
         dividerNode.backgroundColor = .separator
         dividerNode.isHidden = true
+    }
+
+    /// Texture may call configure/setup from a background node-block queue.
+    /// UIView/CALayer access must hop to main; node properties stay thread-safe.
+    private func performOnMain(_ work: @escaping () -> Void) {
+        if Thread.isMainThread {
+            work()
+        } else {
+            DispatchQueue.main.async(execute: work)
+        }
     }
 
     // MARK: - Configure
@@ -278,7 +299,12 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
         currentShowsDivider = showsDivider
         currentLayoutWidth = payload.layoutWidth
         currentResolvedLayout = payload.layout
-        currentContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+        // UIApplication is main-thread only; node-blocks may configure off-main.
+        if Thread.isMainThread {
+            Self.lastKnownContentSizeCategory = UIApplication.shared.preferredContentSizeCategory
+            cachedDisplayScale = UIScreen.main.scale
+        }
+        currentContentSizeCategory = Self.lastKnownContentSizeCategory
 
         let vd = FirePostCellLayoutCalculator.visualDepth(for: depth)
         let avatarSz = vd > 0 ? FirePostCellLayoutCalculator.avatarSizeNested : FirePostCellLayoutCalculator.avatarSizeRoot
@@ -321,7 +347,7 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
         let avatarURL = fireAvatarURL(
             avatarTemplate: payload.post.avatarTemplate,
             size: avatarSize,
-            scale: UIScreen.main.scale,
+            scale: cachedDisplayScale,
             baseURLString: payload.baseURLString
         )
         let nextAvatarSignature = [
@@ -546,15 +572,21 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
             bodyTextNode.isHidden = true
             bodySelectableTextNode.attributedText = nil
             bodySelectableTextNode.isHidden = true
+            renderedContentID = nil
             return
         }
 
-        let contentID = "post:\(payload.post.id)|render:\(payload.renderContent.signature.token)"
         let isCollapsed = payload.textExpansionState.isCollapsed
+        // Include collapse state so ASTextNode rebuilds when expanding/collapsing
+        // (blank-line normalization only applies while collapsed).
+        let contentID = "post:\(payload.post.id)|render:\(payload.renderContent.signature.token)|collapsed:\(isCollapsed)"
 
         if renderedContentID != contentID {
             renderedContentID = contentID
-            bodyTextNode.attributedText = attrText
+            let collapsedDisplay = FirePostCollapsedTextNormalizer.attributedTextForCollapsedDisplay(attrText)
+            // Clear first so Texture invalidates cached text layout (intermittent stale metrics).
+            bodyTextNode.attributedText = nil
+            bodyTextNode.attributedText = isCollapsed ? collapsedDisplay : attrText
             bodySelectableTextNode.attributedText = attrText
         }
         bodyTextNode.isHidden = !isCollapsed
@@ -563,8 +595,12 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
             ? UInt(FirePostTextExpansionState.collapsedLineLimit)
             : 0
         bodyTextNode.truncationAttributedText = isCollapsed
-            ? Self.expansionTruncationToken()
+            ? FirePostCollapsedTextNormalizer.expansionTruncationToken(accentColor: Self.accentTextColor)
             : nil
+        // Keep natural height tight to measured glyphs — do not let the stack stretch lines.
+        bodyTextNode.style.flexGrow = 0
+        bodyTextNode.style.flexShrink = 1.0
+        bodySelectableTextNode.style.flexGrow = 0
 
         linkDelegate = RichTextNodeLinkDelegate(
             onLink: { [weak self] url in
@@ -670,11 +706,8 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
         payload: FirePostCellRenderPayload,
         availableWidth: CGFloat? = nil
     ) {
-        for view in pollViews {
-            view.removeFromSuperview()
-        }
-        pollViews.removeAll()
-        pollHeights.removeAll()
+        // Do not touch UIView hierarchy here — this path can run off-main in Texture.
+        pollHeights.removeAll(keepingCapacity: true)
         let width = availableWidth ?? Self.availableContentWidth(
             totalWidth: payload.layoutWidth,
             depth: currentDepth,
@@ -682,33 +715,58 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
             avatarSpacing: currentAvatarSpacing
         )
 
-        for (index, model) in models.enumerated() {
-            guard index < polls.count else { break }
-            let pollView = FirePostPollView()
-            let poll = polls[index]
-            pollView.configure(
-                model: model,
-                canInteract: payload.canWriteInteractions,
-                isMutating: payload.isMutating,
-                onSubmit: { [weak self] selectedOptions in
-                    guard let self, let p = self.currentPayload, let callbacks = self.currentCallbacks else { return }
-                    callbacks.onVotePoll(p.post, poll, selectedOptions)
-                },
-                onRemoveVote: { [weak self] in
-                    guard let self, let p = self.currentPayload, let callbacks = self.currentCallbacks else { return }
-                    callbacks.onUnvotePoll(p.post, poll)
-                }
-            )
-            pollContainerNode.view.addSubview(pollView)
-            pollViews.append(pollView)
-            pollHeights.append(FirePostPollView.preferredHeight(
+        // Heights are pure layout math and can stay on the Texture worker queue.
+        var nextHeights: [CGFloat] = []
+        nextHeights.reserveCapacity(models.count)
+        for model in models {
+            nextHeights.append(FirePostPollView.preferredHeight(
                 for: model,
                 availableWidth: width,
-                contentSizeCategory: UIApplication.shared.preferredContentSizeCategory
+                contentSizeCategory: currentContentSizeCategory
             ))
         }
+        pollHeights = nextHeights
         let totalPollHeight = pollHeights.reduce(0, +) + CGFloat(max(pollHeights.count - 1, 0)) * 10
         pollContainerNode.style.preferredSize = CGSize(width: 1, height: ceil(totalPollHeight))
+
+        // UIView construction / hierarchy edits must happen on main.
+        let pollsSnapshot = polls
+        let modelsSnapshot = models
+        let canWrite = payload.canWriteInteractions
+        let isMutating = payload.isMutating
+        performOnMain { [weak self] in
+            guard let self else { return }
+            for view in self.pollViews {
+                view.removeFromSuperview()
+            }
+            self.pollViews.removeAll(keepingCapacity: true)
+
+            for (index, model) in modelsSnapshot.enumerated() {
+                guard index < pollsSnapshot.count else { break }
+                let pollView = FirePostPollView()
+                let poll = pollsSnapshot[index]
+                pollView.configure(
+                    model: model,
+                    canInteract: canWrite,
+                    isMutating: isMutating,
+                    onSubmit: { [weak self] selectedOptions in
+                        guard let self,
+                              let p = self.currentPayload,
+                              let callbacks = self.currentCallbacks else { return }
+                        callbacks.onVotePoll(p.post, poll, selectedOptions)
+                    },
+                    onRemoveVote: { [weak self] in
+                        guard let self,
+                              let p = self.currentPayload,
+                              let callbacks = self.currentCallbacks else { return }
+                        callbacks.onUnvotePoll(p.post, poll)
+                    }
+                )
+                self.pollContainerNode.view.addSubview(pollView)
+                self.pollViews.append(pollView)
+            }
+            self.setNeedsLayout()
+        }
     }
 
     private func configureBoosts(payload: FirePostCellRenderPayload) {
@@ -765,11 +823,14 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
     private func configureFixedBoostManualScroller(boosts: [TopicPostBoostState]) {
         boostManualBoosts = boosts
         boostManualScrollerNode.isHidden = boosts.isEmpty
-        guard boostManualScrollerNode.isNodeLoaded,
-              let view = boostManualScrollerNode.view as? FirePostBoostManualScrollerView else {
-            return
+        performOnMain { [weak self] in
+            guard let self,
+                  self.boostManualScrollerNode.isNodeLoaded,
+                  let view = self.boostManualScrollerNode.view as? FirePostBoostManualScrollerView else {
+                return
+            }
+            view.configure(boosts: boosts)
         }
-        view.configure(boosts: boosts)
     }
 
     private func fixedBoostManualScrollerHeight(availableWidth: CGFloat) -> CGFloat {
@@ -793,11 +854,19 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
         boostBarrageBoosts = boosts
         boostBarrageLines = boosts.map(FirePostBoostDisplay.displayLine(for:))
         boostBarrageBatchSignature = batchSignature
-        guard boostBarrageNode.isNodeLoaded,
-              let view = boostBarrageNode.view as? FirePostBoostBarrageView else {
-            return
+        let animationsEnabled = boostAnimationsEnabled
+        performOnMain { [weak self] in
+            guard let self,
+                  self.boostBarrageNode.isNodeLoaded,
+                  let view = self.boostBarrageNode.view as? FirePostBoostBarrageView else {
+                return
+            }
+            view.configure(
+                boosts: boosts,
+                batchSignature: batchSignature,
+                animationsEnabled: animationsEnabled
+            )
         }
-        view.configure(boosts: boosts, batchSignature: batchSignature, animationsEnabled: boostAnimationsEnabled)
     }
 
     private func configureReplyShortcut(payload: FirePostCellRenderPayload) {
@@ -823,8 +892,12 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
     func setBoostAnimationsEnabled(_ enabled: Bool) {
         guard boostAnimationsEnabled != enabled else { return }
         boostAnimationsEnabled = enabled
-        if boostBarrageNode.isNodeLoaded,
-           let view = boostBarrageNode.view as? FirePostBoostBarrageView {
+        performOnMain { [weak self] in
+            guard let self,
+                  self.boostBarrageNode.isNodeLoaded,
+                  let view = self.boostBarrageNode.view as? FirePostBoostBarrageView else {
+                return
+            }
             view.setAnimationsEnabled(enabled)
         }
     }
@@ -883,6 +956,7 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
 
         for reaction in reactions {
             let button = ASButtonNode()
+            button.fireBindPressBounce(.chip)
             button.addTarget(self, action: #selector(handleReactionTap(_:)), forControlEvents: .touchUpInside)
             configureReactionButton(button, reaction: reaction, payload: payload)
             reactionButtons.append(button)
@@ -900,8 +974,9 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
         reaction: TopicReactionState,
         payload: FirePostCellRenderPayload
     ) {
+        // Stay tappable while network is in-flight — optimistic UI owns the wait.
+        // Only block when the user cannot write or the current reaction is locked.
         let canChangeReaction = payload.canWriteInteractions
-            && !payload.isMutating
             && (payload.post.currentUserReaction?.canUndo ?? true)
 
         let option = FireTopicPresentation.reactionOption(for: reaction.id)
@@ -925,6 +1000,7 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
             attributes: [.font: countFont, .foregroundColor: color]
         ))
         button.setAttributedTitle(title, for: .normal)
+        // Node-level chrome only — never touch `.view`/`.layer` here (node-block thread).
         button.cornerRadius = 14
         button.clipsToBounds = true
         button.contentEdgeInsets = UIEdgeInsets(top: 6, left: 10, bottom: 6, right: 10)
@@ -1375,12 +1451,13 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
               index < displayedReactions.count else {
             return
         }
+        // Press bounce is owned by fireBindPressBounce(.chip).
         let reaction = displayedReactions[index]
         if reaction.id == "heart" {
             FireMotionHaptics.impact(.medium)
             callbacks.onToggleLike(payload.post)
         } else {
-            FireMotionHaptics.selection()
+            FireMotionHaptics.impact(.light)
             callbacks.onSelectReaction(payload.post, reaction.id)
         }
     }
@@ -1534,19 +1611,6 @@ final class FirePostCellNode: ASCellNode, UIGestureRecognizerDelegate {
                 ]
             ))
         }
-        return result
-    }
-
-    private static func expansionTruncationToken() -> NSAttributedString {
-        let font = UIFont.preferredFont(forTextStyle: .subheadline)
-        let result = NSMutableAttributedString(
-            string: "... ",
-            attributes: [.font: font, .foregroundColor: UIColor.label]
-        )
-        result.append(NSAttributedString(
-            string: "展开",
-            attributes: [.font: font, .foregroundColor: accentTextColor]
-        ))
         return result
     }
 
@@ -1873,8 +1937,17 @@ private final class FireSelectableRichTextNode: ASDisplayNode, UITextViewDelegat
         guard isNodeLoaded else {
             return
         }
-        richTextView?.attributedText = attributedText
-        (richTextView as? FireRichTextTextView)?.refreshQuotePreviewLayers()
+        let text = attributedText
+        let apply = { [weak self] in
+            guard let self else { return }
+            self.richTextView?.attributedText = text
+            (self.richTextView as? FireRichTextTextView)?.refreshQuotePreviewLayers()
+        }
+        if Thread.isMainThread {
+            apply()
+        } else {
+            DispatchQueue.main.async(execute: apply)
+        }
     }
 }
 
@@ -1943,6 +2016,7 @@ private final class FirePostImageNode: ASControlNode {
         retryNode.borderColor = UIColor.systemBlue.withAlphaComponent(0.45).cgColor
         retryNode.backgroundColor = FireTheme.uiCanvas.withAlphaComponent(0.8)
         retryNode.addTarget(self, action: #selector(handleRetryTap), forControlEvents: .touchUpInside)
+        retryNode.fireBindPressBounce(.compact)
 
         updateRenderSize(renderSize)
         loadImage()
@@ -2080,7 +2154,8 @@ private final class FirePostImageNode: ASControlNode {
     }
 
     private func thumbnailImage(for image: UIImage) -> UIImage {
-        let scale = UIScreen.main.scale
+        // May run on a decode queue — avoid UIScreen.main off the main thread.
+        let scale: CGFloat = Thread.isMainThread ? UIScreen.main.scale : 3
         let targetSize = CGSize(
             width: max(renderSize.width * scale, 1),
             height: max(renderSize.height * scale, 1)
@@ -2199,16 +2274,12 @@ private final class FirePostBoostBarrageView: UIView {
         isHidden = visibleBoosts.isEmpty
 
         for boost in visibleBoosts {
-            let chip = FirePostBoostChipView(
-                backgroundColor: FireTheme.uiCanvas.withAlphaComponent(0.72),
-                textColor: .label,
-                borderColor: UIColor.systemOrange.withAlphaComponent(0.28)
-            )
+            let chip = FirePostBoostChipView.styleForBarrage()
             chip.configure(
-                attributedText: FirePostBoostDisplay.displayContent(
+                attributedText: FirePostBoostDisplay.compactChipContent(
                     for: boost,
-                    textColor: .label,
-                    accentColor: .systemBlue
+                    textColor: FireTheme.uiInk,
+                    usernameColor: FireTheme.uiAccent
                 ),
                 signature: FirePostBoostDisplay.contentSignature(for: boost)
             )
@@ -2368,20 +2439,43 @@ private final class FirePostBoostBarrageView: UIView {
 
 private final class FirePostBoostChipView: UIView {
     private(set) var signature: String = ""
+    private let iconView = UIImageView()
     private let textView = FireRichTextUIView()
-    private let horizontalInset: CGFloat = 10
+    private let horizontalInset: CGFloat = 8
+    private let iconSize: CGFloat = 11
 
-    init(backgroundColor: UIColor, textColor: UIColor, borderColor: UIColor? = nil) {
+    static func styleForManual() -> FirePostBoostChipView {
+        FirePostBoostChipView(
+            backgroundColor: FireTheme.uiAccent.withAlphaComponent(0.10),
+            borderColor: FireTheme.uiAccent.withAlphaComponent(0.18)
+        )
+    }
+
+    static func styleForBarrage() -> FirePostBoostChipView {
+        FirePostBoostChipView(
+            backgroundColor: FireTheme.uiSurface.withAlphaComponent(0.92),
+            borderColor: FireTheme.uiAccent.withAlphaComponent(0.22)
+        )
+    }
+
+    init(backgroundColor: UIColor, borderColor: UIColor? = nil) {
         super.init(frame: .zero)
         isUserInteractionEnabled = false
         clipsToBounds = true
         self.backgroundColor = backgroundColor
-        layer.cornerRadius = 12
+        layer.cornerRadius = 11
+        layer.cornerCurve = .continuous
         layer.masksToBounds = true
         if let borderColor {
-            layer.borderWidth = 0.5
+            layer.borderWidth = 1.0 / UIScreen.main.scale
             layer.borderColor = borderColor.cgColor
         }
+
+        let iconConfig = UIImage.SymbolConfiguration(pointSize: 9, weight: .bold)
+        iconView.image = UIImage(systemName: "bolt.fill", withConfiguration: iconConfig)
+        iconView.tintColor = FireTheme.uiAccent
+        iconView.contentMode = .scaleAspectFit
+
         textView.isEditable = false
         textView.isSelectable = false
         textView.isScrollEnabled = false
@@ -2389,9 +2483,9 @@ private final class FirePostBoostChipView: UIView {
         textView.textContainerInset = .zero
         textView.textContainer.lineFragmentPadding = 0
         textView.backgroundColor = .clear
-        textView.textColor = textColor
         textView.textContainer.maximumNumberOfLines = 1
         textView.textContainer.lineBreakMode = .byTruncatingTail
+        addSubview(iconView)
         addSubview(textView)
     }
 
@@ -2409,8 +2503,17 @@ private final class FirePostBoostChipView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        let contentBounds = bounds.insetBy(dx: horizontalInset, dy: 0)
-        let measuredHeight = measuredSingleLineTextSize(maxWidth: max(contentBounds.width, 1)).height
+        let iconY = max((bounds.height - iconSize) / 2, 0)
+        iconView.frame = CGRect(
+            x: horizontalInset,
+            y: iconY,
+            width: iconSize,
+            height: iconSize
+        )
+        let textX = iconView.frame.maxX + 4
+        let textWidth = max(bounds.width - textX - horizontalInset, 1)
+        let textFrame = CGRect(x: textX, y: 0, width: textWidth, height: bounds.height)
+        let measuredHeight = measuredSingleLineTextSize(maxWidth: textWidth).height
         let verticalInset = max((bounds.height - measuredHeight) / 2, 0)
         if abs(textView.textContainerInset.top - verticalInset) > 0.5
             || abs(textView.textContainerInset.bottom - verticalInset) > 0.5 {
@@ -2421,18 +2524,20 @@ private final class FirePostBoostChipView: UIView {
                 right: 0
             )
         }
-        textView.frame = contentBounds
+        textView.frame = textFrame
     }
 
     override func sizeThatFits(_ size: CGSize) -> CGSize {
+        let textMaxWidth = max(size.width - horizontalInset * 2 - iconSize - 4, 1)
         let textSize = FirePostBoostManualLayout.measuredSingleLineTextSize(
             attributedText: textView.attributedText,
-            maxWidth: max(size.width - horizontalInset * 2, 1)
+            maxWidth: textMaxWidth
         )
-        return CGSize(
-            width: min(textSize.width + horizontalInset * 2, size.width),
-            height: size.height
+        let width = min(
+            textSize.width + horizontalInset * 2 + iconSize + 4,
+            size.width
         )
+        return CGSize(width: width, height: size.height)
     }
 
     private func measuredSingleLineTextSize(maxWidth: CGFloat) -> CGSize {
@@ -2606,15 +2711,12 @@ private final class FirePostBoostManualScrollerView: UIView {
         isHidden = visibleBoosts.isEmpty
 
         for (index, boost) in visibleBoosts.enumerated() {
-            let chip = FirePostBoostChipView(
-                backgroundColor: UIColor.secondarySystemFill.withAlphaComponent(0.78),
-                textColor: .secondaryLabel
-            )
+            let chip = FirePostBoostChipView.styleForManual()
             chip.configure(
-                attributedText: FirePostBoostDisplay.displayContent(
+                attributedText: FirePostBoostDisplay.compactChipContent(
                     for: boost,
-                    textColor: .secondaryLabel,
-                    accentColor: .systemBlue
+                    textColor: FireTheme.uiSubtleInk,
+                    usernameColor: FireTheme.uiAccent
                 ),
                 signature: FirePostBoostDisplay.contentSignature(for: boost)
             )

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostLayoutManager.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostLayoutManager.swift
@@ -185,6 +185,16 @@ final class FirePostLayoutManager: ObservableObject {
             containerWidth: availableWidth,
             contentSizeCategory: contentSizeCategory
         )
+        let collapsedTextHeightOverride: CGFloat?
+        if key.textExpansionState.isCollapsed {
+            collapsedTextHeightOverride = FirePostCellLayoutCalculator.measureCollapsedRichTextHeight(
+                attributedText: attributedText,
+                containerWidth: availableWidth,
+                truncationToken: FirePostCollapsedTextNormalizer.expansionTruncationToken()
+            )
+        } else {
+            collapsedTextHeightOverride = nil
+        }
         let imageSizes = images.map { image in
             FirePostCellLayoutCalculator.imageRenderSize(
                 for: image,
@@ -206,7 +216,8 @@ final class FirePostLayoutManager: ObservableObject {
             imageSizes: imageSizes,
             pollHeights: pollHeights,
             boostLines: boostLines,
-            trait: trait
+            trait: trait,
+            collapsedTextHeightOverride: collapsedTextHeightOverride
         )
     }
 }

--- a/native/ios-app/App/ListKit/TopicDetail/FirePostPollRenderer.swift
+++ b/native/ios-app/App/ListKit/TopicDetail/FirePostPollRenderer.swift
@@ -235,8 +235,10 @@ final class FirePostPollView: UIView {
         removeVoteButton.setTitle("撤销投票", for: .normal)
         removeVoteButton.setImage(UIImage(systemName: "arrow.uturn.left"), for: .normal)
         removeVoteButton.addTarget(self, action: #selector(removeVoteTapped), for: .touchUpInside)
+        removeVoteButton.fireBindPressBounce(.compact)
         submitButton.setTitle("提交", for: .normal)
         submitButton.addTarget(self, action: #selector(submitTapped), for: .touchUpInside)
+        submitButton.fireBindPressBounce(.button)
 
         addSubview(titleLabel)
         addSubview(votersLabel)
@@ -276,6 +278,7 @@ final class FirePostPollView: UIView {
             let button = FirePostPollOptionButton()
             button.configure(option: option)
             button.addTarget(self, action: #selector(optionTapped(_:)), for: .touchUpInside)
+            button.fireBindPressBounce(.compact)
             addSubview(button)
             return button
         }

--- a/native/ios-app/App/Stores/FireHomeFeedStore.swift
+++ b/native/ios-app/App/Stores/FireHomeFeedStore.swift
@@ -30,12 +30,11 @@ public enum FireHomeTopicListDisplayState: Hashable {
 final class FireHomeFeedStore: ObservableObject {
     private static let topicListRefreshLoadingPollInterval: Duration = .milliseconds(250)
 
-    private struct FireHomeTopicRowsMergeResult {
+    private struct FireHomeTopicRowsMergeResult: Sendable {
         let rows: [FireTopicRowPresentation]
         let entities: FireEntityIndex<UInt64, FireTopicRowPresentation>
         let order: FireOrderedIDList<UInt64>
-        let dirtyTopicIDs: Set<UInt64>
-        let rebuildAllTokens: Bool
+        let contentTokens: [UInt64: String]
     }
 
     @Published private(set) var selectedTopicKind: TopicListKindState = .latest
@@ -196,10 +195,10 @@ final class FireHomeFeedStore: ObservableObject {
         topicEntities.upsert([patched], id: \.topic.id)
         let rows = topicEntities.orderedValues(for: topicOrder)
         topicRows = rows
-        updateTopicRowContentTokens(
-            rows: rows,
-            dirtyTopicIDs: [detail.id],
-            rebuildAll: false
+        // Single-row patch is cheap; keep it synchronous on main.
+        topicRowContentTokensByID[detail.id] = Self.makeTopicRowContentToken(
+            patched,
+            category: categoryPresentation(for: patched.topic.categoryId)
         )
         visibleTopicIDs = Self.sanitizedVisibleTopicIDs(
             currentTopicIDs: rows.map(\.topic.id),
@@ -267,20 +266,23 @@ final class FireHomeFeedStore: ObservableObject {
     }
 
     func applyTopicList(_ state: TopicListState) {
-        let mergeResult = mergeTopicRows(
-            incoming: state.rows,
-            reset: true,
-            usesIncrementalRefresh: false
-        )
-        applyTopicRows(mergeResult)
-        renderedTopicListScope = currentTopicListRefreshScope
-        topicLoadErrorMessage = nil
-        isOffline = state.isCached
-        moreTopicsUrl = state.moreTopicsUrl
-        nextTopicsPage = state.nextPage
-        isLoadingTopics = false
-        isAppendingTopics = false
-        appViewModel.updateWidgetData()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let mergeResult = await self.prepareTopicRowsMerge(
+                incoming: state.rows,
+                reset: true,
+                usesIncrementalRefresh: false
+            )
+            self.applyTopicRows(mergeResult)
+            self.renderedTopicListScope = self.currentTopicListRefreshScope
+            self.topicLoadErrorMessage = nil
+            self.isOffline = state.isCached
+            self.moreTopicsUrl = state.moreTopicsUrl
+            self.nextTopicsPage = state.nextPage
+            self.isLoadingTopics = false
+            self.isAppendingTopics = false
+            self.appViewModel.updateWidgetData()
+        }
     }
 
     @discardableResult
@@ -567,7 +569,7 @@ final class FireHomeFeedStore: ObservableObject {
                 return false
             }
 
-            let mergeResult = mergeTopicRows(
+            let mergeResult = await prepareTopicRowsMerge(
                 incoming: response.rows,
                 reset: reset,
                 usesIncrementalRefresh: usesIncrementalRefresh
@@ -649,11 +651,7 @@ final class FireHomeFeedStore: ObservableObject {
         topicEntities = result.entities
         topicOrder = result.order
         topicRows = result.rows
-        updateTopicRowContentTokens(
-            rows: result.rows,
-            dirtyTopicIDs: result.dirtyTopicIDs,
-            rebuildAll: result.rebuildAllTokens
-        )
+        topicRowContentTokensByID = result.contentTokens
         visibleTopicIDs = Self.sanitizedVisibleTopicIDs(
             currentTopicIDs: result.rows.map(\.topic.id),
             candidateVisibleTopicIDs: visibleTopicIDs
@@ -671,76 +669,123 @@ final class FireHomeFeedStore: ObservableObject {
         renderedTopicListScope = nil
     }
 
-    private func mergeTopicRows(
+    /// Snapshot current indexes, then merge + rebuild content tokens off the main actor.
+    private func prepareTopicRowsMerge(
         incoming: [FireTopicRowPresentation],
         reset: Bool,
         usesIncrementalRefresh: Bool
+    ) async -> FireHomeTopicRowsMergeResult {
+        let existingRows = topicRows
+        let existingEntities = topicEntities
+        let existingOrder = topicOrder
+        let previousTokens = topicRowContentTokensByID
+        let categories = topicCategories
+
+        return await Task.detached(priority: .userInitiated) {
+            Self.mergeTopicRows(
+                incoming: incoming,
+                existingRows: existingRows,
+                existingEntities: existingEntities,
+                existingOrder: existingOrder,
+                previousTokens: previousTokens,
+                categories: categories,
+                reset: reset,
+                usesIncrementalRefresh: usesIncrementalRefresh
+            )
+        }.value
+    }
+
+    nonisolated private static func mergeTopicRows(
+        incoming: [FireTopicRowPresentation],
+        existingRows: [FireTopicRowPresentation],
+        existingEntities: FireEntityIndex<UInt64, FireTopicRowPresentation>,
+        existingOrder: FireOrderedIDList<UInt64>,
+        previousTokens: [UInt64: String],
+        categories: [UInt64: FireTopicCategoryPresentation],
+        reset: Bool,
+        usesIncrementalRefresh: Bool
     ) -> FireHomeTopicRowsMergeResult {
+        let dirtyTopicIDs = Set(incoming.map(\.topic.id))
+        let rebuildAllTokens: Bool
+        let rows: [FireTopicRowPresentation]
+        let entities: FireEntityIndex<UInt64, FireTopicRowPresentation>
+        let order: FireOrderedIDList<UInt64>
+
         if reset {
             if usesIncrementalRefresh {
-                let rows = FireTopicListMessageBusRefreshMerger.merge(
-                    existing: topicRows,
+                let mergedRows = FireTopicListMessageBusRefreshMerger.merge(
+                    existing: existingRows,
                     incoming: incoming
                 )
-                var entities = FireEntityIndex<UInt64, FireTopicRowPresentation>()
-                entities.replaceAll(rows, id: \.topic.id)
-                let order = FireOrderedIDList(ids: rows.map(\.topic.id))
-                return FireHomeTopicRowsMergeResult(
-                    rows: rows,
-                    entities: entities,
-                    order: order,
-                    dirtyTopicIDs: Set(incoming.map(\.topic.id)),
-                    rebuildAllTokens: false
-                )
+                var nextEntities = FireEntityIndex<UInt64, FireTopicRowPresentation>()
+                nextEntities.replaceAll(mergedRows, id: \.topic.id)
+                rows = mergedRows
+                entities = nextEntities
+                order = FireOrderedIDList(ids: mergedRows.map(\.topic.id))
+                rebuildAllTokens = false
+            } else {
+                var nextEntities = FireEntityIndex<UInt64, FireTopicRowPresentation>()
+                nextEntities.replaceAll(incoming, id: \.topic.id)
+                rows = incoming
+                entities = nextEntities
+                order = FireOrderedIDList(ids: incoming.map(\.topic.id))
+                rebuildAllTokens = true
             }
-            var entities = FireEntityIndex<UInt64, FireTopicRowPresentation>()
-            entities.replaceAll(incoming, id: \.topic.id)
-            let order = FireOrderedIDList(ids: incoming.map(\.topic.id))
-            return FireHomeTopicRowsMergeResult(
-                rows: incoming,
-                entities: entities,
-                order: order,
-                dirtyTopicIDs: Set(incoming.map(\.topic.id)),
-                rebuildAllTokens: true
-            )
+        } else {
+            var nextEntities = existingEntities
+            nextEntities.upsert(incoming, id: \.topic.id)
+            var nextOrder = existingOrder
+            nextOrder.append(incoming.map(\.topic.id))
+            rows = nextEntities.orderedValues(for: nextOrder)
+            entities = nextEntities
+            order = nextOrder
+            rebuildAllTokens = false
         }
 
-        var entities = topicEntities
-        entities.upsert(incoming, id: \.topic.id)
-        var order = topicOrder
-        order.append(incoming.map(\.topic.id))
+        let contentTokens = buildTopicRowContentTokens(
+            rows: rows,
+            dirtyTopicIDs: dirtyTopicIDs,
+            rebuildAll: rebuildAllTokens,
+            previousTokens: previousTokens,
+            categories: categories
+        )
+
         return FireHomeTopicRowsMergeResult(
-            rows: entities.orderedValues(for: order),
+            rows: rows,
             entities: entities,
             order: order,
-            dirtyTopicIDs: Set(incoming.map(\.topic.id)),
-            rebuildAllTokens: false
+            contentTokens: contentTokens
         )
     }
 
-    private func updateTopicRowContentTokens(
+    nonisolated private static func buildTopicRowContentTokens(
         rows: [FireTopicRowPresentation],
         dirtyTopicIDs: Set<UInt64>,
-        rebuildAll: Bool
-    ) {
+        rebuildAll: Bool,
+        previousTokens: [UInt64: String],
+        categories: [UInt64: FireTopicCategoryPresentation]
+    ) -> [UInt64: String] {
         let currentTopicIDs = Set(rows.map(\.topic.id))
         var nextTokens: [UInt64: String]
         if rebuildAll {
             nextTokens = [:]
             nextTokens.reserveCapacity(rows.count)
         } else {
-            nextTokens = topicRowContentTokensByID.filter { currentTopicIDs.contains($0.key) }
+            nextTokens = previousTokens.filter { currentTopicIDs.contains($0.key) }
         }
 
         for row in rows where rebuildAll || dirtyTopicIDs.contains(row.topic.id) {
-            nextTokens[row.topic.id] = makeTopicRowContentToken(row)
+            let category = row.topic.categoryId.flatMap { categories[$0] }
+            nextTokens[row.topic.id] = makeTopicRowContentToken(row, category: category)
         }
-        topicRowContentTokensByID = nextTokens
+        return nextTokens
     }
 
-    private func makeTopicRowContentToken(_ row: FireTopicRowPresentation) -> String {
+    nonisolated static func makeTopicRowContentToken(
+        _ row: FireTopicRowPresentation,
+        category: FireTopicCategoryPresentation?
+    ) -> String {
         let topic = row.topic
-        let category = categoryPresentation(for: topic.categoryId)
         var parts: [String] = []
         parts.reserveCapacity(26)
         parts.append(String(topic.id))

--- a/native/ios-app/App/Stores/FireTopicDetailStore.swift
+++ b/native/ios-app/App/Stores/FireTopicDetailStore.swift
@@ -5,9 +5,17 @@ private enum FireTopicDetailSearchDirection {
     case forward
 }
 
-private struct FireTopicDetailPagePayload {
+private struct FireTopicDetailPagePayload: Sendable {
     let sourceSnapshot: TopicDetailSourceSnapshotState
     let treePresentation: TopicTreePresentationState
+}
+
+/// Pure data product of a topic-detail page payload, prepared off the main actor.
+private struct FirePreparedTopicDetailPage: Sendable {
+    let treePresentation: TopicTreePresentationState
+    let detail: TopicDetailState
+    let postLookup: [UInt64: TopicPostState]
+    let suggestedUnreadRootPostNumber: UInt32?
 }
 
 private struct FireTopicDetailFeedContentToken: Equatable {
@@ -785,6 +793,17 @@ final class FireTopicDetailStore: ObservableObject {
         sourceSnapshot: TopicDetailSourceSnapshotState,
         treePresentation: TopicTreePresentationState
     ) -> TopicDetailState {
+        Self.synthesizedTopicDetail(
+            sourceSnapshot: sourceSnapshot,
+            treePresentation: treePresentation
+        )
+    }
+
+    /// Pure topic-detail synthesis — safe to run off the main actor.
+    nonisolated private static func synthesizedTopicDetail(
+        sourceSnapshot: TopicDetailSourceSnapshotState,
+        treePresentation: TopicTreePresentationState
+    ) -> TopicDetailState {
         let replyRows = FireTopicPresentation
             .uniqueTreeRowsPreservingOrder(treePresentation.replyRows)
             .filter { row in
@@ -832,6 +851,40 @@ final class FireTopicDetailStore: ObservableObject {
         )
     }
 
+    /// Dedup/filter tree rows + synthesize detail/lookup off-main so the main actor
+    /// only commits state and kicks render/UI work.
+    nonisolated private static func prepareTopicDetailPagePayload(
+        _ payload: FireTopicDetailPagePayload,
+        allowsSuggestedUnreadRootScrollTarget: Bool
+    ) -> FirePreparedTopicDetailPage {
+        var treePresentation = payload.treePresentation
+        treePresentation.replyRows = FireTopicPresentation
+            .uniqueTreeRowsPreservingOrder(treePresentation.replyRows)
+            .filter { $0.postId != payload.sourceSnapshot.body.post.id }
+
+        let detail = synthesizedTopicDetail(
+            sourceSnapshot: payload.sourceSnapshot,
+            treePresentation: treePresentation
+        )
+        let postLookup = FireTopicPresentation.topicPostsByID(detail.postStream.posts)
+
+        let suggestedUnreadRootPostNumber: UInt32?
+        if allowsSuggestedUnreadRootScrollTarget,
+           let suggestedTarget = treePresentation.firstUnreadRootPostNumber,
+           suggestedTarget > 1 {
+            suggestedUnreadRootPostNumber = suggestedTarget
+        } else {
+            suggestedUnreadRootPostNumber = nil
+        }
+
+        return FirePreparedTopicDetailPage(
+            treePresentation: treePresentation,
+            detail: detail,
+            postLookup: postLookup,
+            suggestedUnreadRootPostNumber: suggestedUnreadRootPostNumber
+        )
+    }
+
     private func applyTopicDetailPagePayload(
         _ payload: FireTopicDetailPagePayload,
         detailNotice: FireTopicDetailStatusMessage?,
@@ -839,37 +892,35 @@ final class FireTopicDetailStore: ObservableObject {
         allowsSuggestedUnreadRootScrollTarget: Bool = false
     ) async {
         let applyStartedAt = Date()
-        var treePresentation = payload.treePresentation
-        treePresentation.replyRows = FireTopicPresentation
-            .uniqueTreeRowsPreservingOrder(treePresentation.replyRows)
-            .filter { $0.postId != payload.sourceSnapshot.body.post.id }
-        if allowsSuggestedUnreadRootScrollTarget,
-           let suggestedTarget = treePresentation.firstUnreadRootPostNumber,
-           suggestedTarget > 1,
+        let prepared = await Task.detached(priority: .userInitiated) {
+            Self.prepareTopicDetailPagePayload(
+                payload,
+                allowsSuggestedUnreadRootScrollTarget: allowsSuggestedUnreadRootScrollTarget
+            )
+        }.value
+
+        if let suggestedTarget = prepared.suggestedUnreadRootPostNumber,
            topicDetailTargetPostNumbers[topicId] == nil {
             setPendingScrollTarget(suggestedTarget, topicId: topicId)
         }
         rememberTopicRecoverySlug(payload.sourceSnapshot.header.slug, topicId: topicId)
         updateTopicDetailNotice(detailNotice, topicId: topicId)
         topicSourceSnapshots[topicId] = payload.sourceSnapshot
-        topicTreePresentations[topicId] = treePresentation
+        topicTreePresentations[topicId] = prepared.treePresentation
         if let cursor = payload.sourceSnapshot.sourceCursor {
             topicSourceCursorsByTopic[topicId] = cursor
         } else {
             topicSourceCursorsByTopic.removeValue(forKey: topicId)
         }
         setLoadMoreTopicPostsError(nil, topicId: topicId)
-        let detail = rebuildTopicDetail(
-            sourceSnapshot: payload.sourceSnapshot,
-            treePresentation: treePresentation,
-            topicId: topicId
-        )
+        topicPostLookups[topicId] = prepared.postLookup
+
         appViewModel.topicDetailLogger()?.debug(
-            "topic detail page main apply topic_id=\(topicId) main_apply_ms=\(Self.elapsedMilliseconds(since: applyStartedAt)) source_loaded_posts=\(payload.sourceSnapshot.loadedPosts.count) body_post_included=true tree_total_loaded_post_count=\(treePresentation.totalLoadedPostCount) reply_rows=\(treePresentation.replyRows.count) cooked_byte_count=\(Self.cookedByteCount(sourceSnapshot: payload.sourceSnapshot))"
+            "topic detail page main apply topic_id=\(topicId) main_apply_ms=\(Self.elapsedMilliseconds(since: applyStartedAt)) source_loaded_posts=\(payload.sourceSnapshot.loadedPosts.count) body_post_included=true tree_total_loaded_post_count=\(prepared.treePresentation.totalLoadedPostCount) reply_rows=\(prepared.treePresentation.replyRows.count) cooked_byte_count=\(Self.cookedByteCount(sourceSnapshot: payload.sourceSnapshot))"
         )
-        _ = await buildTopicDetailRenderUpdate(detail: detail, topicId: topicId)
-        appViewModel.patchHomeTopicCounts(from: detail)
-        loadTopicAiSummaryIfNeeded(topicId: topicId, detail: detail)
+        _ = await buildTopicDetailRenderUpdate(detail: prepared.detail, topicId: topicId)
+        appViewModel.patchHomeTopicCounts(from: prepared.detail)
+        loadTopicAiSummaryIfNeeded(topicId: topicId, detail: prepared.detail)
     }
 
     private func loadNextTopicSourcePage(
@@ -1689,8 +1740,17 @@ final class FireTopicDetailStore: ObservableObject {
             throw FireTopicInteractionError.requiresAuthenticatedWrite
         }
         guard !mutatingPostIDs.contains(postId) else {
-            return
+            // Another reaction for this post is already in-flight.
+            throw CancellationError()
         }
+
+        // Optimistic UI first — network settles in the background; revert on failure.
+        let rollback = captureReactionSnapshot(topicId: topicId, postId: postId)
+        applyOptimisticReactionChange(
+            topicId: topicId,
+            postId: postId,
+            desiredReactionID: liked ? "heart" : nil
+        )
 
         setMutatingPost(true, topicId: topicId, postId: postId)
         defer { setMutatingPost(false, topicId: topicId, postId: postId) }
@@ -1714,6 +1774,9 @@ final class FireTopicDetailStore: ObservableObject {
                 try? await refreshTopicDetailAfterMutation(topicId: topicId, sessionStore: sessionStore)
             }
         } catch {
+            if let rollback {
+                restoreReactionSnapshot(rollback, topicId: topicId, postId: postId)
+            }
             if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
                 throw error
             }
@@ -1736,8 +1799,22 @@ final class FireTopicDetailStore: ObservableObject {
             throw FireTopicInteractionError.requiresAuthenticatedWrite
         }
         guard !mutatingPostIDs.contains(postId) else {
-            return
+            throw CancellationError()
         }
+
+        let currentID = topicDetails[topicId]?
+            .postStream.posts
+            .first(where: { $0.id == postId })?
+            .currentUserReaction?.id
+        let desiredID = currentID == trimmedReactionID ? nil : trimmedReactionID
+
+        // Optimistic UI first — network settles in the background; revert on failure.
+        let rollback = captureReactionSnapshot(topicId: topicId, postId: postId)
+        applyOptimisticReactionChange(
+            topicId: topicId,
+            postId: postId,
+            desiredReactionID: desiredID
+        )
 
         setMutatingPost(true, topicId: topicId, postId: postId)
         defer { setMutatingPost(false, topicId: topicId, postId: postId) }
@@ -1755,6 +1832,9 @@ final class FireTopicDetailStore: ObservableObject {
             }
             applyPostReactionUpdate(topicId: topicId, postId: postId, update: update)
         } catch {
+            if let rollback {
+                restoreReactionSnapshot(rollback, topicId: topicId, postId: postId)
+            }
             if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
                 throw error
             }
@@ -3220,10 +3300,107 @@ final class FireTopicDetailStore: ObservableObject {
         return lowerBound..<upperBound
     }
 
+    private struct ReactionSnapshot {
+        let reactions: [TopicReactionState]
+        let currentUserReaction: TopicReactionState?
+        let likeCount: UInt32
+    }
+
+    private func captureReactionSnapshot(
+        topicId: UInt64,
+        postId: UInt64
+    ) -> ReactionSnapshot? {
+        guard let post = topicDetails[topicId]?.postStream.posts.first(where: { $0.id == postId }) else {
+            return nil
+        }
+        return ReactionSnapshot(
+            reactions: post.reactions,
+            currentUserReaction: post.currentUserReaction,
+            likeCount: post.likeCount
+        )
+    }
+
+    private func restoreReactionSnapshot(
+        _ snapshot: ReactionSnapshot,
+        topicId: UInt64,
+        postId: UInt64
+    ) {
+        applyPostReactionUpdate(
+            topicId: topicId,
+            postId: postId,
+            update: PostReactionUpdateState(
+                reactions: snapshot.reactions,
+                currentUserReaction: snapshot.currentUserReaction
+            ),
+            likeCountOverride: snapshot.likeCount
+        )
+    }
+
+    /// Immediately mirrors the desired reaction in local state so chips feel instant.
+    private func applyOptimisticReactionChange(
+        topicId: UInt64,
+        postId: UInt64,
+        desiredReactionID: String?
+    ) {
+        guard let post = topicDetails[topicId]?.postStream.posts.first(where: { $0.id == postId }) else {
+            return
+        }
+        let currentID = post.currentUserReaction?.id
+        guard currentID != desiredReactionID else { return }
+
+        var reactions = post.reactions
+        func adjustCount(for reactionID: String, delta: Int) {
+            if let index = reactions.firstIndex(where: { $0.id == reactionID }) {
+                let next = max(0, Int(reactions[index].count) + delta)
+                if next == 0 {
+                    reactions.remove(at: index)
+                } else {
+                    reactions[index] = TopicReactionState(
+                        id: reactions[index].id,
+                        kind: reactions[index].kind,
+                        count: UInt32(next),
+                        canUndo: reactions[index].canUndo
+                    )
+                }
+            } else if delta > 0 {
+                reactions.append(
+                    TopicReactionState(
+                        id: reactionID,
+                        kind: nil,
+                        count: UInt32(delta),
+                        canUndo: true
+                    )
+                )
+            }
+        }
+
+        if let currentID {
+            adjustCount(for: currentID, delta: -1)
+        }
+        if let desiredReactionID {
+            adjustCount(for: desiredReactionID, delta: 1)
+        }
+
+        let currentUserReaction = desiredReactionID.map {
+            TopicReactionState(id: $0, kind: nil, count: 1, canUndo: true)
+        }
+        let heartCount = reactions.first(where: { $0.id == "heart" })?.count ?? 0
+        applyPostReactionUpdate(
+            topicId: topicId,
+            postId: postId,
+            update: PostReactionUpdateState(
+                reactions: reactions,
+                currentUserReaction: currentUserReaction
+            ),
+            likeCountOverride: heartCount
+        )
+    }
+
     private func applyPostReactionUpdate(
         topicId: UInt64,
         postId: UInt64,
-        update: PostReactionUpdateState
+        update: PostReactionUpdateState,
+        likeCountOverride: UInt32? = nil
     ) {
         guard var detail = topicDetails[topicId] else {
             return
@@ -3239,7 +3416,9 @@ final class FireTopicDetailStore: ObservableObject {
         post.reactions = update.reactions
         post.currentUserReaction = update.currentUserReaction
 
-        if let updatedHeartCount {
+        if let likeCountOverride {
+            post.likeCount = likeCountOverride
+        } else if let updatedHeartCount {
             post.likeCount = updatedHeartCount
         } else if previousHeartCount != nil || post.currentUserReaction?.id == "heart" {
             post.likeCount = 0

--- a/native/ios-app/App/Stores/Shared/FireEntityIndex.swift
+++ b/native/ios-app/App/Stores/Shared/FireEntityIndex.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct FireEntityIndex<ID: Hashable, Entity> {
+struct FireEntityIndex<ID: Hashable & Sendable, Entity: Sendable>: Sendable {
     private(set) var entitiesByID: [ID: Entity] = [:]
 
     var isEmpty: Bool {

--- a/native/ios-app/App/Stores/Shared/FireOrderedIDList.swift
+++ b/native/ios-app/App/Stores/Shared/FireOrderedIDList.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct FireOrderedIDList<ID: Hashable> {
+struct FireOrderedIDList<ID: Hashable & Sendable>: Sendable {
     private(set) var ids: [ID] = []
     private var idSet: Set<ID> = []
 

--- a/native/ios-app/App/TopicDetail/Support/FireTopicPresentation.swift
+++ b/native/ios-app/App/TopicDetail/Support/FireTopicPresentation.swift
@@ -5,6 +5,126 @@ import UIKit
 typealias FireTopicCategoryPresentation = TopicCategoryState
 typealias FireTopicRowPresentation = TopicRowState
 
+// MARK: - Home / list metric emphasis
+
+/// Visual weight for topic-list reply / view / like chips.
+/// Normal stays quiet; only notable / high / surge values light up.
+enum FireTopicListMetricEmphasis: Equatable, Sendable {
+    /// Default muted chrome — majority of rows.
+    case normal
+    /// Mild lift for above-average values.
+    case notable
+    /// Clearly hot absolute value.
+    case high
+    /// Young topic with unusually high view velocity (views only).
+    case surge
+}
+
+enum FireTopicListMetricKind: Equatable, Sendable {
+    case replies
+    case views
+    case likes
+}
+
+/// Pure ranking helpers for list metrics. Thresholds are absolute + age-aware
+/// so ordinary rows stay calm while breakout posts get a small accent.
+enum FireTopicListMetricRanking {
+    /// Reply thresholds (LinuxDo-scale list density).
+    static let repliesNotable: UInt32 = 15
+    static let repliesHigh: UInt32 = 40
+
+    /// Like thresholds.
+    static let likesNotable: UInt32 = 8
+    static let likesHigh: UInt32 = 25
+
+    /// Absolute view thresholds.
+    static let viewsNotable: UInt32 = 800
+    static let viewsHigh: UInt32 = 3_000
+
+    /// Surge: short-lived topics that already pulled solid traffic.
+    static let surgeMaxAgeHours: Double = 36
+    static let surgeViewsPerHour: Double = 70
+    static let surgeMinViews: UInt32 = 180
+    /// Extra absolute floor when still very fresh.
+    static let surgeFreshHours: Double = 8
+    static let surgeFreshMinViews: UInt32 = 120
+
+    static func ageHours(
+        createdTimestampUnixMs: UInt64?,
+        now: Date = Date()
+    ) -> Double? {
+        guard let createdTimestampUnixMs else { return nil }
+        let created = Date(timeIntervalSince1970: Double(createdTimestampUnixMs) / 1_000.0)
+        let hours = now.timeIntervalSince(created) / 3_600.0
+        return max(hours, 0)
+    }
+
+    static func emphasis(
+        kind: FireTopicListMetricKind,
+        value: UInt32,
+        createdTimestampUnixMs: UInt64?,
+        now: Date = Date()
+    ) -> FireTopicListMetricEmphasis {
+        switch kind {
+        case .replies:
+            if value >= repliesHigh { return .high }
+            if value >= repliesNotable { return .notable }
+            return .normal
+        case .likes:
+            if value >= likesHigh { return .high }
+            if value >= likesNotable { return .notable }
+            return .normal
+        case .views:
+            if isViewSurge(
+                views: value,
+                createdTimestampUnixMs: createdTimestampUnixMs,
+                now: now
+            ) {
+                return .surge
+            }
+            if value >= viewsHigh { return .high }
+            if value >= viewsNotable { return .notable }
+            return .normal
+        }
+    }
+
+    static func isViewSurge(
+        views: UInt32,
+        createdTimestampUnixMs: UInt64?,
+        now: Date = Date()
+    ) -> Bool {
+        guard views >= surgeMinViews,
+              let ageHours = ageHours(createdTimestampUnixMs: createdTimestampUnixMs, now: now),
+              ageHours <= surgeMaxAgeHours
+        else {
+            return false
+        }
+
+        // Brand-new posts need a lower absolute bar so early breakouts still light up.
+        if ageHours <= surgeFreshHours, views >= surgeFreshMinViews {
+            return true
+        }
+
+        let safeHours = max(ageHours, 0.35)
+        let viewsPerHour = Double(views) / safeHours
+        return viewsPerHour >= surgeViewsPerHour && views >= surgeMinViews
+    }
+
+    /// Tiny accessory on surge rows: rocket when very fresh, flame otherwise.
+    static func surgeAccessorySymbol(
+        createdTimestampUnixMs: UInt64?,
+        now: Date = Date()
+    ) -> String {
+        if let ageHours = ageHours(createdTimestampUnixMs: createdTimestampUnixMs, now: now),
+           ageHours <= surgeFreshHours
+        {
+            return "rocket.fill"
+        }
+        return "flame.fill"
+    }
+}
+
+
 struct FireTopicTimelineEntry: Hashable, Sendable {
     let postId: UInt64
     let postNumber: UInt32

--- a/native/ios-app/App/TopicDetail/Support/FireTopicPresentation.swift
+++ b/native/ios-app/App/TopicDetail/Support/FireTopicPresentation.swift
@@ -124,7 +124,6 @@ enum FireTopicListMetricRanking {
     }
 }
 
-
 struct FireTopicTimelineEntry: Hashable, Sendable {
     let postId: UInt64
     let postNumber: UInt32
@@ -376,17 +375,16 @@ enum FireTopicPresentation {
         from document: RenderDocumentState,
         sourceToken: String
     ) -> FireTopicPostRenderContent {
-        let richContent = FireRenderBlockNodeBuilder.build(document: document)
-        return renderContent(from: richContent, source: sourceToken)
+        renderContentFromRenderDocument(document, source: sourceToken)
     }
 
     static func renderContent(from post: TopicPostState) -> FireTopicPostRenderContent? {
         guard let document = post.renderDocument else {
             return nil
         }
-        return renderContent(
-            from: document,
-            sourceToken: Self.renderInput(for: post).renderDocumentChecksum.map(String.init) ?? "missing"
+        return renderContentFromRenderDocument(
+            document,
+            source: Self.renderInput(for: post).renderDocumentChecksum.map(String.init) ?? "missing"
         )
     }
 
@@ -397,7 +395,17 @@ enum FireTopicPresentation {
     }
 
     private static func renderDocumentChecksum(_ document: RenderDocumentState) -> UInt64 {
-        FireTopicPostRenderSignature.stableChecksum(String(reflecting: document))
+        // Stable, cheap fingerprint from Rust IR fields — never String(reflecting:).
+        var hasherParts: [String] = [
+            document.plainText,
+            String(document.blocks.count),
+            String(document.imageAttachments.count),
+        ]
+        hasherParts.reserveCapacity(3 + document.imageAttachments.count)
+        for image in document.imageAttachments {
+            hasherParts.append(image.url)
+        }
+        return FireTopicPostRenderSignature.stableChecksum(hasherParts.joined(separator: "\u{1E}"))
     }
 
     private static func renderContent(
@@ -409,7 +417,13 @@ enum FireTopicPresentation {
                 from: richContent.nodes,
                 accentColor: FireTopicDetailCellColors.accent
             )
-        let segments = renderSegments(from: richContent)
+        // Fallback path when only Swift nodes are available (tests / legacy).
+        let segments: [FireTopicPostRenderSegment]
+        if richContent.imageAttachments.isEmpty {
+            segments = attributedText.map { [.text($0)] } ?? []
+        } else {
+            segments = renderSegmentsFromNodes(richContent)
+        }
         return FireTopicPostRenderContent(
             plainText: richContent.plainText,
             attributedText: attributedText,
@@ -423,190 +437,72 @@ enum FireTopicPresentation {
         )
     }
 
-    private enum RawRenderSegment {
-        case nodes([FireRichTextNode])
-        case image(FireCookedImage)
-    }
-
-    private static func renderSegments(from richContent: FireRichTextContent) -> [FireTopicPostRenderSegment] {
-        var attachmentIndex = 0
-        let rawSegments = rawRenderSegments(
-            from: richContent.nodes,
-            imageAttachments: richContent.imageAttachments,
-            attachmentIndex: &attachmentIndex
-        )
-        var renderedSegments = rawSegments.compactMap { segment -> FireTopicPostRenderSegment? in
+    /// Preferred path: segment plan comes from Rust `display_segments_from_render_document`.
+    private static func renderContentFromRenderDocument(
+        _ document: RenderDocumentState,
+        source: String
+    ) -> FireTopicPostRenderContent {
+        let richContent = FireRenderBlockNodeBuilder.build(document: document)
+        let rustSegments = displaySegmentsFromRenderDocument(document: document)
+        let segments = rustSegments.compactMap { segment -> FireTopicPostRenderSegment? in
             switch segment {
-            case .nodes(let nodes):
+            case let .rich(subdocument):
+                let nodes = FireRenderBlockNodeBuilder.build(document: subdocument).nodes
                 guard !nodes.isEmpty else { return nil }
                 let attributedText = FireRichTextAttributedStringBuilder.build(
                     from: nodes,
                     accentColor: FireTopicDetailCellColors.accent
                 )
                 return attributedText.length > 0 ? .text(attributedText) : nil
-            case .image(let image):
-                return .image(image)
-            }
-        }
-        var emittedImageIDs = Set(renderedSegments.compactMap { segment -> String? in
-            guard case .image(let image) = segment else {
-                return nil
-            }
-            return image.id
-        })
-        for image in richContent.imageAttachments where emittedImageIDs.insert(image.id).inserted {
-            renderedSegments.append(.image(image))
-        }
-        return renderedSegments
-    }
-
-    private static func rawRenderSegments(
-        from nodes: [FireRichTextNode],
-        imageAttachments: [FireCookedImage],
-        attachmentIndex: inout Int
-    ) -> [RawRenderSegment] {
-        var segments: [RawRenderSegment] = []
-        for node in nodes {
-            appendRawRenderSegments(
-                for: node,
-                to: &segments,
-                imageAttachments: imageAttachments,
-                attachmentIndex: &attachmentIndex
-            )
-        }
-        return segments
-    }
-
-    private static func appendRawRenderSegments(
-        for node: FireRichTextNode,
-        to segments: inout [RawRenderSegment],
-        imageAttachments: [FireCookedImage],
-        attachmentIndex: inout Int
-    ) {
-        switch node {
-        case .image(let src, let alt, let width, let height):
-            appendImageSegment(
-                src: src,
-                altText: alt,
-                width: width,
-                height: height,
-                to: &segments,
-                imageAttachments: imageAttachments,
-                attachmentIndex: &attachmentIndex
-            )
-        case .paragraph(let children):
-            appendContainerSegments(
-                children,
-                wrap: { .paragraph($0) },
-                to: &segments,
-                imageAttachments: imageAttachments,
-                attachmentIndex: &attachmentIndex
-            )
-        case .heading(let level, let children):
-            appendContainerSegments(
-                children,
-                wrap: { .heading(level: level, children: $0) },
-                to: &segments,
-                imageAttachments: imageAttachments,
-                attachmentIndex: &attachmentIndex
-            )
-        case .blockquote(let children):
-            appendContainerSegments(
-                children,
-                wrap: { .blockquote($0) },
-                to: &segments,
-                imageAttachments: imageAttachments,
-                attachmentIndex: &attachmentIndex
-            )
-        case .quote(let author, let postNumber, let topicId, let children):
-            appendContainerSegments(
-                children,
-                wrap: { .quote(author: author, postNumber: postNumber, topicId: topicId, children: $0) },
-                to: &segments,
-                imageAttachments: imageAttachments,
-                attachmentIndex: &attachmentIndex
-            )
-        case .details(let summary, let children):
-            let summaryNode = FireRichTextNode.details(summary: summary, children: [])
-            appendTextSegment([summaryNode], to: &segments)
-            appendContainerSegments(
-                children,
-                wrap: { .paragraph($0) },
-                to: &segments,
-                imageAttachments: imageAttachments,
-                attachmentIndex: &attachmentIndex
-            )
-        case .list(let ordered, let items):
-            for item in items {
-                appendContainerSegments(
-                    item,
-                    wrap: { .list(ordered: ordered, items: [$0]) },
-                    to: &segments,
-                    imageAttachments: imageAttachments,
-                    attachmentIndex: &attachmentIndex
+            case let .image(imageState):
+                guard let url = URL(string: imageState.url) else { return nil }
+                return .image(
+                    FireCookedImage(
+                        url: url,
+                        altText: imageState.altText,
+                        width: imageState.width.map(CGFloat.init),
+                        height: imageState.height.map(CGFloat.init)
+                    )
                 )
             }
-        default:
-            appendTextSegment([node], to: &segments)
         }
+
+        let attributedText = richContent.nodes.isEmpty ? nil :
+            FireRichTextAttributedStringBuilder.build(
+                from: richContent.nodes,
+                accentColor: FireTopicDetailCellColors.accent
+            )
+
+        return FireTopicPostRenderContent(
+            plainText: document.plainText,
+            attributedText: attributedText,
+            imageAttachments: richContent.imageAttachments,
+            segments: segments,
+            signature: FireTopicPostRenderSignature.make(
+                source: source,
+                imageAttachments: richContent.imageAttachments,
+                segments: segments
+            )
+        )
     }
 
-    private static func appendContainerSegments(
-        _ children: [FireRichTextNode],
-        wrap: ([FireRichTextNode]) -> FireRichTextNode,
-        to segments: inout [RawRenderSegment],
-        imageAttachments: [FireCookedImage],
-        attachmentIndex: inout Int
-    ) {
-        let childSegments = rawRenderSegments(
-            from: children,
-            imageAttachments: imageAttachments,
-            attachmentIndex: &attachmentIndex
-        )
-        for segment in childSegments {
-            switch segment {
-            case .nodes(let nodes):
-                appendTextSegment([wrap(nodes)], to: &segments)
-            case .image(let image):
-                appendImageSegment(image, to: &segments)
+    /// Legacy node walk kept only for fixture paths that construct `FireRichTextContent` directly.
+    private static func renderSegmentsFromNodes(_ richContent: FireRichTextContent) -> [FireTopicPostRenderSegment] {
+        // When images exist without a RenderDocument plan, keep a single text body + trailing images.
+        var segments: [FireTopicPostRenderSegment] = []
+        if !richContent.nodes.isEmpty {
+            let attributedText = FireRichTextAttributedStringBuilder.build(
+                from: richContent.nodes,
+                accentColor: FireTopicDetailCellColors.accent
+            )
+            if attributedText.length > 0 {
+                segments.append(.text(attributedText))
             }
         }
-    }
-
-    private static func appendImageSegment(
-        src: String,
-        altText: String?,
-        width: CGFloat?,
-        height: CGFloat?,
-        to segments: inout [RawRenderSegment],
-        imageAttachments: [FireCookedImage],
-        attachmentIndex: inout Int
-    ) {
-        defer { attachmentIndex += 1 }
-        if attachmentIndex < imageAttachments.count {
-            appendImageSegment(imageAttachments[attachmentIndex], to: &segments)
-            return
+        for image in richContent.imageAttachments {
+            segments.append(.image(image))
         }
-        guard let url = URL(string: src) else {
-            return
-        }
-        appendImageSegment(
-            FireCookedImage(url: url, altText: altText, width: width, height: height),
-            to: &segments
-        )
-    }
-
-    private static func appendImageSegment(_ image: FireCookedImage, to segments: inout [RawRenderSegment]) {
-        segments.append(.image(image))
-    }
-
-    private static func appendTextSegment(_ nodes: [FireRichTextNode], to segments: inout [RawRenderSegment]) {
-        guard !nodes.isEmpty else { return }
-        if case .nodes(let existingNodes) = segments.last {
-            segments[segments.count - 1] = .nodes(existingNodes + nodes)
-        } else {
-            segments.append(.nodes(nodes))
-        }
+        return segments
     }
 
     static func detailRenderState(

--- a/native/ios-app/App/Views/Bookmarks/FireBookmarksViewController.swift
+++ b/native/ios-app/App/Views/Bookmarks/FireBookmarksViewController.swift
@@ -138,6 +138,9 @@ final class FireBookmarksViewController: UIViewController {
             onPrefetchItems: { [controllerReference] items in
                 controllerReference.controller?.loadMoreIfNeeded(from: items)
             },
+            onScrollActivityChanged: { scrolling in
+                FireTopicListMetricEffectCoordinator.shared.setScrolling(scrolling)
+            },
             onRefresh: { [bookmarksViewModel] in
                 await bookmarksViewModel.refresh()
             },
@@ -826,11 +829,15 @@ final class FireTopicListTopicCell: UICollectionViewCell {
     private let chipStack = UIStackView()
     private let usernameLabel = UILabel()
     private let timestampLabel = UILabel()
-    private let replyMetric = FireTopicListMetricView(systemImage: "arrowshape.turn.up.left")
-    private let viewsMetric = FireTopicListMetricView(systemImage: "eye")
-    private let likesMetric = FireTopicListMetricView(systemImage: "heart")
+    private let replyMetric = FireTopicListMetricView(kind: .replies)
+    private let viewsMetric = FireTopicListMetricView(kind: .views)
+    private let likesMetric = FireTopicListMetricView(kind: .likes)
     private var onEditBookmark: (() -> Void)?
     private var onDeleteBookmark: (() -> Void)?
+    private var boundTopicID: UInt64?
+    private var pendingViewSurgePulse = false
+    private var pendingHeartBalloon = false
+    private var pendingHeartTint: UIColor = FireTheme.uiAccent
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -844,13 +851,99 @@ final class FireTopicListTopicCell: UICollectionViewCell {
 
     override func prepareForReuse() {
         super.prepareForReuse()
+        FireTopicListMetricEffectCoordinator.shared.untrack(self)
+        boundTopicID = nil
+        pendingViewSurgePulse = false
+        pendingHeartBalloon = false
         avatarView.prepareForReuse()
+        replyMetric.prepareForReuse()
+        viewsMetric.prepareForReuse()
+        likesMetric.prepareForReuse()
         onEditBookmark = nil
         onDeleteBookmark = nil
         moreButton.menu = nil
     }
 
+    private func configureMetrics(for row: FireTopicRowPresentation) {
+        let created = row.createdTimestampUnixMs
+        boundTopicID = row.topic.id
+
+        let replyEmphasis = FireTopicListMetricRanking.emphasis(
+            kind: .replies,
+            value: row.topic.replyCount,
+            createdTimestampUnixMs: created
+        )
+        let viewsEmphasis = FireTopicListMetricRanking.emphasis(
+            kind: .views,
+            value: row.topic.views,
+            createdTimestampUnixMs: created
+        )
+        let likesEmphasis = FireTopicListMetricRanking.emphasis(
+            kind: .likes,
+            value: row.topic.likeCount,
+            createdTimestampUnixMs: created
+        )
+
+        // Static chrome always updates immediately — only micro-animations wait.
+        replyMetric.configure(value: row.topic.replyCount, emphasis: replyEmphasis)
+        viewsMetric.configure(
+            value: row.topic.views,
+            emphasis: viewsEmphasis,
+            surgeAccessorySymbol: viewsEmphasis == .surge
+                ? FireTopicListMetricRanking.surgeAccessorySymbol(createdTimestampUnixMs: created)
+                : nil,
+            animateEffects: false
+        )
+        likesMetric.configure(
+            value: row.topic.likeCount,
+            emphasis: likesEmphasis,
+            animateEffects: false
+        )
+
+        pendingViewSurgePulse = viewsEmphasis == .surge
+            && !FireTopicListMetricEffectCoordinator.shared.hasPlayed(
+                .viewSurgePulse,
+                topicID: row.topic.id
+            )
+        pendingHeartBalloon = likesEmphasis == .high
+            && !FireTopicListMetricEffectCoordinator.shared.hasPlayed(
+                .heartBalloon,
+                topicID: row.topic.id
+            )
+        pendingHeartTint = FireTopicListMetricView.tint(
+            kind: .likes,
+            emphasis: likesEmphasis
+        )
+
+        FireTopicListMetricEffectCoordinator.shared.track(self)
+    }
+
+    /// Invoked by the effect coordinator once the host list is settled.
+    func playPendingMetricEffectsIfNeeded() {
+        guard let topicID = boundTopicID else { return }
+        guard FireTopicListMetricEffectCoordinator.shared.isSettled else { return }
+        guard window != nil else { return }
+
+        if pendingViewSurgePulse {
+            pendingViewSurgePulse = false
+            if FireTopicListMetricEffectCoordinator.shared.claim(.viewSurgePulse, topicID: topicID) {
+                viewsMetric.playSurgePulse()
+            }
+        }
+
+        if pendingHeartBalloon {
+            pendingHeartBalloon = false
+            if FireTopicListMetricEffectCoordinator.shared.claim(.heartBalloon, topicID: topicID) {
+                likesMetric.playHeartBalloons(tint: pendingHeartTint)
+            }
+        }
+    }
+
     func configureMissing() {
+        FireTopicListMetricEffectCoordinator.shared.untrack(self)
+        boundTopicID = nil
+        pendingViewSurgePulse = false
+        pendingHeartBalloon = false
         titleLabel.text = nil
         chipStack.arrangedSubviews.forEach { view in
             chipStack.removeArrangedSubview(view)
@@ -858,6 +951,9 @@ final class FireTopicListTopicCell: UICollectionViewCell {
         }
         metaStack.isHidden = true
         avatarView.prepareForReuse()
+        replyMetric.prepareForReuse()
+        viewsMetric.prepareForReuse()
+        likesMetric.prepareForReuse()
     }
 
     func configure(
@@ -874,9 +970,7 @@ final class FireTopicListTopicCell: UICollectionViewCell {
         titleLabel.text = row.topic.title
         usernameLabel.text = username
         timestampLabel.text = FireTopicPresentation.compactTimestamp(unixMs: row.createdTimestampUnixMs)
-        replyMetric.configure(value: row.topic.replyCount)
-        viewsMetric.configure(value: row.topic.views)
-        likesMetric.configure(value: row.topic.likeCount)
+        configureMetrics(for: row)
         avatarView.configure(
             username: username,
             avatarTemplate: row.originalPosterAvatarTemplate,
@@ -978,15 +1072,19 @@ final class FireTopicListTopicCell: UICollectionViewCell {
 
     private func configureSubviews() {
         backgroundConfiguration = .clear()
+        // Allow high-like heart balloons to rise a few points above the metric chip.
+        clipsToBounds = false
+        contentView.clipsToBounds = false
         contentView.directionalLayoutMargins = NSDirectionalEdgeInsets(
-            top: 8,
+            top: 10,
             leading: 16,
-            bottom: 8,
+            bottom: 10,
             trailing: 16
         )
 
         outerStack.axis = .vertical
-        outerStack.spacing = 6
+        outerStack.spacing = 8
+        outerStack.clipsToBounds = false
         outerStack.translatesAutoresizingMaskIntoConstraints = false
 
         metaStack.axis = .horizontal
@@ -1017,13 +1115,15 @@ final class FireTopicListTopicCell: UICollectionViewCell {
         rowStack.axis = .horizontal
         rowStack.alignment = .top
         rowStack.spacing = 12
+        rowStack.clipsToBounds = false
 
         let bodyStack = UIStackView()
         bodyStack.axis = .vertical
         bodyStack.alignment = .fill
-        bodyStack.spacing = 6
+        bodyStack.spacing = 7
+        bodyStack.clipsToBounds = false
 
-        titleLabel.font = UIFont.preferredFont(forTextStyle: .subheadline).withWeight(.medium)
+        titleLabel.font = UIFont.preferredFont(forTextStyle: .subheadline).withWeight(.semibold)
         titleLabel.adjustsFontForContentSizeCategory = true
         titleLabel.textColor = .label
         titleLabel.numberOfLines = 2
@@ -1037,12 +1137,12 @@ final class FireTopicListTopicCell: UICollectionViewCell {
         bylineStack.alignment = .center
         bylineStack.spacing = 6
 
-        usernameLabel.font = UIFont.preferredFont(forTextStyle: .caption2).withWeight(.medium)
+        usernameLabel.font = UIFont.preferredFont(forTextStyle: .caption1).withWeight(.medium)
         usernameLabel.adjustsFontForContentSizeCategory = true
         usernameLabel.textColor = FireTopicListPalette.subtleInk
         usernameLabel.numberOfLines = 1
 
-        timestampLabel.font = UIFont.preferredFont(forTextStyle: .caption2)
+        timestampLabel.font = UIFont.preferredFont(forTextStyle: .caption1)
         timestampLabel.adjustsFontForContentSizeCategory = true
         timestampLabel.textColor = FireTopicListPalette.tertiaryInk
         timestampLabel.numberOfLines = 1
@@ -1051,11 +1151,25 @@ final class FireTopicListTopicCell: UICollectionViewCell {
         bylineStack.addArrangedSubview(timestampLabel)
         bylineStack.addArrangedSubview(UIView())
 
-        let metricStack = UIStackView(arrangedSubviews: [replyMetric, viewsMetric, likesMetric])
+        // Reply + views stay left-clustered; likes hug the trailing edge for balance.
+        let leadingMetrics = UIStackView(arrangedSubviews: [replyMetric, viewsMetric])
+        leadingMetrics.axis = .horizontal
+        leadingMetrics.alignment = .center
+        leadingMetrics.spacing = 14
+        leadingMetrics.clipsToBounds = false
+
+        let metricSpacer = UIView()
+        metricSpacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        metricSpacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        likesMetric.setContentHuggingPriority(.required, for: .horizontal)
+        likesMetric.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        let metricStack = UIStackView(arrangedSubviews: [leadingMetrics, metricSpacer, likesMetric])
         metricStack.axis = .horizontal
         metricStack.alignment = .center
-        metricStack.distribution = .fillEqually
         metricStack.spacing = 8
+        metricStack.clipsToBounds = false
 
         bodyStack.addArrangedSubview(titleLabel)
         bodyStack.addArrangedSubview(chipStack)
@@ -1069,13 +1183,20 @@ final class FireTopicListTopicCell: UICollectionViewCell {
         outerStack.addArrangedSubview(rowStack)
 
         contentView.addSubview(outerStack)
+        // Self-sizing list cells briefly apply UIView-Encapsulated-Layout-Height (often ~52).
+        // Keep the bottom edge one step below required so that temporary height does not fight
+        // fixed metric icon sizes and spam unsatisfiable-constraint logs.
+        let bottom = outerStack.bottomAnchor.constraint(
+            equalTo: contentView.layoutMarginsGuide.bottomAnchor
+        )
+        bottom.priority = UILayoutPriority(999)
         NSLayoutConstraint.activate([
-            avatarView.widthAnchor.constraint(equalToConstant: 34),
-            avatarView.heightAnchor.constraint(equalToConstant: 34),
+            avatarView.widthAnchor.constraint(equalToConstant: 36),
+            avatarView.heightAnchor.constraint(equalToConstant: 36),
             outerStack.leadingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.leadingAnchor),
             outerStack.trailingAnchor.constraint(equalTo: contentView.layoutMarginsGuide.trailingAnchor),
             outerStack.topAnchor.constraint(equalTo: contentView.layoutMarginsGuide.topAnchor),
-            outerStack.bottomAnchor.constraint(equalTo: contentView.layoutMarginsGuide.bottomAnchor),
+            bottom,
         ])
     }
 
@@ -1159,7 +1280,7 @@ final class FireTopicListAvatarView: UIView {
         monogramLabel.text = monogramForUsername(username: username.isEmpty ? "?" : username)
         let avatarURL = fireAvatarURL(
             avatarTemplate: avatarTemplate,
-            size: 34,
+            size: 36,
             scale: UIScreen.main.scale,
             baseURLString: baseURLString
         )
@@ -1192,12 +1313,17 @@ final class FireTopicListAvatarView: UIView {
         imageView.alpha = 1
     }
 
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        // Stay circular at every call-site size (home 36 / profile header 56).
+        layer.cornerRadius = min(bounds.width, bounds.height) / 2
+    }
+
     private func configureSubviews() {
         clipsToBounds = true
-        layer.cornerRadius = 17
         backgroundColor = FireTopicListPalette.accent
 
-        monogramLabel.font = UIFont.systemFont(ofSize: 12, weight: .bold)
+        monogramLabel.font = UIFont.systemFont(ofSize: 13, weight: .bold)
         monogramLabel.textColor = .white
         monogramLabel.textAlignment = .center
         monogramLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -1222,13 +1348,28 @@ final class FireTopicListAvatarView: UIView {
 }
 
 final class FireTopicListMetricView: UIView {
+    private let kind: FireTopicListMetricKind
     private let imageView = UIImageView()
+    private let accessoryView = UIImageView()
     private let valueLabel = UILabel()
+    private var isPulsing = false
+    private var heartBalloonWorkItems: [DispatchWorkItem] = []
+    private var activeHeartViews: [UIView] = []
 
-    init(systemImage: String) {
+    private static let pulseKey = "fire.metric.surgePulse"
+    /// Finite breaths so surge does not loop forever on a parked row.
+    private static let surgePulseRepeatCount: Float = 3
+    /// Keep balloon bursts rare: only true high-likes, 2 tiny hearts, one shot.
+    private static let heartBalloonCount = 2
+
+    init(kind: FireTopicListMetricKind) {
+        self.kind = kind
         super.init(frame: .zero)
-        imageView.image = UIImage(systemName: systemImage)
+        // Hearts float slightly above the chip; ancestors must not clip either.
+        clipsToBounds = false
+        isUserInteractionEnabled = false
         configureSubviews()
+        apply(value: 0, emphasis: .normal, surgeAccessorySymbol: nil)
     }
 
     @available(*, unavailable)
@@ -1236,34 +1377,389 @@ final class FireTopicListMetricView: UIView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    func configure(value: UInt32) {
+    func prepareForReuse() {
+        stopPulse()
+        cancelHeartBalloons()
+        accessoryView.isHidden = true
+        accessoryView.image = nil
+        apply(value: 0, emphasis: .normal, surgeAccessorySymbol: nil)
+    }
+
+    /// Updates static metric chrome. Micro-animations are opt-in via
+    /// `playSurgePulse()` / `playHeartBalloons(tint:)` after the list settles.
+    func configure(
+        value: UInt32,
+        emphasis: FireTopicListMetricEmphasis,
+        surgeAccessorySymbol: String? = nil,
+        animateEffects: Bool = true
+    ) {
+        apply(value: value, emphasis: emphasis, surgeAccessorySymbol: surgeAccessorySymbol)
+
+        // Legacy path (if any caller still wants immediate play). Prefer the
+        // coordinator-driven APIs from the topic cell.
+        guard animateEffects else { return }
+        if emphasis == .surge {
+            playSurgePulse()
+        }
+        if kind == .likes, emphasis == .high {
+            playHeartBalloons(tint: Self.tint(kind: kind, emphasis: emphasis))
+        }
+    }
+
+    static func tint(kind: FireTopicListMetricKind, emphasis: FireTopicListMetricEmphasis) -> UIColor {
+        style(kind: kind, emphasis: emphasis).tint
+    }
+
+    func playSurgePulse() {
+        guard kind == .views else { return }
+        guard !accessoryView.isHidden else { return }
+        startPulseIfNeeded()
+    }
+
+    func playHeartBalloons(tint: UIColor) {
+        guard kind == .likes else { return }
+        scheduleHeartBalloons(tint: tint)
+    }
+
+    private func apply(
+        value: UInt32,
+        emphasis: FireTopicListMetricEmphasis,
+        surgeAccessorySymbol: String?
+    ) {
+        // Always clear running effects before restyling — scrolling may rebind the cell.
+        stopPulse()
+        cancelHeartBalloons()
+
+        let style = Self.style(kind: kind, emphasis: emphasis)
+        let symbolConfig = UIImage.SymbolConfiguration(pointSize: 11, weight: style.symbolWeight)
+        imageView.image = UIImage(systemName: style.symbol, withConfiguration: symbolConfig)
+        imageView.tintColor = style.tint
+
         valueLabel.text = FireTopicPresentation.compactCount(value)
+        valueLabel.textColor = style.tint
+        valueLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 12, weight: style.fontWeight)
+
+        if emphasis == .surge, let accessory = surgeAccessorySymbol {
+            let accessoryConfig = UIImage.SymbolConfiguration(pointSize: 9, weight: .bold)
+            accessoryView.image = UIImage(systemName: accessory, withConfiguration: accessoryConfig)
+            accessoryView.tintColor = style.accessoryTint
+            accessoryView.isHidden = false
+        } else {
+            accessoryView.isHidden = true
+            accessoryView.image = nil
+        }
+
+        accessibilityLabel = Self.accessibilityLabel(
+            kind: kind,
+            value: value,
+            emphasis: emphasis
+        )
     }
 
     private func configureSubviews() {
-        imageView.tintColor = FireTopicListPalette.tertiaryInk
         imageView.contentMode = .scaleAspectFit
         imageView.setContentHuggingPriority(.required, for: .horizontal)
 
-        valueLabel.font = UIFont.monospacedDigitSystemFont(ofSize: 12, weight: .regular)
-        valueLabel.textColor = FireTopicListPalette.tertiaryInk
-        valueLabel.numberOfLines = 1
+        accessoryView.contentMode = .scaleAspectFit
+        accessoryView.setContentHuggingPriority(.required, for: .horizontal)
+        accessoryView.isHidden = true
 
-        let stack = UIStackView(arrangedSubviews: [imageView, valueLabel])
+        valueLabel.numberOfLines = 1
+        valueLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        let iconStack = UIStackView(arrangedSubviews: [imageView, accessoryView])
+        iconStack.axis = .horizontal
+        iconStack.alignment = .center
+        iconStack.spacing = 1
+        iconStack.clipsToBounds = false
+
+        let stack = UIStackView(arrangedSubviews: [iconStack, valueLabel])
         stack.axis = .horizontal
         stack.alignment = .center
-        stack.spacing = 5
+        stack.spacing = 4
+        stack.clipsToBounds = false
         stack.translatesAutoresizingMaskIntoConstraints = false
 
         addSubview(stack)
+        let imageWidth = imageView.widthAnchor.constraint(equalToConstant: 13)
+        let imageHeight = imageView.heightAnchor.constraint(equalToConstant: 13)
+        let accessoryWidth = accessoryView.widthAnchor.constraint(equalToConstant: 10)
+        let accessoryHeight = accessoryView.heightAnchor.constraint(equalToConstant: 10)
+        // Soften fixed icon sizes so parent self-sizing passes never break required constraints.
+        [imageWidth, imageHeight, accessoryWidth, accessoryHeight].forEach {
+            $0.priority = UILayoutPriority(999)
+        }
         NSLayoutConstraint.activate([
-            imageView.widthAnchor.constraint(equalToConstant: 14),
-            imageView.heightAnchor.constraint(equalToConstant: 14),
+            imageWidth,
+            imageHeight,
+            accessoryWidth,
+            accessoryHeight,
             stack.leadingAnchor.constraint(equalTo: leadingAnchor),
-            stack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
             stack.topAnchor.constraint(equalTo: topAnchor),
             stack.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
+    }
+
+    private func startPulseIfNeeded() {
+        guard !UIAccessibility.isReduceMotionEnabled else {
+            stopPulse()
+            return
+        }
+        guard !isPulsing else { return }
+        isPulsing = true
+
+        // Tiny breathe on the surge badge only — finite, never the whole metric row.
+        let opacity = CABasicAnimation(keyPath: "opacity")
+        opacity.fromValue = 0.55
+        opacity.toValue = 1.0
+        opacity.duration = 1.6
+        opacity.autoreverses = true
+        opacity.repeatCount = Self.surgePulseRepeatCount
+        opacity.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        opacity.isRemovedOnCompletion = false
+        opacity.fillMode = .forwards
+
+        let scale = CABasicAnimation(keyPath: "transform.scale")
+        scale.fromValue = 0.92
+        scale.toValue = 1.08
+        scale.duration = 1.6
+        scale.autoreverses = true
+        scale.repeatCount = Self.surgePulseRepeatCount
+        scale.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+        scale.isRemovedOnCompletion = false
+        scale.fillMode = .forwards
+
+        accessoryView.layer.add(opacity, forKey: Self.pulseKey + ".opacity")
+        accessoryView.layer.add(scale, forKey: Self.pulseKey + ".scale")
+
+        let total = TimeInterval(Self.surgePulseRepeatCount) * 1.6 * 2
+        DispatchQueue.main.asyncAfter(deadline: .now() + total) { [weak self] in
+            self?.stopPulse()
+        }
+    }
+
+    private func stopPulse() {
+        isPulsing = false
+        accessoryView.layer.removeAnimation(forKey: Self.pulseKey + ".opacity")
+        accessoryView.layer.removeAnimation(forKey: Self.pulseKey + ".scale")
+        accessoryView.layer.opacity = 1
+        accessoryView.layer.transform = CATransform3DIdentity
+    }
+
+    private func scheduleHeartBalloons(tint: UIColor) {
+        guard kind == .likes else { return }
+        guard !UIAccessibility.isReduceMotionEnabled else { return }
+        cancelHeartBalloons()
+
+        // Defer until after Auto Layout so the heart originates on the icon.
+        let start = DispatchWorkItem { [weak self] in
+            self?.emitHeartBalloons(tint: tint)
+        }
+        heartBalloonWorkItems.append(start)
+        DispatchQueue.main.async(execute: start)
+    }
+
+    private func emitHeartBalloons(tint: UIColor) {
+        // Stagger two micro hearts so it reads as a soft bubble, not a particle storm.
+        for index in 0..<Self.heartBalloonCount {
+            let work = DispatchWorkItem { [weak self] in
+                self?.spawnHeartBalloon(index: index, tint: tint)
+            }
+            heartBalloonWorkItems.append(work)
+            DispatchQueue.main.asyncAfter(
+                deadline: .now() + 0.08 + Double(index) * 0.28,
+                execute: work
+            )
+        }
+    }
+
+    private func spawnHeartBalloon(index: Int, tint: UIColor) {
+        guard window != nil, bounds.width > 0 else { return }
+
+        let size: CGFloat = index == 0 ? 8 : 7
+        let config = UIImage.SymbolConfiguration(pointSize: size - 1, weight: .bold)
+        let heart = UIImageView(image: UIImage(systemName: "heart.fill", withConfiguration: config))
+        heart.tintColor = tint.withAlphaComponent(0.82)
+        heart.contentMode = .scaleAspectFit
+        heart.isUserInteractionEnabled = false
+        heart.alpha = 0
+
+        let iconFrame = imageView.convert(imageView.bounds, to: self)
+        // Slight horizontal scatter so the two hearts do not stack.
+        let driftX: CGFloat = index == 0 ? -3 : 5
+        heart.frame = CGRect(
+            x: iconFrame.midX - size / 2 + driftX * 0.2,
+            y: iconFrame.midY - size / 2,
+            width: size,
+            height: size
+        )
+        addSubview(heart)
+        activeHeartViews.append(heart)
+
+        let rise: CGFloat = -(16 + CGFloat(index) * 5)
+        let endDriftX: CGFloat = driftX
+
+        // Phase 1: soft pop + lift. Phase 2: fade while still drifting up.
+        UIView.animate(
+            withDuration: 0.55,
+            delay: 0,
+            options: [.curveEaseOut, .allowUserInteraction, .beginFromCurrentState]
+        ) {
+            heart.alpha = 0.88
+            heart.transform = CGAffineTransform(translationX: endDriftX * 0.45, y: rise * 0.55)
+                .scaledBy(x: 1.08, y: 1.08)
+        } completion: { [weak self, weak heart] _ in
+            guard let heart else { return }
+            UIView.animate(
+                withDuration: 0.75,
+                delay: 0.02,
+                options: [.curveEaseIn, .allowUserInteraction, .beginFromCurrentState]
+            ) {
+                heart.alpha = 0
+                heart.transform = CGAffineTransform(translationX: endDriftX, y: rise)
+                    .scaledBy(x: 0.72, y: 0.72)
+            } completion: { [weak self, weak heart] _ in
+                heart?.removeFromSuperview()
+                if let heart {
+                    self?.activeHeartViews.removeAll { $0 === heart }
+                }
+            }
+        }
+    }
+
+    private func cancelHeartBalloons() {
+        heartBalloonWorkItems.forEach { $0.cancel() }
+        heartBalloonWorkItems.removeAll()
+        activeHeartViews.forEach { heart in
+            heart.layer.removeAllAnimations()
+            heart.removeFromSuperview()
+        }
+        activeHeartViews.removeAll()
+    }
+
+    fileprivate struct Style {
+        let symbol: String
+        let symbolWeight: UIImage.SymbolWeight
+        let tint: UIColor
+        let fontWeight: UIFont.Weight
+        let accessoryTint: UIColor
+    }
+
+    fileprivate static func style(
+        kind: FireTopicListMetricKind,
+        emphasis: FireTopicListMetricEmphasis
+    ) -> Style {
+        let muted = FireTheme.uiTertiaryInk
+        let soft = FireTheme.uiSubtleInk
+
+        switch (kind, emphasis) {
+        case (.replies, .normal):
+            return Style(
+                symbol: "bubble.left",
+                symbolWeight: .regular,
+                tint: muted,
+                fontWeight: .regular,
+                accessoryTint: muted
+            )
+        case (.replies, .notable):
+            return Style(
+                symbol: "bubble.left.fill",
+                symbolWeight: .medium,
+                tint: soft,
+                fontWeight: .medium,
+                accessoryTint: soft
+            )
+        case (.replies, .high), (.replies, .surge):
+            return Style(
+                symbol: "bubble.left.fill",
+                symbolWeight: .semibold,
+                tint: FireTheme.uiInfo,
+                fontWeight: .semibold,
+                accessoryTint: FireTheme.uiInfo
+            )
+
+        case (.views, .normal):
+            return Style(
+                symbol: "chart.bar",
+                symbolWeight: .regular,
+                tint: muted,
+                fontWeight: .regular,
+                accessoryTint: muted
+            )
+        case (.views, .notable):
+            return Style(
+                symbol: "chart.bar.fill",
+                symbolWeight: .medium,
+                tint: soft,
+                fontWeight: .medium,
+                accessoryTint: soft
+            )
+        case (.views, .high):
+            return Style(
+                symbol: "chart.bar.fill",
+                symbolWeight: .semibold,
+                tint: UIColor.systemTeal,
+                fontWeight: .semibold,
+                accessoryTint: UIColor.systemTeal
+            )
+        case (.views, .surge):
+            return Style(
+                symbol: "chart.bar.fill",
+                symbolWeight: .semibold,
+                tint: FireTheme.uiWarning,
+                fontWeight: .semibold,
+                accessoryTint: FireTheme.uiAccent
+            )
+
+        case (.likes, .normal):
+            return Style(
+                symbol: "heart",
+                symbolWeight: .regular,
+                tint: muted,
+                fontWeight: .regular,
+                accessoryTint: muted
+            )
+        case (.likes, .notable):
+            return Style(
+                symbol: "heart.fill",
+                symbolWeight: .medium,
+                tint: UIColor.systemPink.withAlphaComponent(0.85),
+                fontWeight: .medium,
+                accessoryTint: UIColor.systemPink
+            )
+        case (.likes, .high), (.likes, .surge):
+            return Style(
+                symbol: "heart.fill",
+                symbolWeight: .semibold,
+                tint: FireTheme.uiAccent,
+                fontWeight: .semibold,
+                accessoryTint: FireTheme.uiAccent
+            )
+        }
+    }
+
+    private static func accessibilityLabel(
+        kind: FireTopicListMetricKind,
+        value: UInt32,
+        emphasis: FireTopicListMetricEmphasis
+    ) -> String {
+        let base: String
+        switch kind {
+        case .replies: base = "\(value) 回复"
+        case .views: base = "\(value) 浏览"
+        case .likes: base = "\(value) 赞"
+        }
+        switch emphasis {
+        case .normal:
+            return base
+        case .notable:
+            return base + "，热度偏高"
+        case .high:
+            return base + "，热门"
+        case .surge:
+            return base + "，浏览激增"
+        }
     }
 }
 

--- a/native/ios-app/App/Views/Composer/FireComposerView.swift
+++ b/native/ios-app/App/Views/Composer/FireComposerView.swift
@@ -1041,6 +1041,7 @@ final class FireComposerViewController: UIViewController {
         categoryButton.contentHorizontalAlignment = .leading
         categoryButton.configuration = makePlainButtonConfiguration(title: "选择分类", systemImage: "folder")
         categoryButton.addTarget(self, action: #selector(categoryButtonTapped), for: .touchUpInside)
+        categoryButton.fireBindPressBounce(.compact)
 
         requirementsStack.axis = .vertical
         requirementsStack.spacing = 8
@@ -1093,8 +1094,10 @@ final class FireComposerViewController: UIViewController {
 
         imageButton.configuration = makePlainButtonConfiguration(title: "图片", systemImage: "photo")
         imageButton.addTarget(self, action: #selector(imageButtonTapped), for: .touchUpInside)
+        imageButton.fireBindPressBounce(.compact)
         previewButton.configuration = makePlainButtonConfiguration(title: "预览", systemImage: "eye")
         previewButton.addTarget(self, action: #selector(previewButtonTapped), for: .touchUpInside)
+        previewButton.fireBindPressBounce(.compact)
 
         countLabel.font = .preferredFont(forTextStyle: .caption1)
         countLabel.adjustsFontForContentSizeCategory = true
@@ -1133,6 +1136,7 @@ final class FireComposerViewController: UIViewController {
             button.accessibilityLabel = action.accessibilityLabel
             button.configuration = makeToolbarButtonConfiguration(for: action)
             button.addTarget(self, action: #selector(markdownButtonTapped(_:)), for: .touchUpInside)
+            button.fireBindPressBounce(.compact)
             markdownToolbarStack.addArrangedSubview(button)
             NSLayoutConstraint.activate([
                 button.widthAnchor.constraint(equalToConstant: 36),
@@ -1182,6 +1186,7 @@ final class FireComposerViewController: UIViewController {
         clearDraftButton.setTitle("清除草稿", for: .normal)
         clearDraftButton.titleLabel?.font = .preferredFont(forTextStyle: .subheadline)
         clearDraftButton.addTarget(self, action: #selector(clearDraftButtonTapped), for: .touchUpInside)
+        clearDraftButton.fireBindPressBounce(.compact)
 
         submitButtonConfiguration.cornerStyle = .capsule
         submitButtonConfiguration.baseBackgroundColor = FireTopicListPalette.accent
@@ -1189,6 +1194,7 @@ final class FireComposerViewController: UIViewController {
         submitButtonConfiguration.contentInsets = NSDirectionalEdgeInsets(top: 12, leading: 18, bottom: 12, trailing: 18)
         submitButton.configuration = submitButtonConfiguration
         submitButton.addTarget(self, action: #selector(submitButtonTapped), for: .touchUpInside)
+        submitButton.fireBindPressBounce(.button)
 
         let buttonRow = UIStackView(arrangedSubviews: [clearDraftButton, UIView(), submitButton])
         buttonRow.axis = .horizontal
@@ -2310,6 +2316,7 @@ final class FireComposerViewController: UIViewController {
         let button = UIButton(type: .system)
         button.configuration = configuration
         button.titleLabel?.font = .preferredFont(forTextStyle: .caption1)
+        button.fireBindPressBounce(.compact)
         return button
     }
 
@@ -2333,6 +2340,7 @@ final class FireComposerViewController: UIViewController {
         let button = UIButton(type: .system)
         button.configuration = configuration
         button.contentHorizontalAlignment = .leading
+        button.fireBindPressBounce(.compact)
         return button
     }
 

--- a/native/ios-app/App/Views/Home/FireFilteredTopicListViewController.swift
+++ b/native/ios-app/App/Views/Home/FireFilteredTopicListViewController.swift
@@ -203,6 +203,9 @@ final class FireFilteredTopicListViewController: UIViewController {
             onPrefetchItems: { [reference] items in
                 reference.controller?.handleVisibleItemsChanged(items)
             },
+            onScrollActivityChanged: { scrolling in
+                FireTopicListMetricEffectCoordinator.shared.setScrolling(scrolling)
+            },
             onRefresh: { [listViewModel] in
                 await listViewModel.refresh()
             },
@@ -598,6 +601,7 @@ private final class FireFilteredFeedSelectorCell: UICollectionViewCell {
                 FireMotionHaptics.selection()
                 onSelectKind(kind)
             }, for: .touchUpInside)
+            button.fireBindPressBounce(.compact)
             stackView.addArrangedSubview(button)
         }
     }

--- a/native/ios-app/App/Views/Home/FireHomeView.swift
+++ b/native/ios-app/App/Views/Home/FireHomeView.swift
@@ -239,6 +239,9 @@ final class FireHomeViewController: UIViewController {
             onScrollMetricsChanged: { [controllerReference] metrics in
                 controllerReference.controller?.handleTopicListScrollMetricsChange(metrics)
             },
+            onScrollActivityChanged: { scrolling in
+                FireTopicListMetricEffectCoordinator.shared.setScrolling(scrolling)
+            },
             onRefresh: { [homeFeedStore] in
                 await homeFeedStore.refreshTopicsAsync()
             },
@@ -1449,6 +1452,7 @@ private extension UICollectionViewCell {
         button.titleLabel?.font = UIFont.preferredFont(forTextStyle: .caption1).withHomeWeight(.medium)
         button.titleLabel?.adjustsFontForContentSizeCategory = true
         button.addAction(UIAction { _ in action() }, for: .touchUpInside)
+        button.fireBindPressBounce(.compact)
         button.setContentCompressionResistancePriority(.required, for: .horizontal)
         button.setContentHuggingPriority(.required, for: .horizontal)
         return button

--- a/native/ios-app/App/Views/Other/FireReadHistoryViewController.swift
+++ b/native/ios-app/App/Views/Other/FireReadHistoryViewController.swift
@@ -139,6 +139,9 @@ final class FireReadHistoryViewController: UIViewController {
             onPrefetchItems: { [controllerReference] items in
                 controllerReference.controller?.loadMoreIfNeeded(from: items)
             },
+            onScrollActivityChanged: { scrolling in
+                FireTopicListMetricEffectCoordinator.shared.setScrolling(scrolling)
+            },
             onRefresh: { [historyViewModel] in
                 await historyViewModel.refresh()
             },

--- a/native/ios-app/App/Views/Profile/FireSettingsViewController.swift
+++ b/native/ios-app/App/Views/Profile/FireSettingsViewController.swift
@@ -68,8 +68,8 @@ final class FireSettingsViewController: UIViewController {
         contentStack.alignment = .fill
         scrollView.addSubview(contentStack)
         contentStack.snp.makeConstraints { make in
-            make.top.equalTo(scrollView.contentLayoutGuide.snp.top).offset(8)
-            make.bottom.equalTo(scrollView.contentLayoutGuide.snp.bottom).offset(-28)
+            make.top.equalTo(scrollView.contentLayoutGuide.snp.top).offset(4)
+            make.bottom.equalTo(scrollView.contentLayoutGuide.snp.bottom).offset(-24)
             make.leading.equalTo(scrollView.frameLayoutGuide.snp.leading).offset(FireTheme.pageHorizontalInset)
             make.trailing.equalTo(scrollView.frameLayoutGuide.snp.trailing).offset(-FireTheme.pageHorizontalInset)
             make.width.equalTo(scrollView.frameLayoutGuide.snp.width).offset(-FireTheme.pageHorizontalInset * 2)
@@ -116,7 +116,8 @@ final class FireSettingsViewController: UIViewController {
                     systemImage: "wrench.and.screwdriver.fill",
                     title: "开发者工具",
                     subtitle: "日志、网络与诊断导出",
-                    showsChevron: true
+                    showsChevron: true,
+                    iconWellColor: UIColor.systemIndigo
                 ),
                 { [weak self] in self?.openDeveloperTools() }
             ),
@@ -131,7 +132,8 @@ final class FireSettingsViewController: UIViewController {
                     .init(
                         systemImage: "rectangle.portrait.and.arrow.right",
                         title: appViewModel.isLoggingOut ? "退出中…" : "退出登录",
-                        showsChevron: false
+                        showsChevron: false,
+                        iconWellColor: FireTheme.uiError
                     ),
                     appViewModel.isLoggingOut ? nil : { [weak self] in self?.confirmLogout() }
                 ),

--- a/native/ios-app/App/Views/Search/FireSearchView.swift
+++ b/native/ios-app/App/Views/Search/FireSearchView.swift
@@ -200,6 +200,9 @@ final class FireSearchViewController: UIViewController {
             onPrefetchItems: { [controllerReference] items in
                 controllerReference.controller?.handlePrefetchItems(items)
             },
+            onScrollActivityChanged: { scrolling in
+                FireTopicListMetricEffectCoordinator.shared.setScrolling(scrolling)
+            },
             contextMenuConfigurationProvider: { [controllerReference] item in
                 controllerReference.controller?.contextMenuConfiguration(for: item)
             },

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		51D27C6354C43E1E83FEA3FB /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 6958AA64094FA7BB21B5FC36 /* PrivacyInfo.xcprivacy */; };
 		522CA82334EAC05D23624720 /* FireTopicDetailModalViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8BC7B03BAACE572DDB87E810 /* FireTopicDetailModalViews.swift */; };
 		52CF002705A0E18AAB2E9E62 /* FireTopicDetailRootNode.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEC29D6B75CD01B9ADD53F1A /* FireTopicDetailRootNode.swift */; };
+		554CC7F69039A6FD88B5C84E /* FireTopicListMetricEffectCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E3DCC9617583661AAF64366 /* FireTopicListMetricEffectCoordinator.swift */; };
 		56EE60CC67C1D8E444227552 /* FireTopicPresentationTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41AECD88340113D3FD81D59B /* FireTopicPresentationTestSupport.swift */; };
 		5A95F9C29909968BF4B17AD7 /* FireAuthCookieKeychainStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C313FFDD8D569FA6D9B1C0E0 /* FireAuthCookieKeychainStore.swift */; };
 		5B9E9ED30FE304D16FAD4694 /* FireProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3803B8939D9AF618CA74A6 /* FireProfileView.swift */; };
@@ -370,6 +371,7 @@
 		8A1B0239607F0ABAEA1ABCE0 /* FirePostLayoutManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePostLayoutManager.swift; sourceTree = "<group>"; };
 		8BC7B03BAACE572DDB87E810 /* FireTopicDetailModalViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailModalViews.swift; sourceTree = "<group>"; };
 		8D0D5E6727E0D21855DDEA2F /* FirePaginatedStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirePaginatedStore.swift; sourceTree = "<group>"; };
+		8E3DCC9617583661AAF64366 /* FireTopicListMetricEffectCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicListMetricEffectCoordinator.swift; sourceTree = "<group>"; };
 		9189433D7C9260885742A5BA /* FireTopicPresentationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicPresentationTests.swift; sourceTree = "<group>"; };
 		925CD02F862E958CC79BC60A /* FireTopicDetailSharedModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailSharedModels.swift; sourceTree = "<group>"; };
 		9267FBC4BA4FD365E6F4E371 /* FireTopicDetailStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailStore.swift; sourceTree = "<group>"; };
@@ -1042,6 +1044,7 @@
 				4E41FA85B0FAA4DAF83AA747 /* FireSceneDelegate.swift */,
 				0182FF50BA5178478278FB01 /* FireShimmerModifier.swift */,
 				E0AA3F1257384BF109634D21 /* FireTheme.swift */,
+				8E3DCC9617583661AAF64366 /* FireTopicListMetricEffectCoordinator.swift */,
 				3FC109FBAA1787EF49336258 /* SessionState+Helpers.swift */,
 				3C38064D8A60C229546F1FCF /* UIKit */,
 			);
@@ -1416,6 +1419,7 @@
 				B80E44034285312AABCD80A0 /* FireTopicImagePipeline.swift in Sources */,
 				69FCB7426098CEDD059BB09A /* FireTopicInteractionService.swift in Sources */,
 				352CD58A1F4D83DC9BE95178 /* FireTopicListMessageBusRefresh.swift in Sources */,
+				554CC7F69039A6FD88B5C84E /* FireTopicListMetricEffectCoordinator.swift in Sources */,
 				83C439B40A75418E1406961F /* FireTopicPresentation.swift in Sources */,
 				2E24DA3BD96C8B64D78FFA5D /* FireTopicQuickReplyBarNode.swift in Sources */,
 				C6D4775AD6FB33FB87BCC6B4 /* FireTopicRoutePresenter.swift in Sources */,

--- a/native/ios-app/Tests/Unit/FirePostCellLayoutCalculatorTests.swift
+++ b/native/ios-app/Tests/Unit/FirePostCellLayoutCalculatorTests.swift
@@ -1250,4 +1250,39 @@ final class FirePostCellLayoutCalculatorTests: XCTestCase {
             onSwipeReply: { _ in }
         )
     }
+
+
+    func testCollapsedTextNormalizerCollapsesBlankLines() {
+        let source = NSMutableAttributedString(string: "Hello\n\n\nWorld\n\nFire")
+        let normalized = FirePostCollapsedTextNormalizer.attributedTextForCollapsedDisplay(source)
+        XCTAssertEqual(normalized.string, "Hello\nWorld\nFire")
+        XCTAssertFalse(normalized.string.contains("\n\n"))
+    }
+
+    func testCollapsedTextNormalizerPreservesSingleNewlines() {
+        let source = NSAttributedString(string: "A\nB\nC")
+        let normalized = FirePostCollapsedTextNormalizer.attributedTextForCollapsedDisplay(source)
+        XCTAssertEqual(normalized.string, "A\nB\nC")
+    }
+
+    func testMeasureCollapsedRichTextHeightIsAtMostFourLines() {
+        let font = UIFont.preferredFont(forTextStyle: .subheadline)
+        let paragraphs = (0..<12).map { "段落\($0) 内容比较长用来换行" }.joined(separator: "\n\n")
+        let attributed = NSAttributedString(string: paragraphs, attributes: [.font: font])
+        let full = FirePostCellLayoutCalculator.measureRichTextHeight(
+            attributedText: attributed,
+            containerWidth: 300,
+            contentSizeCategory: .large
+        )
+        let collapsed = FirePostCellLayoutCalculator.measureCollapsedRichTextHeight(
+            attributedText: attributed,
+            containerWidth: 300,
+            truncationToken: FirePostCollapsedTextNormalizer.expansionTruncationToken()
+        )
+        XCTAssertNotNil(full)
+        XCTAssertNotNil(collapsed)
+        XCTAssertLessThan(collapsed!, full!)
+        let fourLineCap = FirePostCellLayoutCalculator.collapsedTextHeight(contentSizeCategory: .large) * 1.8
+        XCTAssertLessThanOrEqual(collapsed!, fourLineCap)
+    }
 }

--- a/native/ios-app/Tests/Unit/FireTopicPresentationTests.swift
+++ b/native/ios-app/Tests/Unit/FireTopicPresentationTests.swift
@@ -1328,4 +1328,109 @@ final class FireTopicPresentationTests: XCTestCase {
         )
     }
 
+
+
+    // MARK: - List metric ranking
+
+    func testListMetricEmphasisStaysQuietForOrdinaryValues() {
+        XCTAssertEqual(
+            FireTopicListMetricRanking.emphasis(
+                kind: .replies,
+                value: 3,
+                createdTimestampUnixMs: nil
+            ),
+            .normal
+        )
+        XCTAssertEqual(
+            FireTopicListMetricRanking.emphasis(
+                kind: .views,
+                value: 120,
+                createdTimestampUnixMs: nil
+            ),
+            .normal
+        )
+        XCTAssertEqual(
+            FireTopicListMetricRanking.emphasis(
+                kind: .likes,
+                value: 2,
+                createdTimestampUnixMs: nil
+            ),
+            .normal
+        )
+    }
+
+    func testListMetricEmphasisLiftsHighAbsoluteValues() {
+        XCTAssertEqual(
+            FireTopicListMetricRanking.emphasis(
+                kind: .replies,
+                value: FireTopicListMetricRanking.repliesHigh,
+                createdTimestampUnixMs: nil
+            ),
+            .high
+        )
+        XCTAssertEqual(
+            FireTopicListMetricRanking.emphasis(
+                kind: .likes,
+                value: FireTopicListMetricRanking.likesHigh,
+                createdTimestampUnixMs: nil
+            ),
+            .high
+        )
+        XCTAssertEqual(
+            FireTopicListMetricRanking.emphasis(
+                kind: .views,
+                value: FireTopicListMetricRanking.viewsHigh,
+                createdTimestampUnixMs: nil
+            ),
+            .high
+        )
+    }
+
+    func testViewSurgeUsesAgeAwareVelocity() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        // 2 hours old, 400 views → ~200/h, above surge bar.
+        let freshMs = UInt64((now.timeIntervalSince1970 - 2 * 3_600) * 1_000)
+        XCTAssertEqual(
+            FireTopicListMetricRanking.emphasis(
+                kind: .views,
+                value: 400,
+                createdTimestampUnixMs: freshMs,
+                now: now
+            ),
+            .surge
+        )
+        XCTAssertEqual(
+            FireTopicListMetricRanking.surgeAccessorySymbol(
+                createdTimestampUnixMs: freshMs,
+                now: now
+            ),
+            "rocket.fill"
+        )
+
+        // Same views but days old → not a surge.
+        let oldMs = UInt64((now.timeIntervalSince1970 - 72 * 3_600) * 1_000)
+        XCTAssertNotEqual(
+            FireTopicListMetricRanking.emphasis(
+                kind: .views,
+                value: 400,
+                createdTimestampUnixMs: oldMs,
+                now: now
+            ),
+            .surge
+        )
+    }
+
+
+    func testMetricEffectCoordinatorClaimsOncePerTopic() async {
+        await MainActor.run {
+            let coordinator = FireTopicListMetricEffectCoordinator.shared
+            coordinator.resetSessionStateForTesting()
+            XCTAssertTrue(coordinator.claim(.heartBalloon, topicID: 42))
+            XCTAssertFalse(coordinator.claim(.heartBalloon, topicID: 42))
+            XCTAssertTrue(coordinator.claim(.viewSurgePulse, topicID: 42))
+            XCTAssertTrue(coordinator.claim(.heartBalloon, topicID: 99))
+            coordinator.resetSessionStateForTesting()
+        }
+    }
+
 }

--- a/rust/crates/fire-models/src/rich_text.rs
+++ b/rust/crates/fire-models/src/rich_text.rs
@@ -158,3 +158,12 @@ pub struct RenderDocument {
     pub plain_text: String,
     pub image_attachments: Vec<RenderImageAttachment>,
 }
+
+/// Host-facing display plan: interleaved rich subdocuments and standalone images.
+/// Built in Rust so iOS/Android do not re-walk cooked trees for segment splits.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum RenderDisplaySegment {
+    /// Mini `RenderDocument` with a document root + one continuous non-image subtree.
+    Rich(RenderDocument),
+    Image(RenderImageAttachment),
+}

--- a/rust/crates/fire-rich-text/src/lib.rs
+++ b/rust/crates/fire-rich-text/src/lib.rs
@@ -268,9 +268,7 @@ fn subtree_document(block: &RenderBlock, tree: &DisplayBlockTree<'_>) -> RenderD
                     out.push_str(text);
                 }
                 RenderBlockKind::Emoji { fallback_text, .. } => out.push_str(fallback_text),
-                RenderBlockKind::Image {
-                    alt: Some(alt), ..
-                } => out.push_str(alt),
+                RenderBlockKind::Image { alt: Some(alt), .. } => out.push_str(alt),
                 _ => {}
             }
             for child in tree.children_of(node) {

--- a/rust/crates/fire-rich-text/src/lib.rs
+++ b/rust/crates/fire-rich-text/src/lib.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use fire_models::{
     CookedHtmlDocument, CookedHtmlNode, CookedHtmlNodeKind, RenderBlock, RenderBlockKind,
-    RenderDocument, RenderImageAttachment,
+    RenderDisplaySegment, RenderDocument, RenderImageAttachment,
 };
 use url::Url;
 
@@ -41,6 +41,344 @@ pub fn plain_text_from_render_document(document: &RenderDocument) -> String {
 
 pub fn collect_images(document: &RenderDocument) -> Vec<RenderImageAttachment> {
     document.image_attachments.clone()
+}
+
+/// Split a render document into host layout segments (rich runs vs block images).
+///
+/// Mirrors the former Swift `rawRenderSegments` walk so Texture/Android can lay out
+/// inline images as separate cells without re-implementing cooked tree logic.
+pub fn display_segments(document: &RenderDocument) -> Vec<RenderDisplaySegment> {
+    if document.blocks.is_empty() {
+        return Vec::new();
+    }
+
+    let tree = DisplayBlockTree::new(&document.blocks);
+    let Some(root) = tree.root else {
+        return Vec::new();
+    };
+
+    let mut attachment_index = 0_usize;
+    let mut segments = Vec::new();
+    for child in tree.children_of(root) {
+        append_display_segments(child, &tree, document, &mut attachment_index, &mut segments);
+    }
+
+    // Preserve trailing attachments that never appeared as block images.
+    while attachment_index < document.image_attachments.len() {
+        segments.push(RenderDisplaySegment::Image(
+            document.image_attachments[attachment_index].clone(),
+        ));
+        attachment_index += 1;
+    }
+
+    segments
+}
+
+struct DisplayBlockTree<'a> {
+    root: Option<&'a RenderBlock>,
+    children_by_parent: BTreeMap<u32, Vec<&'a RenderBlock>>,
+}
+
+impl<'a> DisplayBlockTree<'a> {
+    fn new(blocks: &'a [RenderBlock]) -> Self {
+        let mut children_by_parent: BTreeMap<u32, Vec<&RenderBlock>> = BTreeMap::new();
+        let mut root = None;
+        for block in blocks {
+            match block.parent_id {
+                Some(parent_id) => {
+                    children_by_parent.entry(parent_id).or_default().push(block);
+                }
+                None if root.is_none() => root = Some(block),
+                None => {}
+            }
+        }
+        Self {
+            root,
+            children_by_parent,
+        }
+    }
+
+    fn children_of(&self, block: &RenderBlock) -> &[&RenderBlock] {
+        self.children_by_parent
+            .get(&block.id)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
+    }
+}
+
+fn append_display_segments(
+    block: &RenderBlock,
+    tree: &DisplayBlockTree<'_>,
+    document: &RenderDocument,
+    attachment_index: &mut usize,
+    segments: &mut Vec<RenderDisplaySegment>,
+) {
+    match &block.kind {
+        RenderBlockKind::Image {
+            url,
+            alt,
+            width,
+            height,
+        } => {
+            let image = take_image_attachment(
+                document,
+                attachment_index,
+                url,
+                alt.as_deref(),
+                *width,
+                *height,
+            );
+            push_image_segment(image, segments);
+        }
+        RenderBlockKind::Paragraph
+        | RenderBlockKind::Heading { .. }
+        | RenderBlockKind::Blockquote
+        | RenderBlockKind::Quote { .. }
+        | RenderBlockKind::List { .. }
+        | RenderBlockKind::ListItem
+        | RenderBlockKind::Details
+        | RenderBlockKind::Spoiler => {
+            let child_segments = collect_child_segments(block, tree, document, attachment_index);
+            for child in child_segments {
+                match child {
+                    RenderDisplaySegment::Rich(subdoc) => {
+                        // Re-wrap child rich content under this container kind.
+                        let wrapped = wrap_rich_segment(block, subdoc);
+                        push_rich_segment(wrapped, segments);
+                    }
+                    RenderDisplaySegment::Image(image) => push_image_segment(image, segments),
+                }
+            }
+        }
+        _ => {
+            // Leaf-ish / continuous rich content — export the subtree as one rich mini-doc.
+            let mini = subtree_document(block, tree);
+            push_rich_segment(mini, segments);
+        }
+    }
+}
+
+fn collect_child_segments(
+    block: &RenderBlock,
+    tree: &DisplayBlockTree<'_>,
+    document: &RenderDocument,
+    attachment_index: &mut usize,
+) -> Vec<RenderDisplaySegment> {
+    let mut child_segments = Vec::new();
+    for child in tree.children_of(block) {
+        append_display_segments(child, tree, document, attachment_index, &mut child_segments);
+    }
+    child_segments
+}
+
+fn wrap_rich_segment(container: &RenderBlock, child_doc: RenderDocument) -> RenderDocument {
+    // child_doc is Document -> content...; lift content under a clone of container kind.
+    let mut blocks = Vec::with_capacity(child_doc.blocks.len() + 2);
+    blocks.push(RenderBlock {
+        id: 0,
+        parent_id: None,
+        depth: 0,
+        kind: RenderBlockKind::Document,
+    });
+    blocks.push(RenderBlock {
+        id: 1,
+        parent_id: Some(0),
+        depth: 1,
+        kind: container.kind.clone(),
+    });
+
+    // Remap child_doc blocks (skip its document root) under id=1.
+    let mut next_id = 2_u32;
+    let mut id_map: BTreeMap<u32, u32> = BTreeMap::new();
+    for block in child_doc.blocks.iter().filter(|b| b.parent_id.is_some()) {
+        let new_id = next_id;
+        next_id += 1;
+        id_map.insert(block.id, new_id);
+        let parent = block
+            .parent_id
+            .and_then(|old| id_map.get(&old).copied())
+            .unwrap_or(1);
+        blocks.push(RenderBlock {
+            id: new_id,
+            parent_id: Some(parent),
+            depth: block.depth.saturating_add(1),
+            kind: block.kind.clone(),
+        });
+    }
+
+    RenderDocument {
+        blocks,
+        plain_text: child_doc.plain_text,
+        image_attachments: child_doc.image_attachments,
+    }
+}
+
+fn subtree_document(block: &RenderBlock, tree: &DisplayBlockTree<'_>) -> RenderDocument {
+    let mut blocks = Vec::new();
+    blocks.push(RenderBlock {
+        id: 0,
+        parent_id: None,
+        depth: 0,
+        kind: RenderBlockKind::Document,
+    });
+
+    fn visit(
+        node: &RenderBlock,
+        parent_id: u32,
+        depth: u32,
+        next_id: &mut u32,
+        tree: &DisplayBlockTree<'_>,
+        blocks: &mut Vec<RenderBlock>,
+    ) {
+        let id = *next_id;
+        *next_id += 1;
+        blocks.push(RenderBlock {
+            id,
+            parent_id: Some(parent_id),
+            depth,
+            kind: node.kind.clone(),
+        });
+        for child in tree.children_of(node) {
+            visit(child, id, depth + 1, next_id, tree, blocks);
+        }
+    }
+
+    let mut next_id = 1_u32;
+    visit(block, 0, 1, &mut next_id, tree, &mut blocks);
+
+    let plain_text = {
+        // Lightweight plain extraction from the copied tree kinds.
+        let mut out = String::new();
+        fn walk(node: &RenderBlock, tree: &DisplayBlockTree<'_>, out: &mut String) {
+            match &node.kind {
+                RenderBlockKind::Text { content }
+                | RenderBlockKind::InlineCode { code: content }
+                | RenderBlockKind::CodeBlock { code: content, .. }
+                | RenderBlockKind::Table { text: content } => out.push_str(content),
+                RenderBlockKind::Mention { username } => {
+                    out.push('@');
+                    out.push_str(username);
+                }
+                RenderBlockKind::MentionGroup { name, .. } => {
+                    out.push('@');
+                    out.push_str(name);
+                }
+                RenderBlockKind::Hashtag { text, .. } => {
+                    out.push('#');
+                    out.push_str(text);
+                }
+                RenderBlockKind::Emoji { fallback_text, .. } => out.push_str(fallback_text),
+                RenderBlockKind::Image {
+                    alt: Some(alt), ..
+                } => out.push_str(alt),
+                _ => {}
+            }
+            for child in tree.children_of(node) {
+                walk(child, tree, out);
+            }
+        }
+        walk(block, tree, &mut out);
+        out
+    };
+
+    RenderDocument {
+        blocks,
+        plain_text,
+        image_attachments: Vec::new(),
+    }
+}
+
+fn take_image_attachment(
+    document: &RenderDocument,
+    attachment_index: &mut usize,
+    url: &str,
+    alt: Option<&str>,
+    width: Option<u32>,
+    height: Option<u32>,
+) -> RenderImageAttachment {
+    if *attachment_index < document.image_attachments.len() {
+        let image = document.image_attachments[*attachment_index].clone();
+        *attachment_index += 1;
+        return image;
+    }
+    *attachment_index += 1;
+    RenderImageAttachment {
+        url: url.to_string(),
+        alt_text: alt.map(str::to_string),
+        width,
+        height,
+    }
+}
+
+fn push_image_segment(image: RenderImageAttachment, segments: &mut Vec<RenderDisplaySegment>) {
+    segments.push(RenderDisplaySegment::Image(image));
+}
+
+fn push_rich_segment(document: RenderDocument, segments: &mut Vec<RenderDisplaySegment>) {
+    if document.blocks.len() <= 1 && document.plain_text.trim().is_empty() {
+        return;
+    }
+    if let Some(RenderDisplaySegment::Rich(existing)) = segments.last_mut() {
+        // Merge adjacent rich runs for fewer host attributed-string builds.
+        *existing = merge_rich_documents(existing, &document);
+        return;
+    }
+    segments.push(RenderDisplaySegment::Rich(document));
+}
+
+fn merge_rich_documents(left: &RenderDocument, right: &RenderDocument) -> RenderDocument {
+    let mut blocks = left.blocks.clone();
+    let left_root = blocks
+        .iter()
+        .find(|b| b.parent_id.is_none())
+        .map(|b| b.id)
+        .unwrap_or(0);
+    let mut next_id = blocks
+        .iter()
+        .map(|b| b.id)
+        .max()
+        .unwrap_or(0)
+        .saturating_add(1);
+    let mut id_map: BTreeMap<u32, u32> = BTreeMap::new();
+
+    for block in right.blocks.iter().filter(|b| b.parent_id.is_some()) {
+        let new_id = next_id;
+        next_id += 1;
+        id_map.insert(block.id, new_id);
+        let parent = block
+            .parent_id
+            .and_then(|old| {
+                // Direct children of right's document root attach to left root.
+                if right
+                    .blocks
+                    .iter()
+                    .any(|b| b.id == old && b.parent_id.is_none())
+                {
+                    Some(left_root)
+                } else {
+                    id_map.get(&old).copied()
+                }
+            })
+            .unwrap_or(left_root);
+        blocks.push(RenderBlock {
+            id: new_id,
+            parent_id: Some(parent),
+            depth: block.depth,
+            kind: block.kind.clone(),
+        });
+    }
+
+    let mut plain = left.plain_text.clone();
+    if !plain.is_empty() && !right.plain_text.is_empty() {
+        plain.push('\n');
+    }
+    plain.push_str(&right.plain_text);
+
+    RenderDocument {
+        blocks,
+        plain_text: plain,
+        image_attachments: Vec::new(),
+    }
 }
 
 fn flatten_tree(root: &TreeRenderBlock) -> Vec<RenderBlock> {
@@ -790,10 +1128,8 @@ fn normalize_quoted_children(children: Vec<TreeRenderBlock>) -> Vec<TreeRenderBl
         .collect::<Vec<_>>();
     let quoted_body = meaningful
         .iter()
-        .filter_map(|child| {
-            (child.kind == RenderBlockKind::Blockquote).then(|| child.children.clone())
-        })
-        .flatten()
+        .filter(|child| child.kind == RenderBlockKind::Blockquote)
+        .flat_map(|child| child.children.clone())
         .collect::<Vec<_>>();
     if !quoted_body.is_empty() {
         return quoted_body;
@@ -1954,6 +2290,7 @@ mod tests {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn image_node_with_attrs(
         id: u32,
         parent_id: u32,

--- a/rust/crates/fire-uniffi-types/src/lib.rs
+++ b/rust/crates/fire-uniffi-types/src/lib.rs
@@ -10,9 +10,9 @@ pub use error::FireUniFfiError;
 pub use panic::{CapturedPanic, PanicState};
 pub use records::{
     DraftDataState, DraftListResponseState, DraftState, RenderBlockKindState, RenderBlockState,
-    RenderDocumentState, RenderImageAttachmentState, RequiredTagGroupState, TopicListKindState,
-    TopicListState, TopicParticipantState, TopicPosterState, TopicRowState, TopicSummaryState,
-    TopicTagState, TopicUserState,
+    RenderDisplaySegmentState, RenderDocumentState, RenderImageAttachmentState,
+    RequiredTagGroupState, TopicListKindState, TopicListState, TopicParticipantState,
+    TopicPosterState, TopicRowState, TopicSummaryState, TopicTagState, TopicUserState,
 };
 pub use runtime::{
     constructor_guard, ffi_runtime, run_fallible, run_infallible, run_on_ffi_runtime,

--- a/rust/crates/fire-uniffi-types/src/records/mod.rs
+++ b/rust/crates/fire-uniffi-types/src/records/mod.rs
@@ -5,7 +5,8 @@ pub mod topic_list;
 
 pub use draft::{DraftDataState, DraftListResponseState, DraftState};
 pub use render_block::{
-    RenderBlockKindState, RenderBlockState, RenderDocumentState, RenderImageAttachmentState,
+    RenderBlockKindState, RenderBlockState, RenderDisplaySegmentState, RenderDocumentState,
+    RenderImageAttachmentState,
 };
 pub use tag::RequiredTagGroupState;
 pub use topic_list::{

--- a/rust/crates/fire-uniffi-types/src/records/render_block.rs
+++ b/rust/crates/fire-uniffi-types/src/records/render_block.rs
@@ -310,3 +310,22 @@ impl From<RenderDocumentState> for RenderDocument {
         }
     }
 }
+
+#[derive(uniffi::Enum, Debug, Clone)]
+pub enum RenderDisplaySegmentState {
+    Rich { document: RenderDocumentState },
+    Image { image: RenderImageAttachmentState },
+}
+
+impl From<fire_models::RenderDisplaySegment> for RenderDisplaySegmentState {
+    fn from(value: fire_models::RenderDisplaySegment) -> Self {
+        match value {
+            fire_models::RenderDisplaySegment::Rich(document) => Self::Rich {
+                document: document.into(),
+            },
+            fire_models::RenderDisplaySegment::Image(image) => Self::Image {
+                image: image.into(),
+            },
+        }
+    }
+}

--- a/rust/crates/fire-uniffi/src/lib.rs
+++ b/rust/crates/fire-uniffi/src/lib.rs
@@ -18,8 +18,8 @@ use fire_uniffi_search::FireSearchHandle;
 use fire_uniffi_session::{FireSessionHandle, SessionState};
 use fire_uniffi_topics::FireTopicsHandle;
 use fire_uniffi_types::{
-    FireUniFfiError, RenderDocumentState, RenderImageAttachmentState, SharedFireCore,
-    TopicListState,
+    FireUniFfiError, RenderDisplaySegmentState, RenderDocumentState, RenderImageAttachmentState,
+    SharedFireCore, TopicListState,
 };
 use fire_uniffi_user::FireUserHandle;
 
@@ -51,6 +51,16 @@ pub fn collect_images_from_render_document(
 #[uniffi::export]
 pub fn plain_text_from_render_document(document: RenderDocumentState) -> String {
     fire_rich_text::plain_text_from_render_document(&document.into())
+}
+
+#[uniffi::export]
+pub fn display_segments_from_render_document(
+    document: RenderDocumentState,
+) -> Vec<RenderDisplaySegmentState> {
+    fire_rich_text::display_segments(&document.into())
+        .into_iter()
+        .map(Into::into)
+        .collect()
 }
 
 #[uniffi::export]


### PR DESCRIPTION
## Summary
Restores the remaining same-day local WIP that was left out of #88–#90:

1. **Topic-list metric emphasis**
   - ranking (notable/high/surge), filled chips, likes trailing
   - settled-scroll micro-effects via `FireTopicListMetricEffectCoordinator`
   - Auto Layout priority 999 for self-sizing cells

2. **Rust `display_segments` + PostCell layout**
   - `fire_rich_text::display_segments` + UniFFI `displaySegmentsFromRenderDocument`
   - iOS presentation uses Rust segment plan
   - collapsed-text normalization + compact boost chips

3. **HomeFeedStore / TopicDetailStore main-thread offload**
   - heavy row merge / detail synthesis prepared off-main
   - main actor only commits state

Also includes small UX polish (composer/empty-state bounce, settings chrome) and architecture notes / threading audit.

## Test plan
- [ ] Home list metrics look correct; hot posts emphasize
- [ ] Topic detail posts: collapsed blank lines no longer waste lines; boost chips compact
- [ ] Scrolling home/detail feels smoother on heavy topics
- [ ] `FireTopicPresentationTests`, `FirePostCellLayoutCalculatorTests`, `FireTopicDetailRuntimeTests`
- [ ] CI: Rust lint/test + iOS xcodegen drift check