### PR TITLE
feat(auth/cf): login CF session alignment and challenge completion UX

### DIFF
--- a/docs/knowledge/discourse-cloudflare-challenge-guide.md
+++ b/docs/knowledge/discourse-cloudflare-challenge-guide.md
@@ -160,6 +160,20 @@ Clients may later expose an automatic verification setting. When disabled,
 challenge detection should surface a manual "verify now" action instead of
 opening a WebView automatically.
 
+Hosts should distinguish challenge failure reasons when surfacing UI:
+
+| reason | Suggested UX |
+|---|---|
+| `required` / `failed` | Offer retry + manual verify |
+| `cancelled` | Soft message; keep manual verify |
+| `cooldown` | Soft message; allow explicit manual verify bypass |
+| `in_progress` | Wait / do not open a second WebView |
+| `background_suppressed` | Do not steal focus; offer manual verify on visible pages |
+
+Logged-in clients should also run a hidden Turnstile clearance refresh runtime
+while the app is foregrounded. Challenge response bodies may carry a Turnstile
+`sitekey`; capture it into bootstrap state when missing so refresh can start.
+
 ## 9. Login CSRF Integration
 
 Password login performs `/session/csrf` inside the login WebView. If that step

--- a/docs/knowledge/discourse-cloudflare-challenge-guide.md
+++ b/docs/knowledge/discourse-cloudflare-challenge-guide.md
@@ -1,8 +1,9 @@
 # Discourse Cloudflare Challenge Guide
 
 This guide is the stack-neutral contract for Cloudflare verification around the
-LinuxDo Discourse site. It captures the v0.2.18 behavior Fire implements without
-depending on any Flutter, Dart, or reference-project source file.
+LinuxDo Discourse site. It is aligned with Fire's Rust/native implementation and
+with the current observed LinuxDo/Cloudflare behavior used by the reference
+client.
 
 Cloudflare verification is a browser-owned operation. Rust detects and
 orchestrates challenge recovery, but platform WebViews complete the challenge
@@ -17,7 +18,9 @@ Cloudflare handling must:
 - Complete verification in a platform WebView.
 - Return fresh `cf_clearance` and related cookies to Rust.
 - Freeze ordinary business requests while verification is active.
-- Avoid resurrecting stale clearance cookies during priming or sweep.
+- Let concurrent CF victims join one shared verification and each retry once.
+- Keep `cf_clearance` one-way: WebView → Rust jar only. Never prime or sweep
+  jar copies back into the browser store.
 
 ## 2. Detection
 
@@ -27,7 +30,8 @@ A response is a Cloudflare challenge when:
 2. The response is from Cloudflare, usually `Server: cloudflare`.
 3. One of these signals is present:
    - `cf-mitigated: challenge`
-   - challenge HTML/body markers such as `cf_chl_opt`
+   - challenge HTML/body markers such as `cf_chl_opt`, `cf-turnstile`,
+     `challenge-running`, or `challenge-stage`
    - `challenge-platform` with Cloudflare context
    - `Just a moment` with Cloudflare or challenge context
 
@@ -40,72 +44,86 @@ requests can receive `text/plain` challenge bodies.
 
 ## 3. Request Modes
 
-Rust should classify challenge requests by mode:
+Rust classifies challenge presentation by mode:
 
 | Mode | Meaning | UI behavior |
 |---|---|---|
-| `silent` | Background, polling, prefetch, or telemetry request | Do not steal focus; fail softly or wait |
-| `data` | Foreground data needed by visible UI | May show contextual verification |
-| `action` | User-initiated action or login prerequisite | May show manual verification immediately |
+| `silent` / background | MessageBus, timings, bootstrap refresh, notification polls | Do not open a new challenge UI. Soft-fail, or join an already running foreground verification |
+| `foreground` / data / action | Visible UI data or user-initiated work | May open manual verification immediately and bypass cooldown |
 
-Explicit manual verification actions may bypass a recent failure cooldown.
+Only foreground requests may start a new platform challenge. Background traffic
+must never steal focus.
 
-## 4. In-Progress State
+## 4. In-Progress State And Join
 
-Rust owns an observable `cf_in_progress` state. It becomes true before platform
-verification starts and false only after verification completes, fails, or is
-cancelled.
+Rust owns `cf_in_progress`. It becomes true before platform verification starts
+and false only after verification accepts or rejects a clearance.
 
 While `cf_in_progress` is true:
 
-- Ordinary API requests are blocked before dispatch.
-- MessageBus polling is paused or cancelled.
-- Reading-time and timing uploads are dropped rather than queued.
-- Only requests marked `skip_cf_block` may proceed.
-- Internal challenge retry requests must also be marked to avoid recursion.
+- Ordinary API requests that have not yet been dispatched are blocked before
+  send (`CloudflareChallengeInProgress`).
+- Requests that already received a CF challenge response join the active
+  verification instead of opening another WebView.
+- After shared success, every joined request retries itself once with
+  `skip_cf_block`.
+- MessageBus polling / timings should remain non-foreground so they do not open
+  UI and do not create clearance write-back storms.
+- Internal challenge retries must be marked to avoid recursion.
 
-This matches browser behavior: once a page is behind a challenge, business
-traffic does not continue with stale cookies.
+This matches browser behavior: once a page is behind a challenge, fresh business
+traffic does not continue with stale cookies, but concurrent victims of the same
+challenge share one verification.
 
 ## 5. Manual Verification
 
-Manual verification opens a platform WebView on a trusted LinuxDo origin. The UI
-may start hidden or contextual, but it must be able to promote to a user-visible
-surface when interaction is required.
+Manual verification opens a platform WebView on a trusted LinuxDo origin.
 
 Recommended completion checks:
 
 1. Snapshot the old `cf_clearance` before verification.
 2. Delete stale `cf_clearance` cookies from the platform WebView store when
-   starting a fresh verification.
-3. Prefer loading the same-origin `/challenge` URL in the WebView. If a
-   platform cannot build that URL, it may fall back to an origin URL on the
-   same LinuxDo host.
-4. Detect active challenge markers in the page.
-5. Poll the WebView cookie store for `cf_clearance`.
+   starting a fresh verification. Active delete is allowed; jar→WebView rewrite
+   is not.
+3. Prefer loading the same-origin `/challenge` URL in the WebView.
+4. Detect active challenge markers in the page
+   (`cf_chl_opt`, `cf-turnstile`, `challenge-running`, `challenge-stage`, etc.).
+5. Poll or event-drive the WebView cookie store for `cf_clearance`.
 6. Accept success only when the platform has independently confirmed a non-empty
    `cf_clearance` after the challenge page is no longer active. That value
    usually differs from the platform baseline, but it may match Rust's previous
    snapshot when the Rust jar and WebView store were out of sync.
 7. Sync the accepted value and related Cloudflare cookies to Rust as trusted
    writes through the challenge-completion path.
+8. On cancel/failure, restore only the WebView-local clearance backup taken at
+   step 1. Do not re-prime clearance from Rust jar state.
 
 Related cookies include `cf_clearance` and `_cfuvid`. A challenge WebView
 snapshot may also contain Discourse identity cookies, but challenge completion
 must merge those inputs into Rust's existing session; it must not treat a partial
-WebView snapshot as proof that `_t` or `_forum_session` disappeared. Replacing
-the Discourse identity pair is reserved for successful login finalization,
-explicit logout, or an explicitly authoritative host resync that contains both
-active identity cookies.
+WebView snapshot as proof that `_t` or `_forum_session` disappeared.
 
-On Android, `CookieManagerCompat.getCookieInfo()` should be preferred because it
-preserves domain/path/flag metadata. If the runtime only exposes
-`CookieManager.getCookie()` name/value data, the platform may still use it to
-report the independently confirmed accepted `cf_clearance` value. Rust remains
-responsible for accepting only that value and treating the rest of the snapshot
-as low-metadata input.
+## 6. `cf_clearance` One-Way Flow
 
-## 6. Freshness Filtering
+`cf_clearance` is authored only by Cloudflare inside a real browser/WebView.
+
+Required rules:
+
+- WebView → Rust jar sync is allowed and expected.
+- Rust jar / canonical store → WebView write-back is forbidden for
+  `cf_clearance` during priming, sweep, nuclear reset, or ordinary cookie push.
+- Challenge start may delete WebView `cf_clearance` to force a fresh challenge.
+- Challenge cancel may restore the WebView backup captured before that delete.
+- If multiple `cf_clearance` variants exist, prefer the freshest by
+  `expires` / latest trusted browser value when selecting what native traffic
+  sends.
+
+Why: replaying jar cookies through `Set-Cookie` can drop `Partitioned` and other
+browser-only attributes, creating a ghost non-partitioned copy. Native code may
+then send the wrong variant and produce a session that stays on CF `403` even
+after restart.
+
+## 7. Freshness Filtering
 
 When the platform sends cookies after verification, the challenge result should
 carry only the confirmed `cf_clearance` variant. Rust must still enforce the
@@ -120,33 +138,29 @@ trusted: true
 accept_values: { "cf_clearance": fresh_clearance } when present
 ```
 
-If `accept_values` contains a cookie name, Rust must accept only the matching
-value for that name. This prevents old WebView variants from overwriting the
-fresh challenge result.
-
 If the platform independently confirms a fresh `cf_clearance` value but the
 cookie snapshot is missing that value or only contains a variant that cannot be
 sent to the site root, Rust must materialize that accepted value as a trusted
 root-path `cf_clearance` for the LinuxDo origin before retrying. The retry
 remains the authority for whether the confirmed clearance is actually usable.
 
-## 7. Cooldown And Auto Verify
-
-Clients may support an automatic verification setting. When enabled, foreground
-requests can show verification automatically. When disabled, challenge detection
-should surface a manual "verify now" action instead of repeatedly opening a
-WebView.
+## 8. Cooldown And Auto Verify
 
 Recommended cooldown:
 
-- Track verification failures.
-- Enter a short cooldown after a failed or cancelled verification.
-- Let explicit foreground/manual verification bypass cooldown.
-- Reset cooldown after confirmed success.
+- Track consecutive verification failures.
+- Enter cooldown after repeated failures (Fire: 3 failures → 30s).
+- Foreground/manual verification may bypass cooldown.
+- Reset failure count after confirmed success.
+- Background traffic must not open UI during cooldown.
 
 Cooldown is a UI/rate-control policy. It must not change cookie freshness rules.
 
-## 8. Login CSRF Integration
+Clients may later expose an automatic verification setting. When disabled,
+challenge detection should surface a manual "verify now" action instead of
+opening a WebView automatically.
+
+## 9. Login CSRF Integration
 
 Password login performs `/session/csrf` inside the login WebView. If that step
 returns a Cloudflare challenge:
@@ -154,13 +168,14 @@ returns a Cloudflare challenge:
 1. Treat it as a challenge response.
 2. Run manual verification once.
 3. Sync fresh cookies as trusted.
-4. Re-prime the same login WebView.
+4. Re-prime the same login WebView for Discourse identity cookies only.
+   Do not rewrite `cf_clearance` from jar state.
 5. Re-run the login JS function with the original hCaptcha token.
 
 This case is handled before hCaptcha create, so the hCaptcha token has not been
 consumed.
 
-## 9. User Agent Repair
+## 10. User Agent Repair
 
 Platforms must use a browser-compatible user agent for challenge WebViews. If a
 platform WebView reports an incomplete or non-browser UA, the platform should
@@ -169,15 +184,17 @@ repair it using native browser version information where available.
 The repaired UA should be returned to Rust so subsequent API requests can align
 with the browser session that produced the clearance.
 
-## 10. Verification Outcomes
+## 11. Verification Outcomes
 
 | Outcome | Rust action |
 |---|---|
-| Fresh clearance returned | Merge trusted challenge cookies, preserve Discourse identity cookies, sweep critical variants, retry original foreground request once |
-| User cancelled | Clear `cf_in_progress`, return a challenge-cancelled error |
-| Cooldown active and no manual bypass | Clear `cf_in_progress`, return a soft challenge error |
+| Fresh clearance returned | Merge trusted challenge cookies, preserve Discourse identity cookies, publish shared success, retry owner + joined requests once |
+| User cancelled | Clear `cf_in_progress`, publish shared failure, return challenge error |
+| Cooldown active and no manual bypass | Do not start platform UI; return soft challenge error |
+| Background request with no active challenge | Do not start platform UI; return soft challenge error |
 | WebView failed without fresh cookie | Clear `cf_in_progress`, preserve existing cookies, surface retry |
-| Original request obsolete by auth generation | Do not retry; discard stale result |
+| New request arrives during active challenge | Block before dispatch (`CloudflareChallengeInProgress`) |
+| Already-challenged concurrent request | Join active verification, then retry once on shared success |
 
 Challenge failures are not logout signals. Preserve Discourse identity cookies
 unless a later session probe proves logout.

--- a/docs/knowledge/discourse-cloudflare-challenge-guide.md
+++ b/docs/knowledge/discourse-cloudflare-challenge-guide.md
@@ -85,18 +85,25 @@ Recommended completion checks:
 2. Delete stale `cf_clearance` cookies from the platform WebView store when
    starting a fresh verification. Active delete is allowed; jar→WebView rewrite
    is not.
-3. Prefer loading the same-origin `/challenge` URL in the WebView.
+3. Prefer loading the same-origin bare `/challenge` URL in the WebView.
 4. Detect active challenge markers in the page
    (`cf_chl_opt`, `cf-turnstile`, `challenge-running`, `challenge-stage`, etc.).
 5. Poll or event-drive the WebView cookie store for `cf_clearance`.
-6. Accept success only when the platform has independently confirmed a non-empty
-   `cf_clearance` after the challenge page is no longer active. That value
-   usually differs from the platform baseline, but it may match Rust's previous
-   snapshot when the Rust jar and WebView store were out of sync.
-7. Sync the accepted value and related Cloudflare cookies to Rust as trusted
+6. After CF passes, the browser often navigates back to bare `/challenge`. That
+   path is **not** a real Discourse page, so the origin returns **404 / page not
+   found**. Treat main-frame bare `/challenge` **404 without**
+   `cf-mitigated: challenge` as a **pass signal**, not a failure.
+7. Cover the WebView with a completion overlay (`正在完成验证…`) as soon as
+   post-pass `/challenge` navigation or origin-404 markers are observed so the
+   user never sees Discourse's "page does not exist" body.
+8. Accept success when the platform has independently confirmed a non-empty
+   fresh `cf_clearance` and the page is no longer an active challenge (including
+   the origin-404 fallback case). Do **not** require a homepage reload probe;
+   finishing on `/challenge` 404 + fresh clearance is enough.
+9. Sync the accepted value and related Cloudflare cookies to Rust as trusted
    writes through the challenge-completion path.
-8. On cancel/failure, restore only the WebView-local clearance backup taken at
-   step 1. Do not re-prime clearance from Rust jar state.
+10. On cancel/failure, restore only the WebView-local clearance backup taken at
+    step 1. Do not re-prime clearance from Rust jar state.
 
 Related cookies include `cf_clearance` and `_cfuvid`. A challenge WebView
 snapshot may also contain Discourse identity cookies, but challenge completion
@@ -187,11 +194,22 @@ A confirmed challenge completion clears the rejected window.
 
 After a successful challenge:
 
-1. Merge trusted clearance into Rust.
+1. Merge **CF-related cookies only** into Rust (`cf_clearance`, `_cfuvid`, and
+   other `cf_` / `__cf*` names). Do **not** let the challenge WebView snapshot
+   overwrite `_t` / `_forum_session` identity cookies.
 2. Open a short trust-settle window so the first request wave sees the jar.
-3. If the user already has a login session, force one bootstrap rebuild
-   (non-blocking relative to the original request retry).
-4. Publish join success so concurrent CF victims can retry.
+3. Prefer finishing on bare `/challenge` source 404 + fresh clearance (with
+   overlay coverage). Avoid navigating the challenge WebView to arbitrary app
+   routes that can flash unrelated UI.
+4. If the user already has a login session, force bootstrap rebuild **and** a full
+   app-state refresh batch (`CloudflareResolved`, bypassing normal debounce).
+   Manual challenge completion and network-owned completion share this path.
+5. Publish join success so concurrent CF victims can retry.
+6. Broadcast a clearance-resolved event (`generation`, `has_login_session`,
+   `can_open_message_bus`) so hosts can:
+   - clear CF error banners
+   - restart MessageBus when readiness allows
+   - continue login finalize / retry login JS when mid-login
 
 ### Login-ready handoff
 
@@ -201,6 +219,8 @@ After WebView login cookie handoff (password or OAuth):
 2. Attempt bootstrap refresh with an ~8s timeout.
 3. Enter home whenever auth cookies are present, even if bootstrap is slow or
    fails (never stick on "syncing login state").
+4. Post-login app-state refresh (home topic list, notifications, MessageBus)
+   runs **after** login-ready / navigation and must not block the handoff UI.
 
 ## 9. Login CSRF Integration
 

--- a/docs/knowledge/discourse-cloudflare-challenge-guide.md
+++ b/docs/knowledge/discourse-cloudflare-challenge-guide.md
@@ -174,6 +174,34 @@ Logged-in clients should also run a hidden Turnstile clearance refresh runtime
 while the app is foregrounded. Challenge response bodies may carry a Turnstile
 `sitekey`; capture it into bootstrap state when missing so refresh can start.
 
+### Clearance trust after rejection
+
+When an API response is classified as a Cloudflare challenge, the current jar
+clearance (if any) must be marked **recently rejected**. Login preflight and
+other "ensure clearance" checks must not skip verification solely because a
+non-empty `cf_clearance` cookie still exists in local storage.
+
+A confirmed challenge completion clears the rejected window.
+
+### Post-success session rebuild
+
+After a successful challenge:
+
+1. Merge trusted clearance into Rust.
+2. Open a short trust-settle window so the first request wave sees the jar.
+3. If the user already has a login session, force one bootstrap rebuild
+   (non-blocking relative to the original request retry).
+4. Publish join success so concurrent CF victims can retry.
+
+### Login-ready handoff
+
+After WebView login cookie handoff (password or OAuth):
+
+1. Finalize trusted cookies + username.
+2. Attempt bootstrap refresh with an ~8s timeout.
+3. Enter home whenever auth cookies are present, even if bootstrap is slow or
+   fails (never stick on "syncing login state").
+
 ## 9. Login CSRF Integration
 
 Password login performs `/session/csrf` inside the login WebView. If that step

--- a/docs/knowledge/discourse-cookie-session-state-guide.md
+++ b/docs/knowledge/discourse-cookie-session-state-guide.md
@@ -178,8 +178,13 @@ There are two authoritative directions.
 When Rust receives `Set-Cookie` from normal API traffic:
 
 1. Save cookies into canonical state as trusted.
-2. For critical cookies, immediately enqueue or execute a WebView write.
-3. Sweep the relevant name to keep the WebView store unique.
+2. For critical cookies **other than `cf_clearance`**, immediately enqueue or
+   execute a WebView write.
+3. Sweep those non-clearance names to keep the WebView store unique.
+4. Never write `cf_clearance` from jar/canonical state back into WebView.
+   Clearance is browser-authored only; jar→WebView replay can drop
+   `Partitioned` and create a ghost variant that keeps native traffic on CF
+   `403`.
 
 ### Path B: WebView Login Or Challenge To Rust
 
@@ -203,7 +208,10 @@ When a WebView flow itself performed the network request:
 7. Challenge completion is a merge, not an authoritative login-state replace.
    If that WebView snapshot lacks `_t` or `_forum_session`, Rust must preserve
    the existing Discourse identity cookies.
-8. Sweep critical names after applying the cookies.
+8. After challenge completion, sync the accepted clearance into Rust only.
+   Do not sweep/rewrite WebView `cf_clearance` from jar state. Multi-variant
+   browser clearance should converge by expires freshness selection on the
+   native send path, not by deleting/recreating browser cookies from Rust.
 
 Generic WebView reads outside these boundary events are untrusted. They may be
 used as an authoritative login-state replacement only when the host resync batch
@@ -214,14 +222,21 @@ contains both active identity cookies, `_t` and `_forum_session`.
 Before opening a login, challenge, or trusted in-app WebView:
 
 1. Ask Rust for a priming payload for `https://linux.do/`.
-2. For each critical cookie being primed, delete existing WebView variants for
-   that name before writing the canonical cookie.
-3. Re-read canonical state immediately before each async write batch.
-4. Write raw `Set-Cookie` headers when available.
-5. Use structured fields to reconstruct `Set-Cookie` only when raw headers are
+2. Priming payloads must omit `cf_clearance`. Clearance stays WebView-local
+   until a challenge/login boundary syncs it into Rust.
+3. For each non-clearance critical cookie being primed, delete existing WebView
+   variants for that name before writing the canonical cookie.
+4. Re-read canonical state immediately before each async write batch.
+5. Write raw `Set-Cookie` headers when available.
+6. Use structured fields to reconstruct `Set-Cookie` only when raw headers are
    absent.
-6. Do not reinsert a cookie Rust deleted during the priming operation.
-7. Deduplicate repeated priming for the same URL unless invalidated.
+7. Do not reinsert a cookie Rust deleted during the priming operation.
+8. Deduplicate repeated priming for the same URL unless invalidated.
+
+Allowed WebView writes for `cf_clearance` are limited to:
+
+- explicit delete before starting a fresh challenge;
+- restore of a WebView-local backup after cancelled/failed challenge.
 
 Priming must be invalidated after CF cleanup, explicit delete, logout, and any
 trusted update to a critical cookie.
@@ -232,8 +247,9 @@ The sentinel enforces this postcondition:
 
 ```text
 For each critical cookie name and WebView URL:
-  ensure_unique => WebView variant count <= 1
+  ensure_unique => WebView variant count <= 1   # except cf_clearance
   delete        => WebView variant count == 0
+  cf_clearance  => read-only sync into jar; do not delete/rewrite WebView
 ```
 
 Concurrency rules:

--- a/docs/knowledge/discourse-webview-login-guide.md
+++ b/docs/knowledge/discourse-webview-login-guide.md
@@ -318,11 +318,14 @@ Rust finalization:
    HTTP.
 6. Uses an 8 second timeout for login-ready refresh.
 7. Always notifies login-ready in `finally` semantics.
+8. Hosts enter home / dismiss login UI as soon as login-ready returns; broader
+   app-state refresh is fire-and-forget and must not re-block the handoff.
 
 The UI must never remain permanently loading because bootstrap refresh failed or
 timed out after a successful cookie handoff. OAuth browser hosts must await
-finalization, dismiss themselves on success, and re-arm polling on transient
-failure.
+cookie finalization (`finalize_login_ready`), dismiss themselves on success, and
+re-arm polling on transient failure — without waiting on the full home refresh
+batch.
 
 ## 12. Browser / OAuth Surfaces
 
@@ -336,7 +339,11 @@ Those surfaces must:
    callback).
 2. Poll WebView cookies after IdP return and also probe on `didFinish`.
 3. Auto-finalize with the §11.1 ready gate.
-4. Await cookie sync + bootstrap refresh, then enter home.
+4. Await cookie sync + bounded login-ready bootstrap, then enter home.
+   Do not block entry on the full post-login app-state refresh batch.
+5. While the login WebView is active (password dialog or OAuth browser), poll the
+   shared active-CF page markers. On hit, run the same-origin manual challenge,
+   re-prime without writing jar `cf_clearance` back, and continue finalize / retry.
 
 They must not reintroduce the Ember `/login` page as the password-login
 fallback.

--- a/docs/knowledge/discourse-webview-login-guide.md
+++ b/docs/knowledge/discourse-webview-login-guide.md
@@ -289,9 +289,24 @@ On login success:
 
 1. Extract `_t`, `_forum_session`, `cf_clearance`, `_cfuvid`, and related
    LinuxDo cookies from the live WebView.
-2. Send those cookies to Rust as trusted WebView-login cookies.
-3. Include the browser user agent when available.
-4. Call the single Rust login finalizer before disposing the WebView.
+2. Resolve the current username from `meta[name=current-username]` or
+   `Discourse.User.current()`.
+3. Send those cookies to Rust as trusted WebView-login cookies.
+4. Include the browser user agent when available.
+5. Call the single Rust login finalizer before disposing the WebView.
+
+### 11.1 Ready gate for auto-finalize (password JS and OAuth)
+
+A WebView login surface may auto-finalize when **both** are true:
+
+1. Active `_t` and `_forum_session` cookies are present in the WebView store.
+2. A non-empty current username is readable from the page.
+
+Reusable homepage bootstrap HTML is preferred but **not required** to start
+finalization. If bootstrap markup is missing after OAuth return, finalize the
+cookie handoff first and refresh bootstrap over HTTP. This matches the fluxdo
+WebView login page behavior: detect username + `_t`, sync cookies, then hydrate
+or refresh preloaded data with a timeout fallback.
 
 Rust finalization:
 
@@ -305,15 +320,23 @@ Rust finalization:
 7. Always notifies login-ready in `finally` semantics.
 
 The UI must never remain permanently loading because bootstrap refresh failed or
-timed out after a successful cookie handoff.
+timed out after a successful cookie handoff. OAuth browser hosts must await
+finalization, dismiss themselves on success, and re-arm polling on transient
+failure.
 
-## 12. Deprecated Normal Path
+## 12. Browser / OAuth Surfaces
 
-The older password-login design loaded `https://linux.do/login`, injected page
-scripts, and inferred success from page state or navigation. That path is not the
-normal Fire implementation target.
+Password login should stay on the minimal native WebView JS path. Separate
+browser surfaces remain required for Google/GitHub/X/Discord/Apple OAuth,
+passkeys, and email-link login.
 
-Browser login surfaces may still be needed later for distinct features such as
-OAuth provider flows, passkeys, or email-link login. Those features must be
-designed separately and must not reintroduce the Ember `/login` page as the
-password-login fallback.
+Those surfaces must:
+
+1. Keep OAuth inside one WebView (no external browser handoff for the Discourse
+   callback).
+2. Poll WebView cookies after IdP return and also probe on `didFinish`.
+3. Auto-finalize with the §11.1 ready gate.
+4. Await cookie sync + bootstrap refresh, then enter home.
+
+They must not reintroduce the Ember `/login` page as the password-login
+fallback.

--- a/native/android-app/build.gradle.kts
+++ b/native/android-app/build.gradle.kts
@@ -142,6 +142,7 @@ dependencies {
     implementation("androidx.lifecycle:lifecycle-viewmodel-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-livedata-ktx:2.8.7")
     implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.8.7")
+    implementation("androidx.lifecycle:lifecycle-process:2.8.7")
     implementation("androidx.datastore:datastore-preferences:1.1.4")
     implementation("androidx.webkit:webkit:1.13.0")
     implementation("com.google.android.material:material:1.12.0")

--- a/native/android-app/src/main/java/com/fire/app/MainActivity.kt
+++ b/native/android-app/src/main/java/com/fire/app/MainActivity.kt
@@ -7,11 +7,15 @@ import androidx.activity.enableEdgeToEdge
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.updatePadding
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.NavController
 import androidx.navigation.NavOptions
 import androidx.navigation.fragment.NavHostFragment
 import com.fire.app.databinding.ActivityMainBinding
+import com.fire.app.session.FireCfClearanceRefreshService
 import com.fire.app.session.FireSessionStoreRepository
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -34,8 +38,31 @@ class MainActivity : AppCompatActivity() {
 
         configureBottomNavigation(navController)
         handleWidgetDeepLink(navController)
+        bindCloudflareRefreshLifecycle()
 
         refreshNotificationBadge()
+    }
+
+    private fun bindCloudflareRefreshLifecycle() {
+        ProcessLifecycleOwner.get().lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onStart(owner: LifecycleOwner) {
+                FireCfClearanceRefreshService.get(this@MainActivity).setSceneActive(true)
+            }
+
+            override fun onStop(owner: LifecycleOwner) {
+                FireCfClearanceRefreshService.get(this@MainActivity).setSceneActive(false)
+            }
+        })
+        lifecycleScope.launch {
+            val store = FireSessionStoreRepository.get(this@MainActivity)
+            val refresh = FireCfClearanceRefreshService.get(this@MainActivity)
+            refresh.bind(store)
+            val snapshot = withContext(Dispatchers.IO) { store.snapshot() }
+            refresh.updateSession(snapshot)
+            if (snapshot.readiness.hasCurrentUser && snapshot.readiness.canReadAuthenticatedApi) {
+                refresh.setLoginStateConfirmed(true)
+            }
+        }
     }
 
     private fun configureBottomNavigation(navController: NavController) {

--- a/native/android-app/src/main/java/com/fire/app/core/error/FireErrorHandling.kt
+++ b/native/android-app/src/main/java/com/fire/app/core/error/FireErrorHandling.kt
@@ -91,7 +91,7 @@ object FireErrorClassifier {
             is FireUniFfiException.StaleSessionResponse -> fireError.operation
             is FireUniFfiException.Network -> fireError.details
             is FireUniFfiException.CloudflareChallenge ->
-                "cloudflare challenge required (${FireCloudflareRecovery.reason(error)})"
+                "cloudflare challenge required (${fireError.reason})"
             is FireUniFfiException.HttpStatus ->
                 "${fireError.operation} HTTP ${fireError.status}: ${fireError.body.abbreviated()}"
             is FireUniFfiException.Storage -> fireError.details

--- a/native/android-app/src/main/java/com/fire/app/core/error/FireErrorHandling.kt
+++ b/native/android-app/src/main/java/com/fire/app/core/error/FireErrorHandling.kt
@@ -1,6 +1,7 @@
 package com.fire.app.core.error
 
 import android.util.Log
+import com.fire.app.session.FireCloudflareRecovery
 import com.fire.app.session.FireSessionStore
 import java.util.concurrent.atomic.AtomicLong
 import kotlinx.coroutines.CancellationException
@@ -33,6 +34,7 @@ data class FireReportedError(
     val displayMessage: String,
     val details: String,
     val isCloudflareChallenge: Boolean,
+    val cloudflareReason: String? = null,
 )
 
 object FireErrorClassifier {
@@ -56,26 +58,12 @@ object FireErrorClassifier {
     }
 
     fun isCloudflareChallenge(error: Throwable?): Boolean {
-        var current = error
-        while (current != null) {
-            when (current) {
-                is FireUniFfiException.CloudflareChallenge -> return true
-                is FireUniFfiException.HttpStatus -> {
-                    if (current.status.toInt() in CLOUDFLARE_CHALLENGE_HTTP_STATUSES &&
-                        current.body.contains(CLOUDFLARE_CHALLENGE_TEXT, ignoreCase = true)
-                    ) {
-                        return true
-                    }
-                }
-            }
-            current = current.cause
-        }
-        return false
+        return FireCloudflareRecovery.isCloudflareChallenge(error)
     }
 
     fun displayMessage(error: Throwable, fallbackMessage: String? = null): String {
         return when (classify(error)) {
-            FireErrorKind.CloudflareChallenge -> "需要完成 Cloudflare 验证"
+            FireErrorKind.CloudflareChallenge -> cloudflareDisplayMessage(error)
             FireErrorKind.Network -> fallbackMessage ?: "网络请求失败，请检查连接后重试"
             FireErrorKind.Authentication,
             FireErrorKind.LoginRequired -> fallbackMessage ?: "当前请求需要有效登录会话，请稍后重试"
@@ -102,7 +90,8 @@ object FireErrorClassifier {
             is FireUniFfiException.LoginRequired -> fireError.details
             is FireUniFfiException.StaleSessionResponse -> fireError.operation
             is FireUniFfiException.Network -> fireError.details
-            is FireUniFfiException.CloudflareChallenge -> "cloudflare challenge required"
+            is FireUniFfiException.CloudflareChallenge ->
+                "cloudflare challenge required (${FireCloudflareRecovery.reason(error)})"
             is FireUniFfiException.HttpStatus ->
                 "${fireError.operation} HTTP ${fireError.status}: ${fireError.body.abbreviated()}"
             is FireUniFfiException.Storage -> fireError.details
@@ -111,6 +100,17 @@ object FireErrorClassifier {
             is FireUniFfiException.Internal -> fireError.details
             null -> error.localizedMessage ?: error.toString()
         }.abbreviated()
+    }
+
+    private fun cloudflareDisplayMessage(error: Throwable): String {
+        return when (FireCloudflareRecovery.reason(error)) {
+            "in_progress" -> "正在完成 Cloudflare 验证，请稍候"
+            "cooldown" -> "Cloudflare 验证暂时冷却中，请稍后重试或手动验证"
+            "cancelled" -> "已取消 Cloudflare 验证"
+            "background_suppressed" -> "后台请求遇到 Cloudflare 验证，请在页面中手动验证"
+            "failed" -> "Cloudflare 验证未完成，请重试"
+            else -> "需要完成 Cloudflare 验证"
+        }
     }
 
     private fun httpStatusMessage(error: Throwable, fallbackMessage: String?): String {
@@ -154,13 +154,15 @@ object FireErrorReporter {
     ): FireReportedError {
         val normalizedOperation = operation.ifBlank { "unknown" }
         val kind = FireErrorClassifier.classify(error)
+        val isCloudflare = FireErrorClassifier.isCloudflareChallenge(error)
         val report = FireReportedError(
             errorId = newErrorId(),
             operation = normalizedOperation,
             kind = kind,
             displayMessage = FireErrorClassifier.displayMessage(error, fallbackMessage),
             details = FireErrorClassifier.details(error),
-            isCloudflareChallenge = FireErrorClassifier.isCloudflareChallenge(error),
+            isCloudflareChallenge = isCloudflare,
+            cloudflareReason = if (isCloudflare) FireCloudflareRecovery.reason(error) else null,
         )
         val message = buildLogMessage(report)
         if (kind.shouldLogAsError()) {

--- a/native/android-app/src/main/java/com/fire/app/messagebus/FireMessageBusCoordinator.kt
+++ b/native/android-app/src/main/java/com/fire/app/messagebus/FireMessageBusCoordinator.kt
@@ -115,5 +115,30 @@ class FireMessageBusCoordinator(private val sessionStore: FireSessionStore) {
                 runCatching { sessionStore.stopMessageBus(clearSubscriptions = false) }
             }
         }
+
+        /**
+         * After Cloudflare success, restart the shared MessageBus even if the
+         * reference count already held a live poll that died mid-challenge.
+         */
+        suspend fun forceRestart(sessionStore: FireSessionStore) {
+            val shouldRestart = synchronized(lock) {
+                if (referenceCount <= 0) {
+                    false
+                } else {
+                    started = true
+                    true
+                }
+            }
+            if (!shouldRestart) return
+            runCatching { sessionStore.stopMessageBus(clearSubscriptions = false) }
+            try {
+                sessionStore.startMessageBus(sharedHandler)
+            } catch (error: Exception) {
+                synchronized(lock) {
+                    started = false
+                }
+                throw error
+            }
+        }
     }
 }

--- a/native/android-app/src/main/java/com/fire/app/richtext/FireSpannableBuilder.kt
+++ b/native/android-app/src/main/java/com/fire/app/richtext/FireSpannableBuilder.kt
@@ -317,9 +317,18 @@ object FireSpannableBuilder {
             builder.setSpan(RelativeSizeSpan(0.8f), headerStart, headerEnd, Spanned.SPAN_EXCLUSIVE_EXCLUSIVE)
             builder.append('\n')
         }
+        val isReplyQuote = !trimmedAuthor.isNullOrEmpty() || postNumber != null
         val bodyBuilder = SpannableStringBuilder()
-        appendNodes(children, bodyBuilder, context.indented().copy(textColor = 0xFF6B7280.toInt()), ctx, onLinkClicked)
-        builder.append(compactQuoteText(bodyBuilder))
+        val bodyColor = if (isReplyQuote) 0xFF6B7280.toInt() else context.textColor
+        appendNodes(
+            children,
+            bodyBuilder,
+            if (isReplyQuote) context.indented().copy(textColor = bodyColor) else context.copy(textColor = bodyColor),
+            ctx,
+            onLinkClicked,
+        )
+        // Plain body blockquotes keep full text (web-like). Reply-quotes stay compact.
+        builder.append(if (isReplyQuote) compactQuoteText(bodyBuilder) else fullQuoteText(bodyBuilder))
         val quoteEnd = builder.length
         if (quoteStart < quoteEnd) {
             builder.setSpan(
@@ -336,11 +345,22 @@ object FireSpannableBuilder {
         ensureBlockBoundary(builder)
     }
 
+    private fun fullQuoteText(value: Spanned): SpannableStringBuilder {
+        val result = SpannableStringBuilder(value)
+        // Collapse triple+ blank lines without truncating content.
+        while (true) {
+            val index = result.indexOf("\n\n\n")
+            if (index < 0) break
+            result.replace(index, index + 3, "\n\n")
+        }
+        return result
+    }
+
     private fun compactQuoteText(value: Spanned): SpannableStringBuilder {
         val ranges = nonBlankLineRanges(value)
         val compact = SpannableStringBuilder()
         val selectedRanges = if (ranges.isNotEmpty()) {
-            ranges.take(QUOTE_PREVIEW_LINE_LIMIT)
+            ranges.take(REPLY_QUOTE_PREVIEW_LINE_LIMIT)
         } else {
             listOfNotNull(trimmedRange(value))
         }
@@ -486,8 +506,8 @@ object FireSpannableBuilder {
 
     private data class TextRange(val start: Int, val end: Int)
 
-    private const val QUOTE_PREVIEW_LINE_LIMIT = 2
-    private const val MAX_QUOTE_PREVIEW_LENGTH = 120
+    private const val REPLY_QUOTE_PREVIEW_LINE_LIMIT = 4
+    private const val MAX_QUOTE_PREVIEW_LENGTH = 220
     private const val QUOTE_ELLIPSIS = "..."
 
     // Emoji placeholder span — replaced with ImageSpan by FireRichTextView

--- a/native/android-app/src/main/java/com/fire/app/session/FireCfClearanceRefreshService.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireCfClearanceRefreshService.kt
@@ -1,0 +1,581 @@
+package com.fire.app.session
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
+import android.webkit.CookieManager
+import android.webkit.JavascriptInterface
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import com.fire.app.FireApplication
+import com.fire.app.ui.webview.FireWebViewSupport
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.HttpURLConnection
+import java.net.URL
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import org.json.JSONObject
+import uniffi.fire_uniffi_session.PlatformCookieState
+import uniffi.fire_uniffi_session.SessionState
+
+/**
+ * Hidden Turnstile runtime that keeps cf_clearance fresh while logged in.
+ *
+ * Mirrors iOS FireCfClearanceRefreshService:
+ * - only runs when scene is active, login is confirmed, and sitekey exists
+ * - intercepts /cdn-cgi/challenge-platform/.../rc/ and completes it natively
+ * - writes accepted clearance through the trusted challenge-completion path
+ * - pauses while a manual challenge WebView is open
+ */
+class FireCfClearanceRefreshService private constructor(
+    context: Context,
+) {
+    private val appContext = context.applicationContext
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val scope = FireApplication.applicationScope()
+
+    @Volatile private var sessionStore: FireSessionStore? = null
+    @Volatile private var session: SessionState? = null
+    @Volatile private var loginStateConfirmed = false
+    @Volatile private var sceneActive = false
+    @Volatile private var manualChallengePauseCount = 0
+    @Volatile private var generation = 0L
+    @Volatile private var consecutiveFailures = 0
+    @Volatile private var activeSitekey: String? = null
+    @Volatile private var activeBaseUrl: String? = null
+    @Volatile private var activeRuntimeToken: String? = null
+    @Volatile private var isCallingRc = false
+
+    private var webView: WebView? = null
+    private var startupJob: Job? = null
+    private var retryJob: Job? = null
+    private var initialTimeoutJob: Job? = null
+    private val started = AtomicBoolean(false)
+
+    fun bind(sessionStore: FireSessionStore) {
+        this.sessionStore = sessionStore
+    }
+
+    fun updateSession(session: SessionState) {
+        this.session = session
+        if (!session.readiness.hasCurrentUser) {
+            loginStateConfirmed = false
+        }
+        reconfigure(reason = "session_update")
+    }
+
+    fun setSceneActive(active: Boolean) {
+        sceneActive = active
+        reconfigure(reason = if (active) "scene_active" else "scene_inactive")
+    }
+
+    fun setLoginStateConfirmed(confirmed: Boolean) {
+        loginStateConfirmed = confirmed
+        reconfigure(reason = if (confirmed) "login_state_confirmed" else "login_state_unconfirmed")
+    }
+
+    fun beginManualChallenge(reason: String) {
+        manualChallengePauseCount += 1
+        stopRuntime(reason)
+    }
+
+    fun endManualChallenge(reason: String) {
+        if (manualChallengePauseCount > 0) {
+            manualChallengePauseCount -= 1
+        }
+        if (manualChallengePauseCount == 0) {
+            reconfigure(reason)
+        }
+    }
+
+    fun noteTurnstileSitekey(sitekey: String?) {
+        val normalized = sitekey?.trim().orEmpty()
+        if (normalized.isEmpty()) return
+        val current = session?.bootstrap?.turnstileSitekey?.trim().orEmpty()
+        if (current.isNotEmpty()) return
+        // Session bootstrap is owned by Rust; keep a local active key so the
+        // runtime can start even when bootstrap lags the challenge body.
+        activeSitekey = normalized
+        reconfigure(reason = "sitekey_from_challenge")
+    }
+
+    private fun reconfigure(reason: String) {
+        if (shouldRun()) {
+            startRuntimeIfNeeded(reason)
+        } else {
+            stopRuntime(reason)
+        }
+    }
+
+    private fun shouldRun(): Boolean {
+        val snapshot = session ?: return false
+        val sitekey = effectiveSitekey(snapshot)
+        return manualChallengePauseCount == 0 &&
+            sceneActive &&
+            loginStateConfirmed &&
+            snapshot.readiness.canReadAuthenticatedApi &&
+            snapshot.readiness.hasCurrentUser &&
+            snapshot.readiness.hasCloudflareClearance &&
+            !sitekey.isNullOrBlank()
+    }
+
+    private fun effectiveSitekey(snapshot: SessionState): String? {
+        val fromBootstrap = snapshot.bootstrap.turnstileSitekey?.trim().orEmpty()
+        if (fromBootstrap.isNotEmpty()) return fromBootstrap
+        return activeSitekey?.trim()?.takeIf { it.isNotEmpty() }
+    }
+
+    private fun startRuntimeIfNeeded(reason: String) {
+        if (!shouldRun()) return
+        if (startupJob?.isActive == true || retryJob?.isActive == true || webView != null) return
+        val snapshot = session ?: return
+        val sitekey = effectiveSitekey(snapshot) ?: return
+        val runtimeToken = UUID.randomUUID().toString()
+        val gen = advanceGeneration()
+        activeSitekey = sitekey
+        activeBaseUrl = snapshot.bootstrap.baseUrl
+        activeRuntimeToken = runtimeToken
+        consecutiveFailures = 0
+        Log.i(TAG, "starting clearance refresh reason=$reason")
+        startupJob = scope.launch(Dispatchers.Main) {
+            try {
+                bootstrapRuntime(sitekey = sitekey, runtimeToken = runtimeToken, generation = gen)
+            } catch (error: Exception) {
+                Log.w(TAG, "startup failed: ${error.message}")
+                handleFailure("startup_failed", gen, runtimeToken)
+            } finally {
+                startupJob = null
+            }
+        }
+    }
+
+    private fun stopRuntime(reason: String) {
+        if (webView == null && startupJob == null && retryJob == null) return
+        cancelRuntime(resetFailures = true)
+        Log.i(TAG, "stopped clearance refresh reason=$reason")
+    }
+
+    private fun cancelRuntime(resetFailures: Boolean) {
+        advanceGeneration()
+        startupJob?.cancel()
+        startupJob = null
+        retryJob?.cancel()
+        retryJob = null
+        initialTimeoutJob?.cancel()
+        initialTimeoutJob = null
+        tearDownWebView()
+        if (resetFailures) {
+            consecutiveFailures = 0
+        }
+        isCallingRc = false
+        started.set(false)
+    }
+
+    private fun advanceGeneration(): Long {
+        generation += 1
+        return generation
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private suspend fun bootstrapRuntime(
+        sitekey: String,
+        runtimeToken: String,
+        generation: Long,
+    ) {
+        if (!isCurrent(generation, runtimeToken)) return
+        val view = ensureWebView(runtimeToken)
+        val html = turnstileHtml(sitekey = sitekey, runtimeToken = runtimeToken)
+        val baseUrl = (session?.bootstrap?.baseUrl ?: "https://linux.do").let {
+            if (it.endsWith("/")) it else "$it/"
+        }
+        withContext(Dispatchers.Main) {
+            view.loadDataWithBaseURL(baseUrl, html, "text/html", "UTF-8", null)
+        }
+        scheduleInitialTimeout(generation, runtimeToken)
+    }
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun ensureWebView(runtimeToken: String): WebView {
+        webView?.let { return it }
+        val view = WebView(appContext)
+        FireWebViewSupport.configureBrowserLikeWebView(view)
+        view.addJavascriptInterface(RcBridge(runtimeToken), JS_BRIDGE)
+        view.webViewClient = object : WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                super.onPageFinished(view, url)
+                injectFetchInterceptor(runtimeToken)
+            }
+        }
+        // Keep off-screen; never attach to a window.
+        view.layout(0, 0, 1, 1)
+        webView = view
+        started.set(true)
+        return view
+    }
+
+    private fun tearDownWebView() {
+        val view = webView ?: return
+        webView = null
+        mainHandler.post {
+            runCatching {
+                view.stopLoading()
+                view.destroy()
+            }
+        }
+    }
+
+    private fun injectFetchInterceptor(runtimeToken: String) {
+        val tokenLiteral = JSONObject.quote(runtimeToken)
+        val script = """
+            (function() {
+              if (window.__fireCfFetchInstalled) { return; }
+              window.__fireCfFetchInstalled = true;
+              window.__fireCfRuntimeToken = $tokenLiteral;
+              var originalFetch = window.fetch ? window.fetch.bind(window) : null;
+              var pendingRc = Object.create(null);
+              var rcId = 0;
+              function parseBody(body) {
+                if (!body) return {};
+                if (typeof body === 'string') {
+                  try { return JSON.parse(body); } catch (e) { return {}; }
+                }
+                return {};
+              }
+              window._resolveRc = function(id, status, body) {
+                var resolve = pendingRc[id];
+                if (!resolve) return;
+                delete pendingRc[id];
+                resolve(new Response(body || '{}', {
+                  status: status,
+                  headers: { 'Content-Type': 'application/json' }
+                }));
+              };
+              if (!originalFetch) return;
+              window.fetch = function(input, init) {
+                var requestURL = typeof input === 'string' ? input : ((input && input.url) || '');
+                if (requestURL.indexOf('/cdn-cgi/challenge-platform/') !== -1 &&
+                    requestURL.indexOf('/rc/') !== -1) {
+                  var id = 'rc_' + (++rcId);
+                  var challengeID = '';
+                  var parts = requestURL.split('/rc/');
+                  if (parts.length > 1) {
+                    challengeID = parts[1].split(/[?#]/)[0];
+                  }
+                  var parsedBody = parseBody(init && init.body);
+                  if (window.FireCfRefresh && window.FireCfRefresh.onRc) {
+                    window.FireCfRefresh.onRc(
+                      id,
+                      challengeID,
+                      parsedBody.secondaryToken || '',
+                      parsedBody.sitekey || '',
+                      window.__fireCfRuntimeToken || ''
+                    );
+                  }
+                  return new Promise(function(resolve) { pendingRc[id] = resolve; });
+                }
+                return originalFetch(input, init);
+              };
+            })();
+        """.trimIndent()
+        webView?.evaluateJavascript(script, null)
+    }
+
+    private fun scheduleInitialTimeout(generation: Long, runtimeToken: String) {
+        initialTimeoutJob?.cancel()
+        initialTimeoutJob = scope.launch {
+            delay(INITIAL_SOLVE_TIMEOUT_MS)
+            if (!isCurrent(generation, runtimeToken)) return@launch
+            handleFailure("initial_timeout", generation, runtimeToken)
+        }
+    }
+
+    private fun handleFailure(reason: String, generation: Long, runtimeToken: String) {
+        if (!isCurrent(generation, runtimeToken)) return
+        consecutiveFailures += 1
+        Log.w(TAG, "refresh failure reason=$reason count=$consecutiveFailures")
+        if (consecutiveFailures >= MAX_FAILURES) {
+            stopRuntime("max_failures")
+            return
+        }
+        cancelRuntime(resetFailures = false)
+        val expectedGeneration = this.generation
+        retryJob = scope.launch {
+            delay(RETRY_DELAY_MS)
+            if (this@FireCfClearanceRefreshService.generation != expectedGeneration) return@launch
+            startRuntimeIfNeeded("retry_after_$reason")
+        }
+    }
+
+    private fun isCurrent(generation: Long, runtimeToken: String): Boolean {
+        return this.generation == generation && activeRuntimeToken == runtimeToken
+    }
+
+    private suspend fun handleRcIntercepted(
+        id: String,
+        challengeId: String,
+        secondaryToken: String,
+        sitekey: String,
+        runtimeToken: String,
+    ) {
+        val generation = this.generation
+        if (!isCurrent(generation, runtimeToken)) return
+        initialTimeoutJob?.cancel()
+        if (isCallingRc) {
+            resolveRc(id, 503, "{}")
+            return
+        }
+        val snapshot = session ?: run {
+            resolveRc(id, 400, "{}")
+            return
+        }
+        val effectiveSitekey = sitekey.trim().ifEmpty { effectiveSitekey(snapshot) }.orEmpty()
+        if (challengeId.isBlank() || effectiveSitekey.isBlank()) {
+            resolveRc(id, 400, "{}")
+            return
+        }
+        val baseUrl = (snapshot.bootstrap.baseUrl.ifBlank { "https://linux.do" }).trimEnd('/')
+        val rcUrl = "$baseUrl/cdn-cgi/challenge-platform/h/g/rc/$challengeId"
+        isCallingRc = true
+        try {
+            val response = withContext(Dispatchers.IO) {
+                postRc(rcUrl, effectiveSitekey, secondaryToken, baseUrl)
+            }
+            if (!isCurrent(generation, runtimeToken)) return
+            resolveRc(id, response.first, response.second)
+            delay(COOKIE_PROPAGATION_DELAY_MS)
+            if (!isCurrent(generation, runtimeToken)) return
+            val store = sessionStore ?: return
+            val previous = snapshot.cookies.cfClearance
+            val cookies = collectPlatformCookies()
+            val fresh = cloudflareClearanceValue(cookies, previous)
+                ?: throw IllegalStateException("missing cf_clearance after rc")
+            val filtered = FireCloudflareChallengeActivity.challengeResultCookies(cookies, fresh)
+            val refreshed = store.completeCloudflareChallenge(
+                cookies = filtered,
+                freshCfClearance = fresh,
+                browserUserAgent = withContext(Dispatchers.Main) {
+                    webView?.settings?.userAgentString
+                },
+            )
+            if (!isCurrent(generation, runtimeToken)) return
+            consecutiveFailures = 0
+            session = refreshed
+            Log.i(TAG, "clearance refresh succeeded")
+        } catch (error: Exception) {
+            Log.w(TAG, "rc call failed: ${error.message}")
+            resolveRc(id, 500, "{}")
+            handleFailure("rc_failed", generation, runtimeToken)
+        } finally {
+            if (isCurrent(generation, runtimeToken)) {
+                isCallingRc = false
+            }
+        }
+    }
+
+    private fun collectPlatformCookies(): List<PlatformCookieState> {
+        val cookieManager = CookieManager.getInstance()
+        val urls = listOf("https://linux.do/", "https://linux.do")
+        val merged = LinkedHashMap<String, PlatformCookieState>()
+        urls.forEach { url ->
+            FireWebViewCookieActionSupport.platformCookies(cookieManager, url)
+                .filter { it.value.isNotBlank() }
+                .forEach { cookie ->
+                    merged.putIfAbsent(
+                        listOf(cookie.name, cookie.value, cookie.domain.orEmpty(), cookie.path.orEmpty())
+                            .joinToString("\u0000"),
+                        cookie,
+                    )
+                }
+        }
+        return merged.values.toList()
+    }
+
+    private fun resolveRc(id: String, status: Int, body: String) {
+        val idLiteral = JSONObject.quote(id)
+        val bodyLiteral = JSONObject.quote(body)
+        val script = "window._resolveRc && window._resolveRc($idLiteral, $status, $bodyLiteral);"
+        mainHandler.post {
+            webView?.evaluateJavascript(script, null)
+        }
+    }
+
+    private fun postRc(
+        rcUrl: String,
+        sitekey: String,
+        secondaryToken: String,
+        origin: String,
+    ): Pair<Int, String> {
+        val connection = (URL(rcUrl).openConnection() as HttpURLConnection).apply {
+            requestMethod = "POST"
+            connectTimeout = 30_000
+            readTimeout = 30_000
+            doOutput = true
+            setRequestProperty("Content-Type", "application/json")
+            setRequestProperty("Origin", origin)
+            setRequestProperty("Referer", if (origin.endsWith("/")) origin else "$origin/")
+            // Attach browser cookies so CF sees the same jar as WebView.
+            val cookieHeader = CookieManager.getInstance().getCookie(origin)
+            if (!cookieHeader.isNullOrBlank()) {
+                setRequestProperty("Cookie", cookieHeader)
+            }
+            instanceFollowRedirects = false
+        }
+        val payload = JSONObject().apply {
+            put("sitekey", sitekey)
+            if (secondaryToken.isNotBlank()) {
+                put("secondaryToken", secondaryToken)
+            }
+        }
+        OutputStreamWriter(connection.outputStream, Charsets.UTF_8).use { writer ->
+            writer.write(payload.toString())
+        }
+        val code = connection.responseCode
+        val stream = if (code in 200..299) connection.inputStream else connection.errorStream
+        val body = stream?.use { input ->
+            BufferedReader(InputStreamReader(input, Charsets.UTF_8)).readText()
+        } ?: "{}"
+        // Mirror Set-Cookie into WebView store.
+        connection.headerFields
+            ?.filterKeys { it.equals("Set-Cookie", ignoreCase = true) }
+            ?.values
+            ?.flatten()
+            ?.forEach { header ->
+                CookieManager.getInstance().setCookie(origin, header)
+            }
+        CookieManager.getInstance().flush()
+        connection.disconnect()
+        return code to body
+    }
+
+    private inner class RcBridge(
+        private val expectedRuntimeToken: String,
+    ) {
+        @JavascriptInterface
+        fun onRc(
+            id: String,
+            challengeId: String,
+            secondaryToken: String,
+            sitekey: String,
+            runtimeToken: String,
+        ) {
+            if (runtimeToken != expectedRuntimeToken && runtimeToken != activeRuntimeToken) {
+                return
+            }
+            scope.launch {
+                handleRcIntercepted(
+                    id = id,
+                    challengeId = challengeId,
+                    secondaryToken = secondaryToken,
+                    sitekey = sitekey,
+                    runtimeToken = runtimeToken.ifBlank { expectedRuntimeToken },
+                )
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "FireCfRefresh"
+        private const val JS_BRIDGE = "FireCfRefresh"
+        private const val INITIAL_SOLVE_TIMEOUT_MS = 30_000L
+        private const val RETRY_DELAY_MS = 2_000L
+        private const val COOKIE_PROPAGATION_DELAY_MS = 500L
+        private const val MAX_FAILURES = 3
+
+        @Volatile
+        private var instance: FireCfClearanceRefreshService? = null
+
+        fun get(context: Context): FireCfClearanceRefreshService {
+            return instance ?: synchronized(this) {
+                instance ?: FireCfClearanceRefreshService(context.applicationContext).also {
+                    instance = it
+                }
+            }
+        }
+
+        fun shouldAutoRefresh(
+            session: SessionState,
+            sceneActive: Boolean,
+            loginStateConfirmed: Boolean,
+        ): Boolean {
+            return sceneActive &&
+                loginStateConfirmed &&
+                session.readiness.canReadAuthenticatedApi &&
+                session.readiness.hasCurrentUser &&
+                session.readiness.hasCloudflareClearance &&
+                !(session.bootstrap.turnstileSitekey.isNullOrBlank())
+        }
+
+        fun cloudflareClearanceValue(
+            cookies: List<PlatformCookieState>,
+            previousValue: String?,
+        ): String? {
+            val values = cookies
+                .filter { it.name.equals("cf_clearance", ignoreCase = true) }
+                .map { it.value.trim() }
+                .filter { it.isNotEmpty() }
+            if (values.isEmpty()) return null
+            val previous = previousValue?.trim().orEmpty()
+            if (previous.isNotEmpty()) {
+                values.firstOrNull { it != previous }?.let { return it }
+            }
+            return values.firstOrNull()
+        }
+
+        fun turnstileHtml(sitekey: String, runtimeToken: String): String {
+            val sitekeyLiteral = JSONObject.quote(sitekey)
+            val runtimeTokenLiteral = JSONObject.quote(runtimeToken)
+            return """
+                <!DOCTYPE html>
+                <html>
+                <head>
+                  <meta charset="utf-8">
+                  <meta name="viewport" content="width=device-width, initial-scale=1">
+                  <style>
+                    html, body { margin:0; padding:0; background:transparent; width:1px; height:1px; overflow:hidden; }
+                    #fire-turnstile { width:1px; height:1px; overflow:hidden; }
+                  </style>
+                  <script>
+                    window.__fireCfRuntimeToken = $runtimeTokenLiteral;
+                    function fireReportTurnstileError(error) {
+                      try {
+                        if (window.FireCfRefresh && window.FireCfRefresh.onRc) {
+                          // Reuse bridge for observability only; empty challenge id is ignored.
+                          console.log('turnstile_error', String(error || ''));
+                        }
+                      } catch (e) {}
+                    }
+                  </script>
+                  <script src="https://challenges.cloudflare.com/turnstile/v0/api.js?onload=fireTurnstileOnLoad" async defer></script>
+                </head>
+                <body>
+                  <div id="fire-turnstile"></div>
+                  <script>
+                    function fireTurnstileOnLoad() {
+                      try {
+                        turnstile.render('#fire-turnstile', {
+                          sitekey: $sitekeyLiteral,
+                          appearance: 'interaction-only',
+                          'refresh-expired': 'auto',
+                          'error-callback': fireReportTurnstileError
+                        });
+                      } catch (error) {
+                        fireReportTurnstileError(error);
+                      }
+                    }
+                  </script>
+                </body>
+                </html>
+            """.trimIndent()
+        }
+    }
+}

--- a/native/android-app/src/main/java/com/fire/app/session/FireClearanceResolvedRepository.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireClearanceResolvedRepository.kt
@@ -1,0 +1,22 @@
+package com.fire.app.session
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import uniffi.fire_uniffi_session.CloudflareClearanceResolvedEventState
+import uniffi.fire_uniffi_session.CloudflareClearanceResolvedHandler
+
+/**
+ * Process-wide bus for Rust Cloudflare clearance-resolved events.
+ * Home / MessageBus / CF banners subscribe here after challenge success.
+ */
+object FireClearanceResolvedRepository : CloudflareClearanceResolvedHandler {
+    private val _events = MutableSharedFlow<CloudflareClearanceResolvedEventState>(
+        extraBufferCapacity = 8,
+    )
+    val events: SharedFlow<CloudflareClearanceResolvedEventState> = _events.asSharedFlow()
+
+    override fun onClearanceResolved(event: CloudflareClearanceResolvedEventState) {
+        _events.tryEmit(event)
+    }
+}

--- a/native/android-app/src/main/java/com/fire/app/session/FireCloudflareChallengeActivity.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireCloudflareChallengeActivity.kt
@@ -254,6 +254,9 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
                   .slice(0, 12000)
                   .toLowerCase();
                 return html.indexOf('cf_chl_opt') !== -1 ||
+                  html.indexOf('cf-turnstile') !== -1 ||
+                  html.indexOf('challenge-running') !== -1 ||
+                  html.indexOf('challenge-stage') !== -1 ||
                   (html.indexOf('challenge-platform') !== -1 && html.indexOf('cloudflare') !== -1) ||
                   title.indexOf('just a moment') !== -1 ||
                   (html.indexOf('just a moment') !== -1 &&

--- a/native/android-app/src/main/java/com/fire/app/session/FireCloudflareChallengeActivity.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireCloudflareChallengeActivity.kt
@@ -35,11 +35,15 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
     private lateinit var targetUrl: String
     private lateinit var webView: WebView
     private lateinit var progressBar: ProgressBar
+    private lateinit var completionOverlay: View
     private var baselineClearance: String? = null
     private var preservedClearanceCookies: List<WebViewCookieInfoState> = emptyList()
     private var completionPollingJob: Job? = null
     private var completionCheckInFlight = false
     private var finishedResult = false
+    /** Once CF UI was observed, bare `/challenge` is treated as post-pass origin fallback. */
+    private var hasSeenActiveChallenge = false
+    private var observedFreshClearance = false
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,6 +58,7 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
         applySystemBarInsets()
         webView = findViewById(R.id.challenge_webview)
         progressBar = findViewById(R.id.challenge_progress)
+        completionOverlay = findViewById(R.id.challenge_completion_overlay)
         findViewById<TextView>(R.id.challenge_close).setOnClickListener {
             finishWithResult(cancelledResult(userCancelled = true))
         }
@@ -70,12 +75,18 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
         webView.webViewClient = object : android.webkit.WebViewClient() {
             override fun onPageFinished(view: WebView, url: String?) {
                 super.onPageFinished(view, url)
+                if (isBareChallengeUrl(url) && (hasSeenActiveChallenge || observedFreshClearance)) {
+                    showCompletionOverlay()
+                }
                 injectChallengeSignalScript()
                 maybeCompleteChallenge()
             }
 
             override fun doUpdateVisitedHistory(view: WebView, url: String?, isReload: Boolean) {
                 super.doUpdateVisitedHistory(view, url, isReload)
+                if (isBareChallengeUrl(url) && (hasSeenActiveChallenge || observedFreshClearance)) {
+                    showCompletionOverlay()
+                }
                 injectChallengeSignalScript()
                 maybeCompleteChallenge()
             }
@@ -99,14 +110,39 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
 
             override fun onPageCommitVisible(view: WebView, url: String?) {
                 super.onPageCommitVisible(view, url)
+                if (isBareChallengeUrl(url) && (hasSeenActiveChallenge || observedFreshClearance)) {
+                    showCompletionOverlay()
+                }
                 injectChallengeSignalScript()
                 maybeCompleteChallenge()
+            }
+
+            override fun onReceivedHttpError(
+                view: WebView,
+                request: WebResourceRequest,
+                errorResponse: WebResourceResponse,
+            ) {
+                super.onReceivedHttpError(view, request, errorResponse)
+                if (request.isForMainFrame &&
+                    isBareChallengeUrl(request.url?.toString()) &&
+                    errorResponse.statusCode == 404
+                ) {
+                    // Source-site 404 on /challenge == CF passed (fluxdo).
+                    showCompletionOverlay()
+                    maybeCompleteChallenge(forceOriginFallback = true)
+                }
             }
 
             override fun shouldOverrideUrlLoading(
                 view: WebView,
                 request: WebResourceRequest,
             ): Boolean {
+                if (request.isForMainFrame &&
+                    isBareChallengeUrl(request.url?.toString()) &&
+                    (hasSeenActiveChallenge || observedFreshClearance)
+                ) {
+                    showCompletionOverlay()
+                }
                 return false
             }
         }
@@ -141,7 +177,7 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
         super.onDestroy()
     }
 
-    private fun maybeCompleteChallenge() {
+    private fun maybeCompleteChallenge(forceOriginFallback: Boolean = false) {
         if (finishedResult || completionCheckInFlight) {
             return
         }
@@ -155,16 +191,33 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
                 if (newClearance.isNullOrBlank() || newClearance == baselineClearance) {
                     return@launch
                 }
-                val stillBlocked = runCatching { challengeStillPresent() }.getOrDefault(true)
-                if (stillBlocked) {
-                    return@launch
+                observedFreshClearance = true
+                val pageState = runCatching { challengePageState() }.getOrDefault(ChallengePageState.ACTIVE)
+                when (pageState) {
+                    ChallengePageState.ACTIVE -> {
+                        hasSeenActiveChallenge = true
+                        if (!forceOriginFallback) return@launch
+                    }
+                    ChallengePageState.ORIGIN_404 -> showCompletionOverlay()
+                    ChallengePageState.PASSED -> {
+                        if (isBareChallengeUrl(withContext(Dispatchers.Main) { webView.url }) ||
+                            hasSeenActiveChallenge ||
+                            forceOriginFallback
+                        ) {
+                            showCompletionOverlay()
+                        }
+                    }
                 }
+                if (forceOriginFallback) {
+                    showCompletionOverlay()
+                }
+                val finalCookies = withContext(Dispatchers.Main) { collectRelevantCookies() }
                 finishWithResult(
                     CloudflareChallengeResultState(
                         completed = true,
                         userCancelled = false,
                         freshCfClearance = newClearance,
-                        cookies = challengeResultCookies(cookies, newClearance),
+                        cookies = challengeResultCookies(finalCookies, newClearance),
                         browserUserAgent = webView.settings.userAgentString,
                     ),
                 )
@@ -244,7 +297,9 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
         )
     }
 
-    private suspend fun challengeStillPresent(): Boolean = withContext(Dispatchers.Main) {
+    private enum class ChallengePageState { ACTIVE, ORIGIN_404, PASSED }
+
+    private suspend fun challengePageState(): ChallengePageState = withContext(Dispatchers.Main) {
         val result = webView.evaluateJavascriptSuspend(
             """
             (function() {
@@ -253,6 +308,19 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
                 var html = ((document.documentElement && document.documentElement.outerHTML) || '')
                   .slice(0, 12000)
                   .toLowerCase();
+                // Origin 404 / non-challenge Discourse pages are post-pass fallback.
+                var originNotFound =
+                  html.indexOf('page-not-found') !== -1 ||
+                  html.indexOf('discourse-no-results') !== -1 ||
+                  html.indexOf('"errortype":"notfound"') !== -1 ||
+                  html.indexOf('404-body') !== -1 ||
+                  html.indexOf('exist or is private') !== -1 ||
+                  html.indexOf('page you requested') !== -1 ||
+                  title.indexOf('page not found') !== -1 ||
+                  title.indexOf('oops') !== -1;
+                if (originNotFound) {
+                  return 'origin_404';
+                }
                 var active = html.indexOf('cf_chl_opt') !== -1 ||
                   html.indexOf('cf-turnstile') !== -1 ||
                   html.indexOf('challenge-running') !== -1 ||
@@ -261,25 +329,34 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
                   title.indexOf('just a moment') !== -1 ||
                   (html.indexOf('just a moment') !== -1 &&
                     (html.indexOf('cloudflare') !== -1 || html.indexOf('cf-challenge') !== -1));
-                // Origin 404 / non-challenge Discourse pages are not active shields.
-                var originNotFound =
-                  html.indexOf('page-not-found') !== -1 ||
-                  html.indexOf('discourse-no-results') !== -1 ||
-                  html.indexOf('"errortype":"notfound"') !== -1 ||
-                  html.indexOf('404-body') !== -1 ||
-                  html.indexOf('exist or is private') !== -1 ||
-                  html.indexOf('page you requested') !== -1;
-                if (originNotFound) {
-                  return false;
-                }
-                return active;
+                return active ? 'active' : 'passed';
               } catch (error) {
-                return true;
+                return 'active';
               }
             })();
             """.trimIndent(),
         )
-        result == "true"
+        when (result.trim('"').lowercase()) {
+            "origin_404" -> ChallengePageState.ORIGIN_404
+            "passed" -> ChallengePageState.PASSED
+            else -> ChallengePageState.ACTIVE
+        }
+    }
+
+    private fun showCompletionOverlay() {
+        if (!::completionOverlay.isInitialized) return
+        runOnUiThread {
+            completionOverlay.visibility = View.VISIBLE
+        }
+    }
+
+    private fun isBareChallengeUrl(url: String?): Boolean {
+        if (url.isNullOrBlank()) return false
+        val uri = runCatching { android.net.Uri.parse(url) }.getOrNull() ?: return false
+        val host = uri.host?.lowercase().orEmpty()
+        if (!host.contains("linux.do")) return false
+        val path = uri.path?.trim('/')?.lowercase().orEmpty()
+        return path == "challenge" && uri.query.isNullOrEmpty()
     }
 
     private fun collectRelevantCookies(): List<PlatformCookieState> {

--- a/native/android-app/src/main/java/com/fire/app/session/FireCloudflareChallengeActivity.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireCloudflareChallengeActivity.kt
@@ -253,7 +253,7 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
                 var html = ((document.documentElement && document.documentElement.outerHTML) || '')
                   .slice(0, 12000)
                   .toLowerCase();
-                return html.indexOf('cf_chl_opt') !== -1 ||
+                var active = html.indexOf('cf_chl_opt') !== -1 ||
                   html.indexOf('cf-turnstile') !== -1 ||
                   html.indexOf('challenge-running') !== -1 ||
                   html.indexOf('challenge-stage') !== -1 ||
@@ -261,6 +261,18 @@ class FireCloudflareChallengeActivity : ComponentActivity() {
                   title.indexOf('just a moment') !== -1 ||
                   (html.indexOf('just a moment') !== -1 &&
                     (html.indexOf('cloudflare') !== -1 || html.indexOf('cf-challenge') !== -1));
+                // Origin 404 / non-challenge Discourse pages are not active shields.
+                var originNotFound =
+                  html.indexOf('page-not-found') !== -1 ||
+                  html.indexOf('discourse-no-results') !== -1 ||
+                  html.indexOf('"errortype":"notfound"') !== -1 ||
+                  html.indexOf('404-body') !== -1 ||
+                  html.indexOf('exist or is private') !== -1 ||
+                  html.indexOf('page you requested') !== -1;
+                if (originNotFound) {
+                  return false;
+                }
+                return active;
               } catch (error) {
                 return true;
               }

--- a/native/android-app/src/main/java/com/fire/app/session/FireCloudflareChallengeCoordinator.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireCloudflareChallengeCoordinator.kt
@@ -35,6 +35,17 @@ class FireCloudflareChallengeCoordinator(
             return cancelledResult(userCancelled = false)
         }
 
+        FireCfClearanceRefreshService.get(context).beginManualChallenge("manual_challenge_start")
+        try {
+            return presentChallenge(request)
+        } finally {
+            FireCfClearanceRefreshService.get(context).endManualChallenge("manual_challenge_end")
+        }
+    }
+
+    private fun presentChallenge(
+        request: CloudflareChallengeRequestState,
+    ): CloudflareChallengeResultState {
         val token = UUID.randomUUID().toString()
         val pending = PendingChallenge()
         PendingChallenges.register(token, pending)

--- a/native/android-app/src/main/java/com/fire/app/session/FireCloudflareChallengeCoordinator.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireCloudflareChallengeCoordinator.kt
@@ -29,6 +29,12 @@ class FireCloudflareChallengeCoordinator(
     fun completeSynchronously(
         request: CloudflareChallengeRequestState,
     ): CloudflareChallengeResultState {
+        // Background/silent traffic must not steal focus. Rust only starts a new
+        // challenge for foreground requests; keep a host-side defensive gate.
+        if (!request.isForeground) {
+            return cancelledResult(userCancelled = false)
+        }
+
         val token = UUID.randomUUID().toString()
         val pending = PendingChallenge()
         PendingChallenges.register(token, pending)

--- a/native/android-app/src/main/java/com/fire/app/session/FireCloudflareRecovery.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireCloudflareRecovery.kt
@@ -1,0 +1,126 @@
+package com.fire.app.session
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import uniffi.fire_uniffi_session.CloudflareChallengeRequestState
+import uniffi.fire_uniffi_types.FireUniFfiException
+
+object FireCloudflareRecovery {
+    suspend fun <T> perform(
+        context: Context,
+        sessionStore: FireSessionStore,
+        operation: String,
+        originUrl: String = "https://linux.do/",
+        work: suspend () -> T,
+    ): T {
+        return try {
+            work()
+        } catch (error: Exception) {
+            if (!isCloudflareChallenge(error)) {
+                throw error
+            }
+            val recovered = completeManualVerification(
+                context = context,
+                sessionStore = sessionStore,
+                operation = operation,
+                originUrl = originUrl,
+            )
+            if (!recovered) {
+                throw error
+            }
+            work()
+        }
+    }
+
+    suspend fun completeManualVerification(
+        context: Context,
+        sessionStore: FireSessionStore,
+        operation: String = "manual.verify",
+        originUrl: String = "https://linux.do/",
+    ): Boolean = withContext(Dispatchers.IO) {
+        val epoch = runCatching { sessionStore.currentSessionEpoch() }.getOrDefault(0u)
+        val result = FireCloudflareChallengeCoordinator(context.applicationContext)
+            .completeSynchronously(
+                CloudflareChallengeRequestState(
+                    operation = operation,
+                    requestUrl = originUrl,
+                    originUrl = originUrl,
+                    isForeground = true,
+                    sessionEpoch = epoch,
+                ),
+            )
+        val fresh = result.freshCfClearance?.trim().orEmpty()
+        if (!result.completed || result.userCancelled || fresh.isEmpty()) {
+            return@withContext false
+        }
+        val session = sessionStore.completeCloudflareChallenge(
+            cookies = result.cookies,
+            freshCfClearance = fresh,
+            browserUserAgent = result.browserUserAgent,
+        )
+        val accepted = session.cookies.cfClearance == fresh
+        if (accepted) {
+            FireCfClearanceRefreshService.get(context).setLoginStateConfirmed(
+                session.readiness.hasCurrentUser && session.readiness.canReadAuthenticatedApi,
+            )
+            FireCfClearanceRefreshService.get(context).updateSession(session)
+        }
+        accepted
+    }
+
+    fun isCloudflareChallenge(error: Throwable?): Boolean {
+        var current = error
+        while (current != null) {
+            when (current) {
+                is FireUniFfiException.CloudflareChallenge -> return true
+                is FireUniFfiException.HttpStatus -> {
+                    if (current.status.toInt() in setOf(403, 429) &&
+                        current.body.contains("Just a moment", ignoreCase = true)
+                    ) {
+                        return true
+                    }
+                }
+            }
+            val message = current.message.orEmpty()
+            if (message.contains("Cloudflare challenge", ignoreCase = true) ||
+                message.contains("cloudflare challenge", ignoreCase = true)
+            ) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
+    }
+
+    fun reason(error: Throwable?): String {
+        var current = error
+        while (current != null) {
+            val message = current.message.orEmpty()
+            for (token in REASONS) {
+                if (message.contains("($token)") || message.endsWith(token)) {
+                    return token
+                }
+            }
+            // Future UniFFI shape: CloudflareChallenge(reason=...)
+            if (current is FireUniFfiException.CloudflareChallenge) {
+                runCatching {
+                    val field = current.javaClass.getDeclaredField("reason")
+                    field.isAccessible = true
+                    (field.get(current) as? String)?.trim()?.takeIf { it.isNotEmpty() }
+                }.getOrNull()?.let { return it }
+            }
+            current = current.cause
+        }
+        return "required"
+    }
+
+    private val REASONS = listOf(
+        "in_progress",
+        "cooldown",
+        "cancelled",
+        "failed",
+        "background_suppressed",
+        "required",
+    )
+}

--- a/native/android-app/src/main/java/com/fire/app/session/FireCloudflareRecovery.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireCloudflareRecovery.kt
@@ -96,19 +96,17 @@ object FireCloudflareRecovery {
     fun reason(error: Throwable?): String {
         var current = error
         while (current != null) {
-            val message = current.message.orEmpty()
-            for (token in REASONS) {
-                if (message.contains("($token)") || message.endsWith(token)) {
-                    return token
+            if (current is FireUniFfiException.CloudflareChallenge) {
+                val reason = current.reason.trim()
+                if (reason.isNotEmpty()) {
+                    return reason
                 }
             }
-            // Future UniFFI shape: CloudflareChallenge(reason=...)
-            if (current is FireUniFfiException.CloudflareChallenge) {
-                runCatching {
-                    val field = current.javaClass.getDeclaredField("reason")
-                    field.isAccessible = true
-                    (field.get(current) as? String)?.trim()?.takeIf { it.isNotEmpty() }
-                }.getOrNull()?.let { return it }
+            val message = current.message.orEmpty()
+            for (token in REASONS) {
+                if (message.contains("($token)") || message.contains(token)) {
+                    return token
+                }
             }
             current = current.cause
         }

--- a/native/android-app/src/main/java/com/fire/app/session/FireLoginScripts.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireLoginScripts.kt
@@ -132,6 +132,34 @@ object FireLoginScripts {
 
     const val readPreloadedData = "(function(){return window.__rawPreloaded||null;})()"
 
+    const val hasActiveCloudflareChallenge = """
+        (function() {
+          try {
+            var title = (document.title || '').toLowerCase();
+            var html = ((document.documentElement && document.documentElement.outerHTML) || '')
+              .slice(0, 12000)
+              .toLowerCase();
+            var active = html.indexOf('cf_chl_opt') !== -1 ||
+              html.indexOf('cf-turnstile') !== -1 ||
+              html.indexOf('challenge-running') !== -1 ||
+              html.indexOf('challenge-stage') !== -1 ||
+              (html.indexOf('challenge-platform') !== -1 && html.indexOf('cloudflare') !== -1) ||
+              title.indexOf('just a moment') !== -1 ||
+              (html.indexOf('just a moment') !== -1 &&
+                (html.indexOf('cloudflare') !== -1 || html.indexOf('cf-challenge') !== -1));
+            var originNotFound =
+              html.indexOf('page-not-found') !== -1 ||
+              html.indexOf('discourse-no-results') !== -1 ||
+              html.indexOf('"errortype":"notfound"') !== -1 ||
+              html.indexOf('404-body') !== -1;
+            if (originNotFound) return false;
+            return active;
+          } catch (error) {
+            return false;
+          }
+        })();
+    """
+
     fun minimalLoginDocument(
         hcaptchaSiteKey: String,
         hcaptchaCreateEndpoint: String? = null,

--- a/native/android-app/src/main/java/com/fire/app/session/FireSessionStore.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireSessionStore.kt
@@ -201,6 +201,20 @@ class FireSessionStore(
         state
     }
 
+    suspend fun cloudflareClearanceIsTrusted(): Boolean = withContext(Dispatchers.Default) {
+        core.session().cloudflareClearanceIsTrusted()
+    }
+
+    suspend fun noteCloudflareClearanceRejected() = withContext(Dispatchers.Default) {
+        core.session().noteCloudflareClearanceRejected()
+    }
+
+    suspend fun finalizeLoginReady(): SessionState = withContext(Dispatchers.Default) {
+        val state = core.session().finalizeLoginReady()
+        persistCurrentSession()
+        state
+    }
+
     suspend fun classifyWebViewLoginResult(
         result: WebViewLoginJsResultState,
     ): WebViewLoginDecisionState = withContext(Dispatchers.Default) {

--- a/native/android-app/src/main/java/com/fire/app/session/FireSessionStore.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireSessionStore.kt
@@ -105,6 +105,10 @@ class FireSessionStore(
         core.session().snapshot()
     }
 
+    suspend fun currentSessionEpoch(): ULong = withContext(Dispatchers.Default) {
+        core.session().sessionEpoch()
+    }
+
     fun registerCloudflareChallengeHandler(handler: CloudflareChallengeHandler) {
         core.session().registerCloudflareChallengeHandler(handler)
     }

--- a/native/android-app/src/main/java/com/fire/app/session/FireSessionStore.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireSessionStore.kt
@@ -31,6 +31,7 @@ import uniffi.fire_uniffi_search.UserMentionQueryState
 import uniffi.fire_uniffi_search.UserMentionResultState
 import uniffi.fire_uniffi_session.AppStateRefreshHandler
 import uniffi.fire_uniffi_session.CloudflareChallengeHandler
+import uniffi.fire_uniffi_session.CloudflareClearanceResolvedHandler
 import uniffi.fire_uniffi_session.CookieSelfHealingHandler
 import uniffi.fire_uniffi_session.CookieReplayEntryState
 import uniffi.fire_uniffi_session.CookieSweepPlanState
@@ -115,6 +116,18 @@ class FireSessionStore(
 
     fun unregisterCloudflareChallengeHandler() {
         core.session().unregisterCloudflareChallengeHandler()
+    }
+
+    fun registerCloudflareClearanceResolvedHandler(handler: CloudflareClearanceResolvedHandler) {
+        core.session().registerCloudflareClearanceResolvedHandler(handler)
+    }
+
+    fun unregisterCloudflareClearanceResolvedHandler() {
+        core.session().unregisterCloudflareClearanceResolvedHandler()
+    }
+
+    fun cloudflareClearanceResolvedGeneration(): ULong {
+        return core.session().cloudflareClearanceResolvedGeneration()
     }
 
     fun registerCookieSelfHealingHandler(handler: CookieSelfHealingHandler) {

--- a/native/android-app/src/main/java/com/fire/app/session/FireSessionStoreRepository.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireSessionStoreRepository.kt
@@ -38,6 +38,7 @@ object FireSessionStoreRepository {
                     )
                 }
                 challengeHandler?.let(store::registerCloudflareChallengeHandler)
+                store.registerCloudflareClearanceResolvedHandler(FireClearanceResolvedRepository)
                 if (cookieSelfHealingHandler == null) {
                     cookieSelfHealingHandler = FireCookieSelfHealingRuntimeHandler(store)
                 }

--- a/native/android-app/src/main/java/com/fire/app/session/FireSessionStoreRepository.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireSessionStoreRepository.kt
@@ -45,8 +45,8 @@ object FireSessionStoreRepository {
                 cookieSelfHealingHandler?.let(store::registerCookieSelfHealingHandler)
                 val refresh = FireCfClearanceRefreshService.get(context.applicationContext)
                 refresh.bind(store)
-                runCatching { store.snapshot() }
-                    .onSuccess(refresh::updateSession)
+                // snapshot() is suspend; callers (e.g. MainActivity / login) update
+                // the refresh service after awaiting get() on a coroutine path.
                 shared = store
                 Log.d(TAG, "session store get cold_create=true session_store_get_ms=${SystemClock.elapsedRealtime() - startedAt}")
             }

--- a/native/android-app/src/main/java/com/fire/app/session/FireSessionStoreRepository.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireSessionStoreRepository.kt
@@ -42,6 +42,10 @@ object FireSessionStoreRepository {
                     cookieSelfHealingHandler = FireCookieSelfHealingRuntimeHandler(store)
                 }
                 cookieSelfHealingHandler?.let(store::registerCookieSelfHealingHandler)
+                val refresh = FireCfClearanceRefreshService.get(context.applicationContext)
+                refresh.bind(store)
+                runCatching { store.snapshot() }
+                    .onSuccess(refresh::updateSession)
                 shared = store
                 Log.d(TAG, "session store get cold_create=true session_store_get_ms=${SystemClock.elapsedRealtime() - startedAt}")
             }

--- a/native/android-app/src/main/java/com/fire/app/session/FireStateObserverRepository.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireStateObserverRepository.kt
@@ -1,5 +1,6 @@
 package com.fire.app.session
 
+import com.fire.app.FireApplication
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -34,6 +35,9 @@ object FireStateObserverRepository : StateObserver {
 
     override fun onSessionSnapshot(snapshot: SessionState) {
         _sessionSnapshots.tryEmit(snapshot)
+        runCatching {
+            FireCfClearanceRefreshService.get(FireApplication.getInstance()).updateSession(snapshot)
+        }
     }
 
     override fun onTopicListSnapshot(snapshot: TopicListState) {

--- a/native/android-app/src/main/java/com/fire/app/session/FireWebViewLoginCoordinator.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireWebViewLoginCoordinator.kt
@@ -264,8 +264,10 @@ class FireWebViewLoginCoordinator(
         val hasAuthCookies = containsActiveAuthCookies(cookies)
         val hasBootstrapHtml =
             preferredBootstrapScore >= FireBootstrapHtmlHeuristics.REUSABLE_LOGIN_BOOTSTRAP_SCORE_THRESHOLD
+        // Align with fluxdo OAuth completion: username + session cookies are enough
+        // to finalize. Bootstrap HTML can be refreshed after cookie handoff.
         return FireLoginSyncReadiness(
-            isReady = normalizedUsername != null && hasAuthCookies && hasBootstrapHtml,
+            isReady = normalizedUsername != null && hasAuthCookies,
             username = normalizedUsername,
             hasAuthCookies = hasAuthCookies,
             hasBootstrapHtml = hasBootstrapHtml,

--- a/native/android-app/src/main/java/com/fire/app/session/FireWebViewLoginCoordinator.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireWebViewLoginCoordinator.kt
@@ -51,11 +51,11 @@ class FireWebViewLoginCoordinator(
             captured = captured,
             allowLowConfidenceSessionCookies = false,
         )
-        if (finalization.session.loginPhase == LoginPhaseState.READY) {
+        if (!finalization.success && finalization.session.cookies.tToken.isNullOrBlank()) {
             return finalization.session
         }
-
-        return sessionStore.refreshBootstrapIfNeeded()
+        // fluxdo LoginReady: bootstrap with timeout, never block home once cookies exist.
+        return sessionStore.finalizeLoginReady()
     }
 
     suspend fun completeJsLogin(webView: WebView, identifier: String): SessionState =

--- a/native/android-app/src/main/java/com/fire/app/ui/auth/LoginWebViewFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/auth/LoginWebViewFragment.kt
@@ -123,7 +123,7 @@ class LoginWebViewFragment : Fragment() {
                 loadingIndicator.isVisible = false
                 updateChrome(webView, pageTitleText, pageUrlText)
                 // Google/OAuth return lands here without the password JS bridge.
-                maybeFinalizeExternalLogin(webView)
+                maybeRecoverActiveCloudflareOrFinalizeExternalLogin(webView)
             }
 
             override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {

--- a/native/android-app/src/main/java/com/fire/app/ui/auth/LoginWebViewFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/auth/LoginWebViewFragment.kt
@@ -39,7 +39,9 @@ import com.fire.app.session.FireWebViewLoginCoordinator
 import com.fire.app.ui.webview.FireWebViewSupport
 import com.google.android.material.button.MaterialButton
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
@@ -59,6 +61,7 @@ class LoginWebViewFragment : Fragment() {
     private var lastLoginHcaptchaToken: String? = null
     private var lastLoginSecondFactorToken: String? = null
     private var cfRetryUsed = false
+    private var oauthPollJob: Job? = null
 
     private val loginBaseUrl = "https://linux.do"
 
@@ -89,6 +92,7 @@ class LoginWebViewFragment : Fragment() {
 
             configureLoginWebView(webView)
             webView.addJavascriptInterface(FireLoginJsInterface(this@LoginWebViewFragment), "Android")
+            startExternalLoginPolling(webView)
 
             identifierInput.setText(credential?.username.orEmpty())
             passwordInput.setText(credential?.password.orEmpty())
@@ -114,6 +118,8 @@ class LoginWebViewFragment : Fragment() {
                 super.onPageFinished(view, url)
                 loadingIndicator.isVisible = false
                 updateChrome(webView, pageTitleText, pageUrlText)
+                // Google/OAuth return lands here without the password JS bridge.
+                maybeFinalizeExternalLogin(webView)
             }
 
             override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
@@ -212,6 +218,8 @@ class LoginWebViewFragment : Fragment() {
     }
 
     override fun onDestroyView() {
+        oauthPollJob?.cancel()
+        oauthPollJob = null
         val webView = view?.findViewById<WebView>(R.id.login_webview)
         webView?.destroy()
         super.onDestroyView()
@@ -507,6 +515,74 @@ class LoginWebViewFragment : Fragment() {
                 syncButton = syncButton,
                 isCloudflareRetry = true,
             )
+        }
+    }
+
+    private fun startExternalLoginPolling(webView: WebView) {
+        oauthPollJob?.cancel()
+        oauthPollJob = viewLifecycleOwner.lifecycleScope.launch {
+            while (isActive) {
+                delay(1_000)
+                if (!isCompletingLogin) {
+                    maybeFinalizeExternalLogin(webView)
+                }
+            }
+        }
+    }
+
+    private fun maybeFinalizeExternalLogin(webView: WebView) {
+        if (isCompletingLogin || !isAdded) return
+        val coordinator = loginCoordinator ?: return
+        val sessionStore = sessionStore ?: return
+        viewLifecycleOwner.lifecycleScope.launch {
+            if (isCompletingLogin) return@launch
+            val readiness = runCatching {
+                coordinator.probeLoginSyncReadiness(webView)
+            }.getOrNull() ?: return@launch
+            if (!readiness.isReady) return@launch
+            completeExternalLoginAndNavigate(webView, readiness.username)
+        }
+    }
+
+    private fun completeExternalLoginAndNavigate(webView: WebView, username: String?) {
+        if (isCompletingLogin) return
+        val sessionStore = requireNotNull(sessionStore)
+        val coordinator = loginCoordinator ?: return
+        isCompletingLogin = true
+        view?.findViewById<MaterialButton>(R.id.sync_button)?.isEnabled = false
+        viewLifecycleOwner.lifecycleScope.launchWithFireErrorHandling(
+            operation = "login_webview.complete_external_login",
+            sessionStore = sessionStore,
+            fallbackMessage = getString(R.string.login_sync_error),
+            onError = { error ->
+                isCompletingLogin = false
+                val identifierInput = view?.findViewById<EditText>(R.id.login_identifier_input)
+                val passwordInput = view?.findViewById<EditText>(R.id.login_password_input)
+                val syncButton = view?.findViewById<MaterialButton>(R.id.sync_button)
+                if (identifierInput != null && passwordInput != null && syncButton != null) {
+                    syncButton.isEnabled = hasEnteredCredentials(identifierInput, passwordInput)
+                }
+                Toast.makeText(requireContext(), error.displayMessage, Toast.LENGTH_SHORT).show()
+            },
+        ) {
+            // Prefer full WebView capture (username from page/meta) so OAuth works
+            // without typed password credentials.
+            if (!username.isNullOrBlank()) {
+                coordinator.completeJsLogin(webView, username)
+            } else {
+                coordinator.completeLogin(webView)
+            }
+            val snapshot = sessionStore.snapshot()
+            val refresh = com.fire.app.session.FireCfClearanceRefreshService.get(requireContext())
+            refresh.bind(sessionStore)
+            refresh.updateSession(snapshot)
+            refresh.setLoginStateConfirmed(true)
+            refresh.setSceneActive(true)
+            sessionStore.triggerAppStateRefresh(
+                RefreshTriggerState.LOGIN_COMPLETED,
+                FireAppStateRefreshRepository,
+            )
+            navigateHome()
         }
     }
 

--- a/native/android-app/src/main/java/com/fire/app/ui/auth/LoginWebViewFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/auth/LoginWebViewFragment.kt
@@ -530,6 +530,12 @@ class LoginWebViewFragment : Fragment() {
             coordinator.completeJsLogin(webView, identifier)
             FireCredentialStore.save(requireContext(), identifier, password)
             credential = FireCredentialStore.load(requireContext())
+            val snapshot = sessionStore.snapshot()
+            val refresh = com.fire.app.session.FireCfClearanceRefreshService.get(requireContext())
+            refresh.bind(sessionStore)
+            refresh.updateSession(snapshot)
+            refresh.setLoginStateConfirmed(true)
+            refresh.setSceneActive(true)
             sessionStore.triggerAppStateRefresh(
                 RefreshTriggerState.LOGIN_COMPLETED,
                 FireAppStateRefreshRepository,

--- a/native/android-app/src/main/java/com/fire/app/ui/auth/LoginWebViewFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/auth/LoginWebViewFragment.kt
@@ -38,11 +38,13 @@ import com.fire.app.session.FireSessionStoreRepository
 import com.fire.app.session.FireWebViewLoginCoordinator
 import com.fire.app.ui.webview.FireWebViewSupport
 import com.google.android.material.button.MaterialButton
+import kotlin.coroutines.resume
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import org.json.JSONObject
 import uniffi.fire_uniffi_session.CloudflareChallengeRequestState
@@ -259,7 +261,8 @@ class LoginWebViewFragment : Fragment() {
     }
 
     private suspend fun ensureCloudflareClearanceForLogin(sessionStore: FireSessionStore) {
-        if (sessionStore.snapshot().readiness.hasCloudflareClearance) {
+        // Skip only when clearance is present and not recently rejected by CF.
+        if (sessionStore.cloudflareClearanceIsTrusted()) {
             return
         }
         val result = withContext(Dispatchers.IO) {
@@ -536,6 +539,20 @@ class LoginWebViewFragment : Fragment() {
         val sessionStore = sessionStore ?: return
         viewLifecycleOwner.lifecycleScope.launch {
             if (isCompletingLogin) return@launch
+            val activeCf = runCatching {
+                withContext(Dispatchers.Main) {
+                    webView.evaluateJavascriptSuspend(FireLoginScripts.hasActiveCloudflareChallenge)
+                }
+            }.getOrNull()
+            if (activeCf == "true") {
+                runCatching {
+                    ensureCloudflareClearanceForLogin(sessionStore)
+                    withContext(Dispatchers.Main) {
+                        webView.loadUrl("$loginBaseUrl/")
+                    }
+                }
+                return@launch
+            }
             val readiness = runCatching {
                 coordinator.probeLoginSyncReadiness(webView)
             }.getOrNull() ?: return@launch
@@ -627,6 +644,13 @@ class LoginWebViewFragment : Fragment() {
         isCompletingLogin = false
         findNavController().navigate(R.id.action_loginWebView_to_home)
     }
+
+    private suspend fun WebView.evaluateJavascriptSuspend(script: String): String =
+        suspendCancellableCoroutine { continuation ->
+            evaluateJavascript(script) { value ->
+                continuation.resume(value ?: "null")
+            }
+        }
 
     private fun updateChrome(
         webView: WebView,

--- a/native/android-app/src/main/java/com/fire/app/ui/auth/LoginWebViewFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/auth/LoginWebViewFragment.kt
@@ -26,6 +26,7 @@ import androidx.webkit.SafeBrowsingResponseCompat
 import androidx.webkit.WebResourceErrorCompat
 import androidx.webkit.WebViewClientCompat
 import androidx.webkit.WebViewFeature
+import com.fire.app.FireApplication
 import com.fire.app.R
 import com.fire.app.core.error.launchWithFireErrorHandling
 import com.fire.app.session.FireAppStateRefreshRepository
@@ -94,7 +95,8 @@ class LoginWebViewFragment : Fragment() {
 
             configureLoginWebView(webView)
             webView.addJavascriptInterface(FireLoginJsInterface(this@LoginWebViewFragment), "Android")
-            startExternalLoginPolling(webView)
+            // Poll OAuth readiness and active CF interstitials for password + OAuth.
+            startLoginSurfacePolling(webView)
 
             identifierInput.setText(credential?.username.orEmpty())
             passwordInput.setText(credential?.password.orEmpty())
@@ -447,7 +449,7 @@ class LoginWebViewFragment : Fragment() {
             syncButton.isEnabled = true
             Toast.makeText(
                 requireContext(),
-                R.string.login_cloudflare_retry_failed,
+                loginCloudflareFailureMessage(null),
                 Toast.LENGTH_LONG,
             ).show()
             return
@@ -484,9 +486,13 @@ class LoginWebViewFragment : Fragment() {
             if (!result.completed) {
                 isCompletingLogin = false
                 syncButton.isEnabled = true
+                val reason = when {
+                    result.userCancelled -> "cancelled"
+                    else -> "failed"
+                }
                 Toast.makeText(
                     requireContext(),
-                    R.string.login_cloudflare_retry_failed,
+                    loginCloudflareFailureMessage(reason),
                     Toast.LENGTH_LONG,
                 ).show()
                 return@launchWithFireErrorHandling
@@ -497,7 +503,7 @@ class LoginWebViewFragment : Fragment() {
                 syncButton.isEnabled = true
                 Toast.makeText(
                     requireContext(),
-                    R.string.login_cloudflare_retry_failed,
+                    loginCloudflareFailureMessage("failed"),
                     Toast.LENGTH_LONG,
                 ).show()
                 return@launchWithFireErrorHandling
@@ -521,19 +527,19 @@ class LoginWebViewFragment : Fragment() {
         }
     }
 
-    private fun startExternalLoginPolling(webView: WebView) {
+    private fun startLoginSurfacePolling(webView: WebView) {
         oauthPollJob?.cancel()
         oauthPollJob = viewLifecycleOwner.lifecycleScope.launch {
             while (isActive) {
                 delay(1_000)
                 if (!isCompletingLogin) {
-                    maybeFinalizeExternalLogin(webView)
+                    maybeRecoverActiveCloudflareOrFinalizeExternalLogin(webView)
                 }
             }
         }
     }
 
-    private fun maybeFinalizeExternalLogin(webView: WebView) {
+    private fun maybeRecoverActiveCloudflareOrFinalizeExternalLogin(webView: WebView) {
         if (isCompletingLogin || !isAdded) return
         val coordinator = loginCoordinator ?: return
         val sessionStore = sessionStore ?: return
@@ -595,10 +601,16 @@ class LoginWebViewFragment : Fragment() {
             refresh.updateSession(snapshot)
             refresh.setLoginStateConfirmed(true)
             refresh.setSceneActive(true)
-            sessionStore.triggerAppStateRefresh(
-                RefreshTriggerState.LOGIN_COMPLETED,
-                FireAppStateRefreshRepository,
-            )
+            // fluxdo finally: trusted cookies are enough to enter home.
+            // Refresh on app scope so navigation cannot cancel it.
+            FireApplication.applicationScope().launch {
+                runCatching {
+                    sessionStore.triggerAppStateRefresh(
+                        RefreshTriggerState.LOGIN_COMPLETED,
+                        FireAppStateRefreshRepository,
+                    )
+                }
+            }
             navigateHome()
         }
     }
@@ -629,10 +641,16 @@ class LoginWebViewFragment : Fragment() {
             refresh.updateSession(snapshot)
             refresh.setLoginStateConfirmed(true)
             refresh.setSceneActive(true)
-            sessionStore.triggerAppStateRefresh(
-                RefreshTriggerState.LOGIN_COMPLETED,
-                FireAppStateRefreshRepository,
-            )
+            // fluxdo finally: trusted cookies are enough to enter home.
+            // Refresh on app scope so navigation cannot cancel it.
+            FireApplication.applicationScope().launch {
+                runCatching {
+                    sessionStore.triggerAppStateRefresh(
+                        RefreshTriggerState.LOGIN_COMPLETED,
+                        FireAppStateRefreshRepository,
+                    )
+                }
+            }
             navigateHome()
         }
     }
@@ -643,6 +661,15 @@ class LoginWebViewFragment : Fragment() {
         }
         isCompletingLogin = false
         findNavController().navigate(R.id.action_loginWebView_to_home)
+    }
+
+    private fun loginCloudflareFailureMessage(reason: String?): String {
+        return when (reason?.trim()?.lowercase()) {
+            "cooldown" -> getString(R.string.login_cloudflare_cooldown)
+            "cancelled" -> getString(R.string.login_cloudflare_cancelled)
+            "in_progress" -> getString(R.string.login_cloudflare_in_progress)
+            else -> getString(R.string.login_cloudflare_retry_failed)
+        }
     }
 
     private suspend fun WebView.evaluateJavascriptSuspend(script: String): String =

--- a/native/android-app/src/main/java/com/fire/app/ui/home/HomeFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/home/HomeFragment.kt
@@ -18,7 +18,10 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.fire.app.R
+import com.fire.app.core.error.FireErrorClassifier
 import com.fire.app.core.ext.optimizeForPaging
+import com.fire.app.core.ui.FireToast
+import com.fire.app.session.FireCloudflareRecovery
 import com.fire.app.session.FireSessionStore
 import com.fire.app.session.FireSessionStoreRepository
 import com.fire.app.ui.composer.TopicComposerSheet
@@ -112,15 +115,32 @@ class HomeFragment : Fragment() {
                 }
                 emptyView.visibility = when {
                     refresh is LoadState.Error -> {
-                        emptyView.text = refresh.error.localizedMessage
-                            ?: getString(R.string.browser_empty)
+                        val isCloudflare = FireErrorClassifier.isCloudflareChallenge(refresh.error)
+                        emptyView.text = if (isCloudflare) {
+                            FireErrorClassifier.displayMessage(refresh.error) +
+                                "\n" +
+                                getString(R.string.action_cloudflare_verify)
+                        } else {
+                            refresh.error.localizedMessage ?: getString(R.string.browser_empty)
+                        }
+                        emptyView.setOnClickListener(
+                            if (isCloudflare) {
+                                View.OnClickListener { recoverHomeCloudflareChallenge() }
+                            } else {
+                                null
+                            },
+                        )
                         View.VISIBLE
                     }
                     refresh is LoadState.NotLoading && adapter.itemCount == 0 -> {
                         emptyView.text = getString(R.string.browser_empty)
+                        emptyView.setOnClickListener(null)
                         View.VISIBLE
                     }
-                    else -> View.GONE
+                    else -> {
+                        emptyView.setOnClickListener(null)
+                        View.GONE
+                    }
                 }
                 if (refresh !is LoadState.Loading) {
                     swipeRefresh.isRefreshing = false
@@ -194,6 +214,30 @@ class HomeFragment : Fragment() {
     override fun onResume() {
         super.onResume()
         topicNavigationGate.reset()
+    }
+
+    private fun recoverHomeCloudflareChallenge() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val sessionStore = FireSessionStoreRepository.get(requireContext())
+            val ok = FireCloudflareRecovery.completeManualVerification(
+                context = requireContext(),
+                sessionStore = sessionStore,
+                operation = "home.manual_verify",
+                originUrl = "https://linux.do/",
+            )
+            if (ok) {
+                viewModel?.prepareTopicRefresh()
+                if (::adapter.isInitialized) {
+                    adapter.refresh()
+                }
+            } else {
+                FireToast.show(
+                    requireView(),
+                    getString(R.string.login_cloudflare_retry_failed),
+                    FireToast.Style.ERROR,
+                )
+            }
+        }
     }
 
     private fun setupCategoryBar() {

--- a/native/android-app/src/main/java/com/fire/app/ui/home/HomeViewModel.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/home/HomeViewModel.kt
@@ -14,6 +14,7 @@ import com.fire.app.data.paging.TopicListPagingSource
 import com.fire.app.data.repository.TopicRepository
 import com.fire.app.messagebus.FireMessageBusCoordinator
 import com.fire.app.session.FireAppStateRefreshRepository
+import com.fire.app.session.FireClearanceResolvedRepository
 import com.fire.app.session.FireSessionStore
 import com.fire.app.session.FireStateObserverRepository
 import com.fire.app.widget.FireWidgetData
@@ -227,6 +228,21 @@ class HomeViewModel(
                 }
             }
         }
+
+        viewModelScope.launch {
+            FireClearanceResolvedRepository.events.collectLatest { event ->
+                try {
+                    handleClearanceResolved(event)
+                } catch (error: Exception) {
+                    val reported = FireErrorReporter.report(
+                        operation = "home.clearance_resolved",
+                        error = error,
+                        sessionStore = sessionStore,
+                    )
+                    handleReportedError(reported)
+                }
+            }
+        }
     }
 
     fun selectKind(kind: TopicListKindState) {
@@ -397,6 +413,21 @@ class HomeViewModel(
         // Paging.refresh() here reissues the same request and can invalidate a
         // deep scroll position at the wrong anchor page.
         if (batch == RefreshBatchState.CORE) return
+    }
+
+    private suspend fun handleClearanceResolved(
+        event: uniffi.fire_uniffi_session.CloudflareClearanceResolvedEventState,
+    ) {
+        val snapshot = sessionStore.snapshot()
+        _session.value = snapshot
+        val canOpenBus = event.canOpenMessageBus || snapshot.readiness.canOpenMessageBus
+        if (canOpenBus) {
+            stopRealtimeRefresh()
+            runCatching { FireMessageBusCoordinator.forceRestart(sessionStore) }
+            startRealtimeRefresh()
+        } else {
+            stopRealtimeRefresh()
+        }
     }
 
     private fun handleTopicListMessageBusEvent(event: MessageBusEventState) {

--- a/native/android-app/src/main/java/com/fire/app/ui/startup/PreheatGateFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/startup/PreheatGateFragment.kt
@@ -12,6 +12,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.fire.app.R
 import com.fire.app.session.FireAppStateRefreshRepository
+import com.fire.app.session.FireCfClearanceRefreshService
 import com.fire.app.session.FireSessionStore
 import com.fire.app.session.FireSessionStoreRepository
 import com.google.android.material.button.MaterialButton
@@ -84,6 +85,12 @@ class PreheatGateFragment : Fragment() {
             logStartupStep("login_state_ms", loginStateStartedAt)
         }) {
             is LoginStateDeterminationState.LoggedIn -> {
+                val snapshot = store.snapshot()
+                val refresh = FireCfClearanceRefreshService.get(requireContext())
+                refresh.bind(store)
+                refresh.updateSession(snapshot)
+                refresh.setLoginStateConfirmed(true)
+                refresh.setSceneActive(true)
                 store.triggerAppStateRefresh(
                     RefreshTriggerState.SESSION_RESTORED,
                     FireAppStateRefreshRepository,
@@ -91,6 +98,7 @@ class PreheatGateFragment : Fragment() {
                 findNavController().navigate(R.id.action_preheatGate_to_home)
             }
             else -> {
+                FireCfClearanceRefreshService.get(requireContext()).setLoginStateConfirmed(false)
                 findNavController().navigate(R.id.action_preheatGate_to_onboarding)
             }
         }

--- a/native/android-app/src/main/java/com/fire/app/ui/topicdetail/TopicDetailActivity.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/topicdetail/TopicDetailActivity.kt
@@ -246,7 +246,28 @@ class TopicDetailActivity : AppCompatActivity() {
             observeViewModel()
 
             retryButton.setOnClickListener {
-                loadRoute(parsedRoute)
+                val vm = viewModel
+                if (vm?.isCloudflareError?.value == true) {
+                    lifecycleScope.launch {
+                        val ok = com.fire.app.session.FireCloudflareRecovery.completeManualVerification(
+                            context = this@TopicDetailActivity,
+                            sessionStore = sessionStore,
+                            operation = "topic_detail.manual_verify",
+                            originUrl = "https://linux.do/t/${parsedRoute.topicId}",
+                        )
+                        if (ok) {
+                            loadRoute(parsedRoute)
+                        } else {
+                            FireToast.show(
+                                binding.root,
+                                getString(R.string.login_cloudflare_retry_failed),
+                                FireToast.Style.ERROR,
+                            )
+                        }
+                    }
+                } else {
+                    loadRoute(parsedRoute)
+                }
             }
 
             replyFab.setOnClickListener {
@@ -301,6 +322,15 @@ class TopicDetailActivity : AppCompatActivity() {
                         View.VISIBLE
                     }
                 }
+            }
+        }
+
+        lifecycleScope.launch {
+            vm.isCloudflareError.collectLatest { isCloudflare ->
+                (retryButton as? com.google.android.material.button.MaterialButton)?.text =
+                    getString(
+                        if (isCloudflare) R.string.action_cloudflare_verify else R.string.action_retry,
+                    )
             }
         }
 

--- a/native/android-app/src/main/java/com/fire/app/ui/topicdetail/TopicDetailViewModel.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/topicdetail/TopicDetailViewModel.kt
@@ -54,6 +54,9 @@ class TopicDetailViewModel(
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage = _errorMessage.asStateFlow()
 
+    private val _isCloudflareError = MutableStateFlow(false)
+    val isCloudflareError = _isCloudflareError.asStateFlow()
+
     private val _postRows = MutableStateFlow<List<PostRow>>(emptyList())
     val postRows = _postRows.asStateFlow()
 
@@ -100,6 +103,7 @@ class TopicDetailViewModel(
         viewModelScope.launch {
             _isLoading.value = true
             _errorMessage.value = null
+            _isCloudflareError.value = false
             prepareForTopicLoad(topicId)
             try {
                 val shouldUseSuggestedUnreadRootTarget = targetPostNumber == null && _detail.value == null
@@ -131,6 +135,7 @@ class TopicDetailViewModel(
                 )
                 if (_detail.value == null && _postRows.value.isEmpty()) {
                     _errorMessage.value = reported.displayMessage
+                    _isCloudflareError.value = reported.isCloudflareChallenge
                 } else {
                     _actionError.tryEmit(reported.displayMessage)
                 }

--- a/native/android-app/src/main/res/layout/activity_cloudflare_challenge.xml
+++ b/native/android-app/src/main/res/layout/activity_cloudflare_challenge.xml
@@ -42,10 +42,38 @@
         android:layout_height="wrap_content"
         android:max="100" />
 
-    <WebView
-        android:id="@+id/challenge_webview"
+    <FrameLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"
-        android:layout_weight="1" />
+        android:layout_weight="1">
+
+        <WebView
+            android:id="@+id/challenge_webview"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent" />
+
+        <!-- Covers Discourse post-pass /challenge 404 ("page does not exist"). -->
+        <LinearLayout
+            android:id="@+id/challenge_completion_overlay"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:background="?android:colorBackground"
+            android:gravity="center"
+            android:orientation="vertical"
+            android:visibility="gone">
+
+            <ProgressBar
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:indeterminate="true" />
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:text="正在完成验证…"
+                android:textAppearance="?attr/textAppearanceBodyMedium" />
+        </LinearLayout>
+    </FrameLayout>
 
 </LinearLayout>

--- a/native/android-app/src/main/res/values/strings.xml
+++ b/native/android-app/src/main/res/values/strings.xml
@@ -502,6 +502,7 @@
     <string name="search_post_meta">@%1$s · #%2$s · %3$s likes</string>
     <string name="search_user_meta">@%1$s</string>
     <string name="action_retry">重试</string>
+    <string name="action_cloudflare_verify">立即验证</string>
     <string name="action_reply">回复</string>
     <string name="stat_label_replies">回复</string>
     <string name="stat_label_views">浏览</string>

--- a/native/android-app/src/main/res/values/strings.xml
+++ b/native/android-app/src/main/res/values/strings.xml
@@ -39,9 +39,12 @@
     <string name="login_two_factor_title">Two-factor code</string>
     <string name="login_two_factor_hint">Authentication code</string>
     <string name="login_two_factor_submit">Verify</string>
-    <string name="login_cloudflare_retry_required">Cloudflare verification is required before login. Try again after verification.</string>
-    <string name="login_cloudflare_retry_running">Complete Cloudflare verification to continue login.</string>
-    <string name="login_cloudflare_retry_failed">Cloudflare verification did not complete. Try login again.</string>
+    <string name="login_cloudflare_retry_required">登录前需要完成网络验证，验证后请重试。</string>
+    <string name="login_cloudflare_retry_running">请完成网络验证以继续登录。</string>
+    <string name="login_cloudflare_retry_failed">网络验证未完成，请重试或手动验证后继续。</string>
+    <string name="login_cloudflare_cooldown">网络验证暂时冷却中，可稍后重试或手动完成验证。</string>
+    <string name="login_cloudflare_cancelled">已取消网络验证，账号密码仍保留，可继续登录。</string>
+    <string name="login_cloudflare_in_progress">网络验证进行中，请稍候。</string>
     <string name="browser_title">Topic Browser</string>
     <string name="in_app_web_title">Web Page</string>
     <string name="diagnostics_title">Diagnostics</string>

--- a/native/android-app/src/test/java/com/fire/app/core/error/FireErrorClassifierTest.kt
+++ b/native/android-app/src/test/java/com/fire/app/core/error/FireErrorClassifierTest.kt
@@ -16,10 +16,11 @@ class FireErrorClassifierTest {
 
     @Test
     fun isCloudflareChallenge_acceptsExplicitChallengeError() {
-        val error = FireUniFfiException.CloudflareChallenge()
+        val error = FireUniFfiException.CloudflareChallenge(reason = "required")
 
         assertTrue(FireErrorClassifier.isCloudflareChallenge(error))
         assertEquals(FireErrorKind.CloudflareChallenge, FireErrorClassifier.classify(error))
+        assertEquals("需要完成 Cloudflare 验证", FireErrorClassifier.displayMessage(error))
     }
 
     @Test

--- a/native/android-app/src/test/java/com/fire/app/session/FireCfClearanceRefreshServiceTest.kt
+++ b/native/android-app/src/test/java/com/fire/app/session/FireCfClearanceRefreshServiceTest.kt
@@ -1,0 +1,45 @@
+package com.fire.app.session
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import uniffi.fire_uniffi_session.PlatformCookieState
+
+class FireCfClearanceRefreshServiceTest {
+    @Test
+    fun cloudflareClearanceValue_prefersChangedValue() {
+        val cookies = listOf(
+            PlatformCookieState(
+                name = "cf_clearance",
+                value = "old",
+                domain = ".linux.do",
+                path = "/",
+                expiresAtUnixMs = null,
+                sameSite = null,
+            ),
+            PlatformCookieState(
+                name = "cf_clearance",
+                value = "new",
+                domain = ".linux.do",
+                path = "/",
+                expiresAtUnixMs = null,
+                sameSite = null,
+            ),
+        )
+        assertEquals(
+            "new",
+            FireCfClearanceRefreshService.cloudflareClearanceValue(cookies, "old"),
+        )
+    }
+
+    @Test
+    fun turnstileHtml_includesSitekeyAndRuntimeToken() {
+        val html = FireCfClearanceRefreshService.turnstileHtml(
+            sitekey = "site-key-123",
+            runtimeToken = "runtime-token-456",
+        )
+        assertTrue(html.contains("site-key-123"))
+        assertTrue(html.contains("runtime-token-456"))
+        assertTrue(html.contains("turnstile.render"))
+    }
+}

--- a/native/ios-app/App/Startup/FireHeadlessExternalLoginEngine.swift
+++ b/native/ios-app/App/Startup/FireHeadlessExternalLoginEngine.swift
@@ -214,6 +214,7 @@ final class FireHeadlessExternalLoginEngine: NSObject {
             Task { @MainActor in
                 guard let self, !self.hasFinished else { return }
                 let hasAuth = cookies.contains { $0.name == "_t" && !$0.value.isEmpty }
+                    && cookies.contains { $0.name == "_forum_session" && !$0.value.isEmpty }
                 guard hasAuth else {
                     self.hasAuthCandidate = false
                     self.watchForInteractionIfNeeded(url: webView.url)
@@ -224,8 +225,20 @@ final class FireHeadlessExternalLoginEngine: NSObject {
 
                 do {
                     let readiness = try await self.viewModel.probeLoginSyncReadiness(from: webView)
-                    guard readiness.isReady else { return }
+                    guard readiness.isReady else {
+                        FireAPMManager.shared.recordBreadcrumb(
+                            level: "info",
+                            target: "auth.login",
+                            message: "headless oauth waiting username=\(readiness.username ?? "nil") auth=\(readiness.hasAuthCookies) bootstrap=\(readiness.hasBootstrapHTML)"
+                        )
+                        return
+                    }
                 } catch {
+                    FireAPMManager.shared.recordBreadcrumb(
+                        level: "warn",
+                        target: "auth.login",
+                        message: "headless oauth probe failed: \(error.localizedDescription)"
+                    )
                     return
                 }
 
@@ -340,6 +353,8 @@ extension FireHeadlessExternalLoginEngine: WKNavigationDelegate, WKUIDelegate {
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         attemptAutoStartIfNeeded(in: webView)
         watchForInteractionIfNeeded(url: webView.url)
+        // After Google/OAuth returns to linux.do, probe auth immediately.
+        checkForAuthToken()
     }
 
     func webView(

--- a/native/ios-app/App/Startup/FireHeadlessExternalLoginEngine.swift
+++ b/native/ios-app/App/Startup/FireHeadlessExternalLoginEngine.swift
@@ -213,6 +213,26 @@ final class FireHeadlessExternalLoginEngine: NSObject {
         webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { [weak self] cookies in
             Task { @MainActor in
                 guard let self, !self.hasFinished else { return }
+
+                if await self.pageHasActiveCloudflareChallenge(in: webView) {
+                    // Need a visible surface to complete interactive CF.
+                    if !self.isPromoted {
+                        self.emitNeedsInteraction(reason: "active_cf_page")
+                    } else {
+                        do {
+                            try await self.viewModel.recoverLoginCloudflareChallenge(in: webView)
+                            webView.load(URLRequest(url: URL(string: "https://linux.do/")!))
+                        } catch {
+                            FireAPMManager.shared.recordBreadcrumb(
+                                level: "warn",
+                                target: "auth.login",
+                                message: "headless oauth CF recover failed: \(error.localizedDescription)"
+                            )
+                        }
+                    }
+                    return
+                }
+
                 let hasAuth = cookies.contains { $0.name == "_t" && !$0.value.isEmpty }
                     && cookies.contains { $0.name == "_forum_session" && !$0.value.isEmpty }
                 guard hasAuth else {
@@ -243,6 +263,14 @@ final class FireHeadlessExternalLoginEngine: NSObject {
                 }
 
                 self.finish(.authenticated)
+            }
+        }
+    }
+
+    private func pageHasActiveCloudflareChallenge(in webView: WKWebView) async -> Bool {
+        await withCheckedContinuation { continuation in
+            webView.evaluateJavaScript(FireLoginScripts.hasActiveCloudflareChallenge) { result, _ in
+                continuation.resume(returning: (result as? Bool) ?? false)
             }
         }
     }

--- a/native/ios-app/App/Stores/FireHomeFeedStore.swift
+++ b/native/ios-app/App/Stores/FireHomeFeedStore.swift
@@ -50,6 +50,7 @@ final class FireHomeFeedStore: ObservableObject {
     @Published private(set) var isLoadingTopics = false
     @Published private(set) var isAppendingTopics = false
     @Published private(set) var topicLoadErrorMessage: String?
+    @Published private(set) var topicLoadErrorIsCloudflare = false
     @Published private(set) var isOffline = false
 
     private(set) var visibleTopicIDs: Set<UInt64> = []
@@ -213,6 +214,7 @@ final class FireHomeFeedStore: ObservableObject {
         }
         selectedTopicKind = kind
         topicLoadErrorMessage = nil
+        topicLoadErrorIsCloudflare = false
         isOffline = false
         syncCurrentHomeTopicListScope()
         scheduleDebouncedRefresh()
@@ -223,6 +225,7 @@ final class FireHomeFeedStore: ObservableObject {
         selectedHomeCategoryId = categoryId
         selectedHomeTags = []
         topicLoadErrorMessage = nil
+        topicLoadErrorIsCloudflare = false
         isOffline = false
         syncCurrentHomeTopicListScope()
         scheduleDebouncedRefresh()
@@ -232,6 +235,7 @@ final class FireHomeFeedStore: ObservableObject {
         guard !selectedHomeTags.contains(tag) else { return }
         selectedHomeTags.append(tag)
         topicLoadErrorMessage = nil
+        topicLoadErrorIsCloudflare = false
         isOffline = false
         syncCurrentHomeTopicListScope()
         scheduleDebouncedRefresh()
@@ -241,6 +245,7 @@ final class FireHomeFeedStore: ObservableObject {
         guard selectedHomeTags.contains(tag) else { return }
         selectedHomeTags.removeAll { $0 == tag }
         topicLoadErrorMessage = nil
+        topicLoadErrorIsCloudflare = false
         isOffline = false
         syncCurrentHomeTopicListScope()
         scheduleDebouncedRefresh()
@@ -250,6 +255,7 @@ final class FireHomeFeedStore: ObservableObject {
         guard !selectedHomeTags.isEmpty else { return }
         selectedHomeTags = []
         topicLoadErrorMessage = nil
+        topicLoadErrorIsCloudflare = false
         isOffline = false
         syncCurrentHomeTopicListScope()
         scheduleDebouncedRefresh()
@@ -276,6 +282,7 @@ final class FireHomeFeedStore: ObservableObject {
             self.applyTopicRows(mergeResult)
             self.renderedTopicListScope = self.currentTopicListRefreshScope
             self.topicLoadErrorMessage = nil
+            self.topicLoadErrorIsCloudflare = false
             self.isOffline = state.isCached
             self.moreTopicsUrl = state.moreTopicsUrl
             self.nextTopicsPage = state.nextPage
@@ -366,6 +373,7 @@ final class FireHomeFeedStore: ObservableObject {
         isLoadingTopics = false
         isAppendingTopics = false
         topicLoadErrorMessage = nil
+        topicLoadErrorIsCloudflare = false
         isOffline = false
         renderedTopicListScope = nil
         selectedHomeCategoryId = nil
@@ -377,6 +385,7 @@ final class FireHomeFeedStore: ObservableObject {
 
     func clearTopicLoadError() {
         topicLoadErrorMessage = nil
+        topicLoadErrorIsCloudflare = false
     }
 
     private var currentTopicListRefreshScope: FireTopicListRefreshScope {
@@ -477,6 +486,7 @@ final class FireHomeFeedStore: ObservableObject {
         isLoadingTopics = true
         isAppendingTopics = !reset
         topicLoadErrorMessage = nil
+        topicLoadErrorIsCloudflare = false
         if reset {
             isOffline = false
         }
@@ -577,6 +587,7 @@ final class FireHomeFeedStore: ObservableObject {
             applyTopicRows(mergeResult)
             renderedTopicListScope = requestedScope
             topicLoadErrorMessage = nil
+            topicLoadErrorIsCloudflare = false
             isOffline = response.isCached
             if reset && page == nil {
                 appViewModel.updateWidgetData()
@@ -634,8 +645,32 @@ final class FireHomeFeedStore: ObservableObject {
             if await appViewModel.handleRecoverableSessionErrorIfNeeded(error) {
                 return false
             }
-            topicLoadErrorMessage = error.localizedDescription
+            if FireAppViewModel.isCloudflareChallengeError(error) {
+                let reason = FireAppViewModel.cloudflareChallengeReason(from: error)
+                topicLoadErrorIsCloudflare = true
+                topicLoadErrorMessage = Self.cloudflareErrorMessage(reason: reason)
+            } else {
+                topicLoadErrorIsCloudflare = false
+                topicLoadErrorMessage = error.localizedDescription
+            }
             return false
+        }
+    }
+
+    private static func cloudflareErrorMessage(reason: String) -> String {
+        switch reason {
+        case "in_progress":
+            return "正在完成 Cloudflare 验证，请稍候"
+        case "cooldown":
+            return "Cloudflare 验证暂时冷却中，可点横幅重试验证"
+        case "cancelled":
+            return "已取消 Cloudflare 验证，可点横幅重新验证"
+        case "background_suppressed":
+            return "后台请求遇到 Cloudflare 验证，可点横幅手动验证"
+        case "failed":
+            return "Cloudflare 验证未完成，可点横幅重试"
+        default:
+            return "需要完成 Cloudflare 验证，可点横幅立即验证"
         }
     }
 

--- a/native/ios-app/App/TopicDetail/Controller/FireTopicDetailViewController.swift
+++ b/native/ios-app/App/TopicDetail/Controller/FireTopicDetailViewController.swift
@@ -505,6 +505,7 @@ final class FireTopicDetailViewController: UIViewController, UIGestureRecognizer
 
     private func configureTopicSearchBar() {
         topicSearchBar.translatesAutoresizingMaskIntoConstraints = true
+        topicSearchBar.autoresizingMask = [.flexibleWidth]
         topicSearchBar.isHidden = true
         topicSearchBar.onQueryChanged = { [weak self] query in
             self?.updateTopicSearchQuery(query)
@@ -1268,12 +1269,17 @@ final class FireTopicDetailViewController: UIViewController, UIGestureRecognizer
     }
 
     private func layoutTopicSearchBar() {
-        let height: CGFloat = topicSearchBar.isHidden ? 0 : 56
+        // Keep a non-zero frame even while hidden. Collapsing to 0×0 fights the
+        // search bar's internal Auto Layout padding and spams unsatisfiable
+        // constraint logs; top inset already uses `currentSearchBarHeight`
+        // (0 when hidden) so chrome spacing stays correct.
+        let width = view.bounds.width
+        guard width > 1 else { return }
         let targetFrame = CGRect(
             x: 0,
             y: view.safeAreaInsets.top,
-            width: view.bounds.width,
-            height: height
+            width: width,
+            height: 56
         )
         if topicSearchBar.frame != targetFrame {
             topicSearchBar.frame = targetFrame
@@ -1785,11 +1791,17 @@ private final class FireTopicSearchBar: UIView, UITextFieldDelegate {
         stackView.addArrangedSubview(nextButton)
         stackView.addArrangedSubview(closeButton)
 
-        NSLayoutConstraint.activate([
+        // Frame-based parent can briefly report 0 size before first layout.
+        // Keep padding required only when space exists so autoresizing masks
+        // do not fight unbreakable internal edges.
+        let edgeConstraints = [
             stackView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 12),
             stackView.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -8),
             stackView.topAnchor.constraint(equalTo: topAnchor, constant: 8),
             stackView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+        ]
+        edgeConstraints.forEach { $0.priority = UILayoutPriority(999) }
+        NSLayoutConstraint.activate(edgeConstraints + [
             previousButton.widthAnchor.constraint(equalToConstant: 34),
             previousButton.heightAnchor.constraint(equalToConstant: 34),
             nextButton.widthAnchor.constraint(equalToConstant: 34),

--- a/native/ios-app/App/ViewModels/FireAppViewModel.swift
+++ b/native/ios-app/App/ViewModels/FireAppViewModel.swift
@@ -1363,7 +1363,55 @@ final class FireAppViewModel: ObservableObject {
         originURL: URL? = nil,
         work: @escaping () async throws -> T
     ) async throws -> T {
-        return try await work()
+        do {
+            return try await work()
+        } catch {
+            guard Self.isCloudflareChallengeError(error) else {
+                throw error
+            }
+            guard let sessionStore else {
+                throw error
+            }
+            let coordinator = FireCloudflareChallengeCoordinator(sessionStore: sessionStore)
+            let result = await coordinator.completeManualVerification(
+                originURL: originURL?.absoluteString ?? "https://linux.do/"
+            )
+            let fresh = result.freshCfClearance?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            guard result.completed, !result.userCancelled, !fresh.isEmpty else {
+                throw error
+            }
+            let session = try await sessionStore.completeCloudflareChallenge(
+                cookies: result.cookies,
+                freshCfClearance: fresh,
+                browserUserAgent: result.browserUserAgent
+            )
+            FireCfClearanceRefreshService.shared.updateSession(
+                session,
+                loginCoordinator: FireWebViewLoginCoordinator(sessionStore: sessionStore)
+            )
+            FireCfClearanceRefreshService.shared.setLoginStateConfirmed(
+                session.readiness.hasCurrentUser && session.readiness.canReadAuthenticatedApi
+            )
+            return try await work()
+        }
+    }
+
+    nonisolated static func isCloudflareChallengeError(_ error: Error) -> Bool {
+        if case FireUniFfiError.CloudflareChallenge = error {
+            return true
+        }
+        let message = String(describing: error).lowercased()
+        return message.contains("cloudflare challenge")
+    }
+
+    nonisolated static func cloudflareChallengeReason(from error: Error) -> String {
+        let message = String(describing: error)
+        for token in ["in_progress", "cooldown", "cancelled", "failed", "background_suppressed", "required"] {
+            if message.contains("(\(token))") || message.contains(token) {
+                return token
+            }
+        }
+        return "required"
     }
 
     /// Read-side recovery for transient `LoginRequired` errors observed during

--- a/native/ios-app/App/ViewModels/FireAppViewModel.swift
+++ b/native/ios-app/App/ViewModels/FireAppViewModel.swift
@@ -1397,14 +1397,23 @@ final class FireAppViewModel: ObservableObject {
     }
 
     nonisolated static func isCloudflareChallengeError(_ error: Error) -> Bool {
-        if case FireUniFfiError.CloudflareChallenge = error {
-            return true
+        if let fireError = error as? FireUniFfiError {
+            if case .CloudflareChallenge = fireError {
+                return true
+            }
         }
         let message = String(describing: error).lowercased()
         return message.contains("cloudflare challenge")
     }
 
     nonisolated static func cloudflareChallengeReason(from error: Error) -> String {
+        if let fireError = error as? FireUniFfiError,
+           case let .CloudflareChallenge(reason) = fireError {
+            let trimmed = reason.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return trimmed
+            }
+        }
         let message = String(describing: error)
         for token in ["in_progress", "cooldown", "cancelled", "failed", "background_suppressed", "required"] {
             if message.contains("(\(token))") || message.contains(token) {

--- a/native/ios-app/App/ViewModels/FireAppViewModel.swift
+++ b/native/ios-app/App/ViewModels/FireAppViewModel.swift
@@ -517,13 +517,14 @@ final class FireAppViewModel: ObservableObject {
     func ensureCloudflareClearance() async -> Bool {
         do {
             let sessionStore = try await sessionStoreValue()
-            if try await sessionStore.snapshot().readiness.hasCloudflareClearance {
+            // Do not trust jar clearance that CF recently rejected (cold start / IP drift).
+            if try sessionStore.cloudflareClearanceIsTrusted() {
                 return true
             }
 
             try await completeLoginCloudflareChallenge(sessionStore: sessionStore)
             try await Task.sleep(for: .milliseconds(1_500))
-            return try await sessionStore.snapshot().readiness.hasCloudflareClearance
+            return try sessionStore.cloudflareClearanceIsTrusted()
         } catch {
             errorMessage = error.localizedDescription
             return false

--- a/native/ios-app/App/ViewModels/FireAppViewModel.swift
+++ b/native/ios-app/App/ViewModels/FireAppViewModel.swift
@@ -283,41 +283,75 @@ final class FireAppViewModel: ObservableObject {
         from webView: WKWebView,
         method: FireLastLoginMethod? = nil
     ) {
+        Task {
+            _ = await completeLoginAwaitingResult(from: webView, method: method)
+        }
+    }
+
+    /// Finalize WebView/OAuth login and return whether session is ready for home.
+    @discardableResult
+    func completeLoginAwaitingResult(
+        from webView: WKWebView,
+        method: FireLastLoginMethod? = nil
+    ) async -> Bool {
         guard !isSyncingLoginSession else {
-            return
+            FireAPMManager.shared.recordBreadcrumb(
+                level: "warn",
+                target: "auth.login",
+                message: "completeLogin ignored; already syncing"
+            )
+            return session.readiness.canReadAuthenticatedApi
         }
 
         isSyncingLoginSession = true
-        Task {
-            defer { isSyncingLoginSession = false }
+        defer { isSyncingLoginSession = false }
 
-            do {
-                try await FireAPMManager.shared.withSpan(.authLoginSync) {
-                    let loginCoordinator = try await loginCoordinatorValue()
-                    let sessionStore = try await sessionStoreValue()
-                    errorMessage = nil
-                    await applySession(
-                        try await loginCoordinator.completeLogin(from: webView),
-                        activateMessageBus: false
-                    )
-                    if let method {
-                        try await persistLastLoginMethod(method, sessionStore: sessionStore)
-                    }
-                    FireCfClearanceRefreshService.shared.setLoginStateConfirmed(true)
-                    try await sessionStore.triggerAppStateRefresh(
-                        .loginCompleted,
-                        handler: appStateRefreshCoordinator
-                    )
-                    setAuthPresentationState(nil)
-                    canSyncLoginSession = false
-                    cachedLoginSyncReadiness = nil
+        do {
+            return try await FireAPMManager.shared.withSpan(.authLoginSync) {
+                let loginCoordinator = try await loginCoordinatorValue()
+                let sessionStore = try await sessionStoreValue()
+                errorMessage = nil
+                let readiness = try await loginCoordinator.probeLoginSyncReadiness(from: webView)
+                FireAPMManager.shared.recordBreadcrumb(
+                    level: "info",
+                    target: "auth.login",
+                    message: "completeLogin probe ready=\(readiness.isReady) username=\(readiness.username ?? "nil") authCookies=\(readiness.hasAuthCookies) bootstrap=\(readiness.hasBootstrapHTML) score=\(readiness.preferredBootstrapScore)"
+                )
+                let session = try await loginCoordinator.completeLogin(from: webView)
+                await applySession(session, activateMessageBus: false)
+                if let method {
+                    try await persistLastLoginMethod(method, sessionStore: sessionStore)
                 }
-            } catch {
-                if await handleRecoverableSessionErrorIfNeeded(error) {
-                    return
-                }
-                errorMessage = error.localizedDescription
+                FireCfClearanceRefreshService.shared.setLoginStateConfirmed(true)
+                FireCfClearanceRefreshService.shared.updateSession(
+                    session,
+                    loginCoordinator: loginCoordinator
+                )
+                try await sessionStore.triggerAppStateRefresh(
+                    .loginCompleted,
+                    handler: appStateRefreshCoordinator
+                )
+                setAuthPresentationState(nil)
+                canSyncLoginSession = false
+                cachedLoginSyncReadiness = nil
+                FireAPMManager.shared.recordBreadcrumb(
+                    level: "info",
+                    target: "auth.login",
+                    message: "completeLogin finished canReadAuth=\(session.readiness.canReadAuthenticatedApi)"
+                )
+                return session.readiness.canReadAuthenticatedApi
             }
+        } catch {
+            FireAPMManager.shared.recordBreadcrumb(
+                level: "error",
+                target: "auth.login",
+                message: "completeLogin failed: \(error.localizedDescription)"
+            )
+            if await handleRecoverableSessionErrorIfNeeded(error) {
+                return session.readiness.canReadAuthenticatedApi
+            }
+            errorMessage = error.localizedDescription
+            return false
         }
     }
 

--- a/native/ios-app/App/ViewModels/FireAppViewModel.swift
+++ b/native/ios-app/App/ViewModels/FireAppViewModel.swift
@@ -37,6 +37,7 @@ final class FireAppViewModel: ObservableObject {
     private var sessionStore: FireSessionStore?
     private var loginCoordinator: FireWebViewLoginCoordinator?
     private var cloudflareChallengeHandler: FireCloudflareChallengeRuntimeHandler?
+    private var clearanceResolvedHandler: FireClearanceResolvedRuntimeHandler?
     private var cookieSelfHealingHandler: FireCookieSelfHealingRuntimeHandler?
     private var sessionStoreInitializationTask: Task<FireSessionStore, Error>?
     private var initialStateTask: Task<Void, Never>?
@@ -318,7 +319,8 @@ final class FireAppViewModel: ObservableObject {
                     message: "completeLogin probe ready=\(readiness.isReady) username=\(readiness.username ?? "nil") authCookies=\(readiness.hasAuthCookies) bootstrap=\(readiness.hasBootstrapHTML) score=\(readiness.preferredBootstrapScore)"
                 )
                 let session = try await loginCoordinator.completeLogin(from: webView)
-                await applySession(session, activateMessageBus: false)
+                // Prefer starting MessageBus when bootstrap already made it possible.
+                await applySession(session, activateMessageBus: true)
                 if let method {
                     try await persistLastLoginMethod(method, sessionStore: sessionStore)
                 }
@@ -327,13 +329,19 @@ final class FireAppViewModel: ObservableObject {
                     session,
                     loginCoordinator: loginCoordinator
                 )
-                try await sessionStore.triggerAppStateRefresh(
-                    .loginCompleted,
-                    handler: appStateRefreshCoordinator
-                )
+                // fluxdo finally: cookies trusted → enter home immediately.
+                // App-state refresh must not block login-ready UI forever.
                 setAuthPresentationState(nil)
                 canSyncLoginSession = false
                 cachedLoginSyncReadiness = nil
+                Task { [weak self] in
+                    guard let self else { return }
+                    try? await sessionStore.triggerAppStateRefresh(
+                        .loginCompleted,
+                        handler: self.appStateRefreshCoordinator
+                    )
+                    await self.ensureMessageBusActiveIfPossible()
+                }
                 FireAPMManager.shared.recordBreadcrumb(
                     level: "info",
                     target: "auth.login",
@@ -444,7 +452,7 @@ final class FireAppViewModel: ObservableObject {
                     target: "auth.login",
                     message: "completeJsLogin ok canReadAuth=\(session.readiness.canReadAuthenticatedApi) loginPhase=\(String(describing: session.loginPhase))"
                 )
-                await applySession(session, activateMessageBus: false)
+                await applySession(session, activateMessageBus: true)
                 try await persistLastLoginMethod(.password, sessionStore: sessionStore)
                 if rememberCredential, !identifier.isEmpty {
                     try await sessionStore.saveLoginCredential(
@@ -457,13 +465,18 @@ final class FireAppViewModel: ObservableObject {
                     savedLoginCredential = nil
                 }
                 FireCfClearanceRefreshService.shared.setLoginStateConfirmed(true)
-                try await sessionStore.triggerAppStateRefresh(
-                    .loginCompleted,
-                    handler: appStateRefreshCoordinator
-                )
+                // fluxdo finally: trusted cookies are enough to leave the login UI.
                 setAuthPresentationState(nil)
                 canSyncLoginSession = false
                 cachedLoginSyncReadiness = nil
+                Task { [weak self] in
+                    guard let self else { return }
+                    try? await sessionStore.triggerAppStateRefresh(
+                        .loginCompleted,
+                        handler: self.appStateRefreshCoordinator
+                    )
+                    await self.ensureMessageBusActiveIfPossible()
+                }
                 FireAPMManager.shared.recordBreadcrumb(
                     level: "info",
                     target: "auth.login",
@@ -518,13 +531,13 @@ final class FireAppViewModel: ObservableObject {
         do {
             let sessionStore = try await sessionStoreValue()
             // Do not trust jar clearance that CF recently rejected (cold start / IP drift).
-            if try sessionStore.cloudflareClearanceIsTrusted() {
+            if try await sessionStore.cloudflareClearanceIsTrusted() {
                 return true
             }
 
             try await completeLoginCloudflareChallenge(sessionStore: sessionStore)
             try await Task.sleep(for: .milliseconds(1_500))
-            return try sessionStore.cloudflareClearanceIsTrusted()
+            return try await sessionStore.cloudflareClearanceIsTrusted()
         } catch {
             errorMessage = error.localizedDescription
             return false
@@ -1684,8 +1697,36 @@ final class FireAppViewModel: ObservableObject {
         await startMessageBus()
     }
 
+    func restartMessageBusAfterClearanceIfPossible() async {
+        if isMessageBusActive {
+            stopMessageBus()
+        }
+        await startMessageBus()
+    }
+
     private func handleAppStateRefreshEvent(_ event: AppStateRefreshEventState) {
-        _ = event
+        if event.trigger == .cloudflareResolved {
+            Task { @MainActor in
+                self.homeFeedStore?.clearTopicLoadError()
+                if self.session.readiness.canOpenMessageBus {
+                    await self.restartMessageBusAfterClearanceIfPossible()
+                }
+            }
+        }
+    }
+
+    private func handleClearanceResolved(_ event: CloudflareClearanceResolvedEventState) async {
+        homeFeedStore?.clearTopicLoadError()
+        FireAPMManager.shared.recordBreadcrumb(
+            level: "info",
+            target: "auth.cf",
+            message: "clearance resolved gen=\(event.generation) login=\(event.hasLoginSession) bus=\(event.canOpenMessageBus)"
+        )
+        if event.canOpenMessageBus || session.readiness.canOpenMessageBus {
+            await restartMessageBusAfterClearanceIfPossible()
+        }
+        // Home topic list may still show a CF failure banner; force one refresh.
+        _ = await refreshHomeFeedIfPossible(force: true)
     }
 
     @discardableResult
@@ -1788,6 +1829,16 @@ final class FireAppViewModel: ObservableObject {
         if let cloudflareChallengeHandler {
             try? await sessionStore.registerCloudflareChallengeHandler(
                 cloudflareChallengeHandler
+            )
+        }
+        if clearanceResolvedHandler == nil {
+            clearanceResolvedHandler = FireClearanceResolvedRuntimeHandler { [weak self] event in
+                await self?.handleClearanceResolved(event)
+            }
+        }
+        if let clearanceResolvedHandler {
+            try? await sessionStore.registerCloudflareClearanceResolvedHandler(
+                clearanceResolvedHandler
             )
         }
         if cookieSelfHealingHandler == nil {

--- a/native/ios-app/App/ViewModels/FireAppViewModelSupport.swift
+++ b/native/ios-app/App/ViewModels/FireAppViewModelSupport.swift
@@ -140,6 +140,20 @@ final class FireAppStateRefreshCoordinator: AppStateRefreshHandler, @unchecked S
     }
 }
 
+final class FireClearanceResolvedRuntimeHandler: CloudflareClearanceResolvedHandler, @unchecked Sendable {
+    private let onResolved: @MainActor (CloudflareClearanceResolvedEventState) async -> Void
+
+    init(onResolved: @escaping @MainActor (CloudflareClearanceResolvedEventState) async -> Void) {
+        self.onResolved = onResolved
+    }
+
+    func onClearanceResolved(event: CloudflareClearanceResolvedEventState) {
+        Task { @MainActor in
+            await onResolved(event)
+        }
+    }
+}
+
 final class FireStateObserverCoordinator: StateObserver, @unchecked Sendable {
     private let onSession: @MainActor (SessionState) async -> Void
     private let onTopicList: @MainActor (TopicListState) async -> Void

--- a/native/ios-app/App/Views/Home/FireHomeView.swift
+++ b/native/ios-app/App/Views/Home/FireHomeView.swift
@@ -169,10 +169,29 @@ final class FireHomeViewController: UIViewController {
         FireHomeCollectionItem
     > { [weak self] cell, _, item in
         guard case let .inlineErrorBanner(message) = item else { return }
+        let isCloudflare = self?.homeFeedStore.topicLoadErrorIsCloudflare == true
         cell.configure(
             message: message,
-            onCopy: {
-                UIPasteboard.general.string = message
+            onCopy: { [weak self] in
+                guard let self else { return }
+                if isCloudflare {
+                    Task { @MainActor in
+                        do {
+                            _ = try await self.appViewModel.performWithCloudflareRecovery(
+                                operation: "首页手动 Cloudflare 验证",
+                                originURL: URL(string: self.baseURLString)
+                            ) {
+                                true
+                            }
+                            self.homeFeedStore.clearTopicLoadError()
+                            await self.homeFeedStore.refreshTopicsAsync()
+                        } catch {
+                            UIPasteboard.general.string = message
+                        }
+                    }
+                } else {
+                    UIPasteboard.general.string = message
+                }
             },
             onDismiss: { [weak self] in
                 self?.homeFeedStore.clearTopicLoadError()

--- a/native/ios-app/App/Views/Other/FireCaptchaLoginDialogController.swift
+++ b/native/ios-app/App/Views/Other/FireCaptchaLoginDialogController.swift
@@ -26,6 +26,8 @@ final class FireCaptchaLoginDialogController: UIViewController {
     private var hasReportedResult = false
     private var didTearDownWebView = false
     private var loginResultTimeoutWorkItem: DispatchWorkItem?
+    private var activeCloudflarePollWorkItem: DispatchWorkItem?
+    private var activeCloudflarePollGeneration: UInt64 = 0
     private let headerView = UIView()
     private let titleLabel = UILabel()
 
@@ -367,6 +369,7 @@ final class FireCaptchaLoginDialogController: UIViewController {
         lastLoginSecondFactorToken = token
 
         scheduleLoginResultTimeout(reason: "after second_factor")
+        startActiveCloudflarePoll(reason: "after second_factor")
         evaluateFireLogin(
             hcaptchaToken: nil,
             secondFactorToken: token,
@@ -382,6 +385,7 @@ final class FireCaptchaLoginDialogController: UIViewController {
 
         hasReportedResult = false
         scheduleLoginResultTimeout(reason: "after cloudflare recovery")
+        startActiveCloudflarePoll(reason: "after cloudflare recovery")
         evaluateFireLogin(
             hcaptchaToken: lastLoginHcaptchaToken,
             secondFactorToken: lastLoginSecondFactorToken,
@@ -401,6 +405,7 @@ final class FireCaptchaLoginDialogController: UIViewController {
             message: "hcaptcha_pass received; invoking __fireLogin token_len=\(hcaptchaToken.count)"
         )
         scheduleLoginResultTimeout(reason: "after hcaptcha_pass")
+        startActiveCloudflarePoll(reason: "after hcaptcha_pass")
         evaluateFireLogin(
             hcaptchaToken: hcaptchaToken,
             secondFactorToken: nil,
@@ -468,6 +473,52 @@ final class FireCaptchaLoginDialogController: UIViewController {
         )
     }
 
+    private func startActiveCloudflarePoll(reason: String) {
+        activeCloudflarePollWorkItem?.cancel()
+        activeCloudflarePollGeneration &+= 1
+        let generation = activeCloudflarePollGeneration
+        FireAPMManager.shared.recordBreadcrumb(
+            level: "info",
+            target: "auth.login",
+            message: "start active CF poll (\(reason))"
+        )
+        scheduleActiveCloudflarePollTick(generation: generation)
+    }
+
+    private func scheduleActiveCloudflarePollTick(generation: UInt64) {
+        let work = DispatchWorkItem { [weak self] in
+            guard let self else { return }
+            guard generation == self.activeCloudflarePollGeneration, !self.hasReportedResult else {
+                return
+            }
+            self.webView.evaluateJavaScript(FireLoginScripts.hasActiveCloudflareChallenge) { result, _ in
+                Task { @MainActor in
+                    guard generation == self.activeCloudflarePollGeneration, !self.hasReportedResult else {
+                        return
+                    }
+                    if (result as? Bool) == true {
+                        FireAPMManager.shared.recordBreadcrumb(
+                            level: "info",
+                            target: "auth.login",
+                            message: "login dialog detected active CF page"
+                        )
+                        self.reportResult(.retryCloudflare)
+                        return
+                    }
+                    self.scheduleActiveCloudflarePollTick(generation: generation)
+                }
+            }
+        }
+        activeCloudflarePollWorkItem = work
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0, execute: work)
+    }
+
+    private func cancelActiveCloudflarePoll() {
+        activeCloudflarePollGeneration &+= 1
+        activeCloudflarePollWorkItem?.cancel()
+        activeCloudflarePollWorkItem = nil
+    }
+
     fileprivate func showHcaptchaError(_ message: String) {
         // Status chrome was removed; keep the dialog open so the widget can be retried.
         FireAPMManager.shared.recordBreadcrumb(
@@ -503,6 +554,7 @@ final class FireCaptchaLoginDialogController: UIViewController {
         hasReportedResult = true
         loginResultTimeoutWorkItem?.cancel()
         loginResultTimeoutWorkItem = nil
+        cancelActiveCloudflarePoll()
 
         switch result {
         case .success, .needSecondFactor, .retryCloudflare:
@@ -525,6 +577,9 @@ final class FireCaptchaLoginDialogController: UIViewController {
     private func handleCancel() {
         guard !hasReportedResult else { return }
         hasReportedResult = true
+        cancelActiveCloudflarePoll()
+        loginResultTimeoutWorkItem?.cancel()
+        loginResultTimeoutWorkItem = nil
         onCancel()
         if presentingViewController != nil {
             dismiss(animated: true)

--- a/native/ios-app/App/Views/Other/FireOnboardingView.swift
+++ b/native/ios-app/App/Views/Other/FireOnboardingView.swift
@@ -673,7 +673,19 @@ final class FireOnboardingViewController: UIViewController {
         logAuth("performLogin begin; ensuring cloudflare clearance")
         let hasCloudflareClearance = await viewModel.ensureCloudflareClearance()
         guard hasCloudflareClearance else {
-            abortLoginAttempt(message: "网络验证失败，请重试", source: "ensureCloudflareClearance")
+            let reason = viewModel.errorMessage.map { message in
+                // Reuse token scan against the last CF error string.
+                for token in ["cooldown", "cancelled", "in_progress", "background_suppressed", "failed", "required"] {
+                    if message.localizedCaseInsensitiveContains(token) {
+                        return token
+                    }
+                }
+                return "failed"
+            }
+            abortLoginAttempt(
+                message: Self.loginCloudflareFailureMessage(reason: reason),
+                source: "ensureCloudflareClearance"
+            )
             return
         }
 
@@ -894,7 +906,10 @@ final class FireOnboardingViewController: UIViewController {
 
     private func recoverCloudflare() {
         guard !cfRetryUsed else {
-            abortLoginAttempt(message: "网络验证失败，请稍后重试", source: "recoverCloudflare already used")
+            abortLoginAttempt(
+                message: Self.loginCloudflareFailureMessage(reason: "failed"),
+                source: "recoverCloudflare already used"
+            )
             return
         }
         cfRetryUsed = true
@@ -902,20 +917,40 @@ final class FireOnboardingViewController: UIViewController {
 
         Task {
             guard let dialog = captchaDialog else {
-                abortLoginAttempt(message: "网络验证失败，请重试", source: "recoverCloudflare missing dialog")
+                abortLoginAttempt(
+                    message: Self.loginCloudflareFailureMessage(reason: "failed"),
+                    source: "recoverCloudflare missing dialog"
+                )
                 return
             }
             do {
                 try await viewModel.recoverLoginCloudflareChallenge(in: dialog.webView)
             } catch {
                 abortLoginAttempt(
-                    message: "网络验证失败，请重试",
+                    message: Self.loginCloudflareFailureMessage(
+                        reason: FireAppViewModel.cloudflareChallengeReason(from: error)
+                    ),
                     source: "recoverCloudflare: \(error.localizedDescription)"
                 )
                 return
             }
             logAuth("recoverCloudflare done; retrying login in dialog")
             dialog.retryAfterCloudflareRecovery()
+        }
+    }
+
+    private static func loginCloudflareFailureMessage(reason: String?) -> String {
+        switch reason?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "cooldown":
+            return "网络验证暂时冷却中，可稍后重试或手动完成验证"
+        case "cancelled":
+            return "已取消网络验证，账号密码仍保留，可继续登录"
+        case "in_progress":
+            return "网络验证进行中，请稍候"
+        case "background_suppressed":
+            return "需要前台完成网络验证，请重试"
+        default:
+            return "网络验证未完成，请重试或手动验证后继续"
         }
     }
 

--- a/native/ios-app/App/Views/Other/FireOnboardingView.swift
+++ b/native/ios-app/App/Views/Other/FireOnboardingView.swift
@@ -604,7 +604,24 @@ final class FireOnboardingViewController: UIViewController {
             logAuth("headless external authenticated method=\(method.rawValue); syncing")
             updateLoggingInMessage("正在同步登录态…")
             applyPhase(.loggingIn)
-            viewModel.completeLogin(from: webView, method: method.lastLoginMethod)
+            Task { @MainActor in
+                let ok = await self.viewModel.completeLoginAwaitingResult(
+                    from: webView,
+                    method: method.lastLoginMethod
+                )
+                if ok {
+                    self.logAuth("headless external login finalized")
+                    self.isAutoLoginInFlight = false
+                    self.activeAutoLoginKind = nil
+                    self.teardownHeadlessExternalEngine()
+                    // Root coordinator swaps to home when canReadAuthenticatedApi flips.
+                } else {
+                    self.abortLoginAttempt(
+                        message: self.viewModel.errorMessage ?? "登录态同步失败，请重试",
+                        source: "headless.authenticated.sync_failed"
+                    )
+                }
+            }
 
         case .needsUserInteraction:
             logAuth("headless external needs user interaction")

--- a/native/ios-app/App/Views/Other/FireWebViewBrowserViewController.swift
+++ b/native/ios-app/App/Views/Other/FireWebViewBrowserViewController.swift
@@ -208,7 +208,8 @@ final class FireWebViewBrowserViewController: UIViewController, WKNavigationDele
 
     private func startCookiePolling() {
         cookiePollTimer?.invalidate()
-        cookiePollTimer = Timer.scheduledTimer(withTimeInterval: 2.0, repeats: true) { [weak self] _ in
+        // Match fluxdo: 1s poll so OAuth return can finalize quickly.
+        cookiePollTimer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
             Task { @MainActor in
                 self?.checkForAuthToken()
             }
@@ -220,21 +221,44 @@ final class FireWebViewBrowserViewController: UIViewController, WKNavigationDele
             Task { @MainActor in
                 guard let self, !self.hasFinalizedLogin else { return }
                 let hasAuth = cookies.contains { $0.name == "_t" && !$0.value.isEmpty }
+                    && cookies.contains { $0.name == "_forum_session" && !$0.value.isEmpty }
                 guard hasAuth else { return }
 
                 do {
                     let readiness = try await self.viewModel.probeLoginSyncReadiness(from: self.webView)
-                    guard readiness.isReady else { return }
+                    guard readiness.isReady else {
+                        FireAPMManager.shared.recordBreadcrumb(
+                            level: "info",
+                            target: "auth.login",
+                            message: "browser oauth waiting username=\(readiness.username ?? "nil") auth=\(readiness.hasAuthCookies) bootstrap=\(readiness.hasBootstrapHTML)"
+                        )
+                        return
+                    }
                 } catch {
+                    FireAPMManager.shared.recordBreadcrumb(
+                        level: "warn",
+                        target: "auth.login",
+                        message: "browser oauth probe failed: \(error.localizedDescription)"
+                    )
                     return
                 }
 
                 self.hasFinalizedLogin = true
                 self.cookiePollTimer?.invalidate()
-                self.viewModel.completeLogin(
+                let ok = await self.viewModel.completeLoginAwaitingResult(
                     from: self.webView,
                     method: self.autoStartExternalLogin?.lastLoginMethod
                 )
+                if ok {
+                    self.dismiss(animated: true)
+                } else {
+                    // Allow another finalize attempt after a transient readiness miss.
+                    self.hasFinalizedLogin = false
+                    self.startCookiePolling()
+                    if let message = self.viewModel.errorMessage, !message.isEmpty {
+                        self.showErrorAlert(message)
+                    }
+                }
             }
         }
     }
@@ -291,6 +315,8 @@ final class FireWebViewBrowserViewController: UIViewController, WKNavigationDele
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         attemptAutoStartExternalLogin(in: webView)
+        // OAuth returns to linux.do after IdP — probe immediately, don't wait for next timer tick.
+        checkForAuthToken()
     }
 
     private func attemptAutoStartExternalLogin(in webView: WKWebView) {

--- a/native/ios-app/App/Views/Other/FireWebViewBrowserViewController.swift
+++ b/native/ios-app/App/Views/Other/FireWebViewBrowserViewController.swift
@@ -220,6 +220,27 @@ final class FireWebViewBrowserViewController: UIViewController, WKNavigationDele
         webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { [weak self] cookies in
             Task { @MainActor in
                 guard let self, !self.hasFinalizedLogin else { return }
+
+                // Login WebView still showing an active CF interstitial.
+                if await self.pageHasActiveCloudflareChallenge() {
+                    FireAPMManager.shared.recordBreadcrumb(
+                        level: "info",
+                        target: "auth.login",
+                        message: "browser oauth hit active CF page; recovering"
+                    )
+                    do {
+                        try await self.viewModel.recoverLoginCloudflareChallenge(in: self.webView)
+                        self.webView.load(URLRequest(url: URL(string: "https://linux.do/")!))
+                    } catch {
+                        FireAPMManager.shared.recordBreadcrumb(
+                            level: "warn",
+                            target: "auth.login",
+                            message: "browser oauth CF recover failed: \(error.localizedDescription)"
+                        )
+                    }
+                    return
+                }
+
                 let hasAuth = cookies.contains { $0.name == "_t" && !$0.value.isEmpty }
                     && cookies.contains { $0.name == "_forum_session" && !$0.value.isEmpty }
                 guard hasAuth else { return }
@@ -259,6 +280,14 @@ final class FireWebViewBrowserViewController: UIViewController, WKNavigationDele
                         self.showErrorAlert(message)
                     }
                 }
+            }
+        }
+    }
+
+    private func pageHasActiveCloudflareChallenge() async -> Bool {
+        await withCheckedContinuation { continuation in
+            webView.evaluateJavaScript(FireLoginScripts.hasActiveCloudflareChallenge) { result, _ in
+                continuation.resume(returning: (result as? Bool) ?? false)
             }
         }
     }

--- a/native/ios-app/App/Views/Shared/FireRichTextRenderer.swift
+++ b/native/ios-app/App/Views/Shared/FireRichTextRenderer.swift
@@ -253,6 +253,7 @@ enum FireRichTextAttributedStringBuilder {
                     context: context
                 )
                 result.append(quoteResult)
+                ensureBlockBoundary(result)
 
             case .quote(let author, let postNumber, let topicId, let children):
                 ensureBlockBoundary(result)
@@ -264,6 +265,7 @@ enum FireRichTextAttributedStringBuilder {
                     context: context
                 )
                 result.append(quoteResult)
+                ensureBlockBoundary(result)
 
             case .onebox(let url, let title, let description):
                 ensureBlockBoundary(result)
@@ -632,37 +634,59 @@ enum FireRichTextAttributedStringBuilder {
             return content
         }
 
-        let paragraph = NSMutableParagraphStyle()
-        // Match web: clearer separation before/after the quote block.
-        paragraph.paragraphSpacing = isReplyQuote ? 10 : 12
-        paragraph.paragraphSpacingBefore = isReplyQuote ? 6 : 8
-        paragraph.lineSpacing = 2
-        paragraph.headIndent = 12
-        paragraph.firstLineHeadIndent = 12
-        paragraph.tailIndent = -8
-
-        // Filled surface closer to Discourse aside/blockquote (not a chat bubble).
+        // Discourse-like filled panel — stronger than canvas so the block reads clearly.
         let fill = UIColor { traits in
-            traits.userInterfaceStyle == .dark
-                ? UIColor(white: 0.22, alpha: 1)
-                : UIColor(white: 0.94, alpha: 1)
+            if traits.userInterfaceStyle == .dark {
+                return UIColor(red: 0.16, green: 0.17, blue: 0.19, alpha: 1)
+            }
+            return UIColor(red: 0.90, green: 0.91, blue: 0.93, alpha: 1) // #E6E8ED
         }
         let stripe = UIColor { traits in
-            traits.userInterfaceStyle == .dark
-                ? UIColor(white: 0.45, alpha: 1)
-                : UIColor.tertiaryLabel
+            if traits.userInterfaceStyle == .dark {
+                return UIColor(white: 0.42, alpha: 1)
+            }
+            return UIColor(red: 0.68, green: 0.71, blue: 0.76, alpha: 1)
         }
 
-        content.addAttributes(
+        // Include vertical padding in layout height (CALayer pad alone gets clipped).
+        let padded = NSMutableAttributedString()
+        padded.append(quotePaddingLine())
+        padded.append(content)
+        padded.append(quotePaddingLine())
+
+        let paragraph = NSMutableParagraphStyle()
+        paragraph.paragraphSpacing = 0
+        paragraph.paragraphSpacingBefore = 0
+        paragraph.lineSpacing = 3
+        paragraph.headIndent = 16
+        paragraph.firstLineHeadIndent = 16
+        paragraph.tailIndent = -12
+        paragraph.lineBreakMode = .byWordWrapping
+
+        padded.addAttributes(
             [
                 .paragraphStyle: paragraph,
                 .fireQuotePreviewBlock: true,
                 .fireQuotePreviewBackgroundColor: fill,
                 .fireQuotePreviewStripeColor: stripe,
             ],
-            range: NSRange(location: 0, length: content.length)
+            range: NSRange(location: 0, length: padded.length)
         )
-        return content
+        return padded
+    }
+
+    private static func quotePaddingLine() -> NSAttributedString {
+        let style = NSMutableParagraphStyle()
+        style.minimumLineHeight = 10
+        style.maximumLineHeight = 10
+        return NSAttributedString(
+            string: "\u{200B}\n",
+            attributes: [
+                .font: UIFont.systemFont(ofSize: 1),
+                .foregroundColor: UIColor.clear,
+                .paragraphStyle: style,
+            ]
+        )
     }
 
     private static func fullBlockquoteBody(_ body: NSAttributedString) -> NSAttributedString {
@@ -1034,15 +1058,13 @@ class FireRichTextTextView: UITextView {
             effectiveRange: nil
         ) as? UIColor ?? .tertiaryLabel
 
-        // Full-bleed quote surface with modest vertical padding (web-like aside).
-        let horizontalInset: CGFloat = 0
-        let verticalPad: CGFloat = 8
+        // Background tracks layout glyphs (padding lines already baked into text).
         let backgroundRect = CGRect(
-            x: textContainerInset.left + horizontalInset,
-            y: unionRect.minY - verticalPad,
-            width: max(bounds.width - textContainerInset.left - textContainerInset.right - horizontalInset * 2, 1),
-            height: unionRect.height + verticalPad * 2
-        ).intersection(bounds.insetBy(dx: 0, dy: -4))
+            x: textContainerInset.left,
+            y: unionRect.minY - 2,
+            width: max(bounds.width - textContainerInset.left - textContainerInset.right, 1),
+            height: unionRect.height + 4
+        ).intersection(bounds.insetBy(dx: 0, dy: -2))
         guard !backgroundRect.isNull, backgroundRect.height > 1 else {
             return
         }
@@ -1051,23 +1073,23 @@ class FireRichTextTextView: UITextView {
         backgroundLayer.fillColor = backgroundColor.resolvedColor(with: traitCollection).cgColor
         backgroundLayer.path = UIBezierPath(
             roundedRect: backgroundRect,
-            cornerRadius: 6
+            cornerRadius: 8
         ).cgPath
         layer.insertSublayer(backgroundLayer, at: 0)
         quotePreviewLayers.append(backgroundLayer)
 
-        // Left accent bar inset inside the filled block (Discourse quote stripe).
+        // Left accent bar (blockquote border-left).
         let stripeRect = CGRect(
-            x: backgroundRect.minX + 6,
+            x: backgroundRect.minX + 8,
             y: backgroundRect.minY + 8,
-            width: 3,
+            width: 4,
             height: max(backgroundRect.height - 16, 1)
         )
         let stripeLayer = CAShapeLayer()
         stripeLayer.fillColor = stripeColor.resolvedColor(with: traitCollection).cgColor
         stripeLayer.path = UIBezierPath(
             roundedRect: stripeRect,
-            cornerRadius: 1.5
+            cornerRadius: 2
         ).cgPath
         layer.insertSublayer(stripeLayer, above: backgroundLayer)
         quotePreviewLayers.append(stripeLayer)

--- a/native/ios-app/App/Views/Shared/FireRichTextRenderer.swift
+++ b/native/ios-app/App/Views/Shared/FireRichTextRenderer.swift
@@ -49,8 +49,10 @@ struct FireRichTextContent: Sendable {
 // MARK: - AttributedString Builder
 
 enum FireRichTextAttributedStringBuilder {
-    private static let quotePreviewLineLimit = 2
-    private static let quotePreviewCharacterLimit = 120
+    /// Compact preview only for Discourse reply-quotes that carry an author/floor.
+    /// Plain body blockquotes (common OP intro blocks) stay full-length like web.
+    private static let replyQuotePreviewLineLimit = 4
+    private static let replyQuotePreviewCharacterLimit = 220
 
     /// Convert parsed nodes into an NSAttributedString suitable for display.
     static func build(
@@ -341,17 +343,42 @@ enum FireRichTextAttributedStringBuilder {
 
             case .divider:
                 ensureBlockBoundary(result)
+                // Thin hairline separator (avoid dashed ASCII which reads noisy).
+                let dividerStyle = NSMutableParagraphStyle()
+                dividerStyle.paragraphSpacingBefore = 10
+                dividerStyle.paragraphSpacing = 10
+                dividerStyle.maximumLineHeight = 1
+                dividerStyle.minimumLineHeight = 1
                 result.append(NSAttributedString(
-                    string: "----------",
-                    attributes: textAttributes(for: context.withTextColor(.separator))
+                    string: "\u{00A0}",
+                    attributes: [
+                        .font: UIFont.systemFont(ofSize: 1),
+                        .foregroundColor: UIColor.clear,
+                        .backgroundColor: UIColor.separator.withAlphaComponent(0.55),
+                        .paragraphStyle: dividerStyle,
+                    ]
                 ))
 
             case .lineBreak:
                 result.append(NSAttributedString(string: "\n"))
 
             case .paragraph(let children):
+                let start = result.length
                 ensureBlockBoundary(result)
                 appendNodes(children, to: result, context: context)
+                // Slightly airier block rhythm closer to Discourse web spacing.
+                if result.length > start {
+                    let style = NSMutableParagraphStyle()
+                    style.paragraphSpacing = 8
+                    style.paragraphSpacingBefore = 2
+                    style.lineSpacing = 2
+                    style.lineBreakMode = .byWordWrapping
+                    result.addAttribute(
+                        .paragraphStyle,
+                        value: style,
+                        range: NSRange(location: start, length: result.length - start)
+                    )
+                }
 
             case .image:
                 break // Handled separately via imageAttachments
@@ -573,6 +600,8 @@ enum FireRichTextAttributedStringBuilder {
         context: RenderContext
     ) -> NSAttributedString {
         let content = NSMutableAttributedString()
+        let isReplyQuote = !(author?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ?? true)
+            || postNumber != nil
 
         if let header = quoteHeaderAttributedString(
             author: author,
@@ -587,44 +616,79 @@ enum FireRichTextAttributedStringBuilder {
         }
 
         let body = NSMutableAttributedString()
-        appendNodes(
-            children,
-            to: body,
-            context: context.indented().withTextColor(.secondaryLabel)
-        )
-        content.append(compactQuoteBody(body))
+        // Body blockquotes should read like surrounding post text (web Discourse),
+        // while reply-quotes stay slightly de-emphasized.
+        let bodyContext = isReplyQuote
+            ? context.indented().withTextColor(.secondaryLabel)
+            : context.withTextColor(context.textColor)
+        appendNodes(children, to: body, context: bodyContext)
+        if isReplyQuote {
+            content.append(compactReplyQuoteBody(body))
+        } else {
+            content.append(fullBlockquoteBody(body))
+        }
 
         guard content.length > 0 else {
             return content
         }
 
         let paragraph = NSMutableParagraphStyle()
-        paragraph.paragraphSpacing = 8
-        paragraph.paragraphSpacingBefore = 4
-        paragraph.lineSpacing = 1.5
-        paragraph.headIndent = 10
-        paragraph.firstLineHeadIndent = 10
-        paragraph.tailIndent = -10
+        // Match web: clearer separation before/after the quote block.
+        paragraph.paragraphSpacing = isReplyQuote ? 10 : 12
+        paragraph.paragraphSpacingBefore = isReplyQuote ? 6 : 8
+        paragraph.lineSpacing = 2
+        paragraph.headIndent = 12
+        paragraph.firstLineHeadIndent = 12
+        paragraph.tailIndent = -8
+
+        // Filled surface closer to Discourse aside/blockquote (not a chat bubble).
+        let fill = UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(white: 0.22, alpha: 1)
+                : UIColor(white: 0.94, alpha: 1)
+        }
+        let stripe = UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(white: 0.45, alpha: 1)
+                : UIColor.tertiaryLabel
+        }
+
         content.addAttributes(
             [
                 .paragraphStyle: paragraph,
-                .backgroundColor: UIColor.secondarySystemBackground,
                 .fireQuotePreviewBlock: true,
-                .fireQuotePreviewBackgroundColor: UIColor.secondarySystemBackground,
-                .fireQuotePreviewStripeColor: UIColor.tertiaryLabel,
+                .fireQuotePreviewBackgroundColor: fill,
+                .fireQuotePreviewStripeColor: stripe,
             ],
             range: NSRange(location: 0, length: content.length)
         )
         return content
     }
 
-    private static func compactQuoteBody(_ body: NSAttributedString) -> NSAttributedString {
+    private static func fullBlockquoteBody(_ body: NSAttributedString) -> NSAttributedString {
+        let result = NSMutableAttributedString(attributedString: body)
+        // Collapse excessive blank lines inside the quote without truncating content.
+        collapseExcessiveBlankLines(in: result)
+        if result.length > 0 {
+            let font = UIFont.preferredFont(forTextStyle: .body)
+            result.addAttributes(
+                [
+                    .font: font,
+                    .foregroundColor: UIColor.label.withAlphaComponent(0.88),
+                ],
+                range: NSRange(location: 0, length: result.length)
+            )
+        }
+        return result
+    }
+
+    private static func compactReplyQuoteBody(_ body: NSAttributedString) -> NSAttributedString {
         let compact = NSMutableAttributedString()
         let source = body.string as NSString
         let ranges = nonBlankLineRanges(in: source)
         let selectedRanges = ranges.isEmpty
             ? trimmedRange(in: source, range: NSRange(location: 0, length: source.length)).map { [$0] } ?? []
-            : Array(ranges.prefix(quotePreviewLineLimit))
+            : Array(ranges.prefix(replyQuotePreviewLineLimit))
 
         for (index, range) in selectedRanges.enumerated() {
             if index > 0 {
@@ -637,13 +701,23 @@ enum FireRichTextAttributedStringBuilder {
         if compact.length > 0 {
             compact.addAttributes(
                 [
-                    .font: UIFont.preferredFont(forTextStyle: .footnote),
+                    .font: UIFont.preferredFont(forTextStyle: .subheadline),
                     .foregroundColor: UIColor.secondaryLabel,
                 ],
                 range: NSRange(location: 0, length: compact.length)
             )
         }
         return compact
+    }
+
+    private static func collapseExcessiveBlankLines(in body: NSMutableAttributedString) {
+        var text = body.string as NSString
+        while text.contains("\n\n\n") {
+            let range = text.range(of: "\n\n\n")
+            guard range.location != NSNotFound else { break }
+            body.replaceCharacters(in: range, with: "\n\n")
+            text = body.string as NSString
+        }
     }
 
     private static func nonBlankLineRanges(in source: NSString) -> [NSRange] {
@@ -687,8 +761,8 @@ enum FireRichTextAttributedStringBuilder {
     }
 
     private static func truncateQuoteBody(_ body: NSMutableAttributedString) {
-        let maxLength = quotePreviewCharacterLimit
-        let ellipsis = "..."
+        let maxLength = replyQuotePreviewCharacterLimit
+        let ellipsis = "…"
         guard body.length > maxLength else {
             return
         }
@@ -960,10 +1034,16 @@ class FireRichTextTextView: UITextView {
             effectiveRange: nil
         ) as? UIColor ?? .tertiaryLabel
 
-        let backgroundRect = unionRect
-            .insetBy(dx: 0, dy: -6)
-            .intersection(bounds.insetBy(dx: 0, dy: -2))
-        guard !backgroundRect.isNull else {
+        // Full-bleed quote surface with modest vertical padding (web-like aside).
+        let horizontalInset: CGFloat = 0
+        let verticalPad: CGFloat = 8
+        let backgroundRect = CGRect(
+            x: textContainerInset.left + horizontalInset,
+            y: unionRect.minY - verticalPad,
+            width: max(bounds.width - textContainerInset.left - textContainerInset.right - horizontalInset * 2, 1),
+            height: unionRect.height + verticalPad * 2
+        ).intersection(bounds.insetBy(dx: 0, dy: -4))
+        guard !backgroundRect.isNull, backgroundRect.height > 1 else {
             return
         }
 
@@ -971,13 +1051,14 @@ class FireRichTextTextView: UITextView {
         backgroundLayer.fillColor = backgroundColor.resolvedColor(with: traitCollection).cgColor
         backgroundLayer.path = UIBezierPath(
             roundedRect: backgroundRect,
-            cornerRadius: 8
+            cornerRadius: 6
         ).cgPath
         layer.insertSublayer(backgroundLayer, at: 0)
         quotePreviewLayers.append(backgroundLayer)
 
+        // Left accent bar inset inside the filled block (Discourse quote stripe).
         let stripeRect = CGRect(
-            x: backgroundRect.minX + 8,
+            x: backgroundRect.minX + 6,
             y: backgroundRect.minY + 8,
             width: 3,
             height: max(backgroundRect.height - 16, 1)

--- a/native/ios-app/Sources/FireAppSession/FireCloudflareChallengeCoordinator.swift
+++ b/native/ios-app/Sources/FireAppSession/FireCloudflareChallengeCoordinator.swift
@@ -615,7 +615,7 @@ private final class FireCloudflareChallengeViewController: UIViewController, WKN
                 var html = (document.documentElement && document.documentElement.outerHTML || '')
                   .slice(0, 12000)
                   .toLowerCase();
-                return html.indexOf('cf_chl_opt') !== -1 ||
+                var active = html.indexOf('cf_chl_opt') !== -1 ||
                   html.indexOf('cf-turnstile') !== -1 ||
                   html.indexOf('challenge-running') !== -1 ||
                   html.indexOf('challenge-stage') !== -1 ||
@@ -623,6 +623,17 @@ private final class FireCloudflareChallengeViewController: UIViewController, WKN
                   (title.indexOf('just a moment') !== -1) ||
                   (html.indexOf('just a moment') !== -1 &&
                     (html.indexOf('cloudflare') !== -1 || html.indexOf('cf-challenge') !== -1));
+                var originNotFound =
+                  html.indexOf('page-not-found') !== -1 ||
+                  html.indexOf('discourse-no-results') !== -1 ||
+                  html.indexOf('"errortype":"notfound"') !== -1 ||
+                  html.indexOf('404-body') !== -1 ||
+                  html.indexOf('exist or is private') !== -1 ||
+                  html.indexOf('page you requested') !== -1;
+                if (originNotFound) {
+                  return false;
+                }
+                return active;
               } catch (error) {
                 return true;
               }

--- a/native/ios-app/Sources/FireAppSession/FireCloudflareChallengeCoordinator.swift
+++ b/native/ios-app/Sources/FireAppSession/FireCloudflareChallengeCoordinator.swift
@@ -396,9 +396,14 @@ private final class FireCloudflareChallengeViewController: UIViewController, WKN
     private let preferredUserAgent: String?
     private let baselineSnapshot: FireCloudflareRecoveryCookieSnapshot
     private var webView: WKWebView?
+    private var completionOverlay: UIView?
     private var continuation: CheckedContinuation<Outcome, Never>?
     private var completionPollingTask: Task<Void, Never>?
     private var finished = false
+    /// Once CF UI was observed, bare `/challenge` navigation is treated as the
+    /// post-pass origin fallback (Discourse 404) and must stay covered.
+    private var hasSeenActiveChallenge = false
+    private var observedFreshClearance = false
 
     init(
         url: URL,
@@ -449,14 +454,44 @@ private final class FireCloudflareChallengeViewController: UIViewController, WKN
         webView.uiDelegate = self
         webView.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(webView)
+
+        // Covers Discourse's post-pass `/challenge` 404 so users never see
+        // "page does not exist" while clearance is finalized (fluxdo behavior).
+        let overlay = UIView()
+        overlay.translatesAutoresizingMaskIntoConstraints = false
+        overlay.backgroundColor = FireTheme.uiCanvas
+        overlay.isHidden = true
+        let spinner = UIActivityIndicatorView(style: .large)
+        spinner.translatesAutoresizingMaskIntoConstraints = false
+        spinner.startAnimating()
+        let label = UILabel()
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.text = "正在完成验证…"
+        label.textAlignment = .center
+        label.textColor = .secondaryLabel
+        label.font = .preferredFont(forTextStyle: .body)
+        overlay.addSubview(spinner)
+        overlay.addSubview(label)
+        view.addSubview(overlay)
+
         NSLayoutConstraint.activate([
             webView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
             webView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             webView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             webView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            overlay.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor),
+            overlay.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            overlay.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            overlay.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+            spinner.centerXAnchor.constraint(equalTo: overlay.centerXAnchor),
+            spinner.centerYAnchor.constraint(equalTo: overlay.centerYAnchor, constant: -16),
+            label.topAnchor.constraint(equalTo: spinner.bottomAnchor, constant: 12),
+            label.leadingAnchor.constraint(equalTo: overlay.leadingAnchor, constant: 24),
+            label.trailingAnchor.constraint(equalTo: overlay.trailingAnchor, constant: -24),
         ])
         configuration.websiteDataStore.httpCookieStore.add(self)
         self.webView = webView
+        self.completionOverlay = overlay
         startCompletionPolling()
         webView.load(URLRequest(url: url))
     }
@@ -519,14 +554,62 @@ private final class FireCloudflareChallengeViewController: UIViewController, WKN
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
         Task { @MainActor in
+            await noteActiveChallengeIfPresent(in: webView)
             await evaluateCompletion()
         }
     }
 
     func webView(_ webView: WKWebView, didCommit navigation: WKNavigation!) {
         Task { @MainActor in
-            await evaluateCompletion()
+            // CF often reloads bare `/challenge` after pass; cover before 404 paints.
+            if self.isBareChallengeURL(webView.url) && self.hasSeenActiveChallenge {
+                self.showCompletionOverlay()
+            }
+            await self.evaluateCompletion()
         }
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        if navigationAction.targetFrame?.isMainFrame != false,
+           isBareChallengeURL(navigationAction.request.url),
+           hasSeenActiveChallenge || observedFreshClearance
+        {
+            // fluxdo: post-pass navigation back to /challenge is origin fallback.
+            showCompletionOverlay()
+        }
+        decisionHandler(.allow)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationResponse: WKNavigationResponse,
+        decisionHandler: @escaping (WKNavigationResponsePolicy) -> Void
+    ) {
+        let response = navigationResponse.response
+        let http = response as? HTTPURLResponse
+        let responseURL = http?.url ?? response.url
+        if navigationResponse.isForMainFrame,
+           isBareChallengeURL(responseURL),
+           let status = http?.statusCode,
+           status == 404,
+           !Self.hasCloudflareMitigatedChallenge(http)
+        {
+            // Source-site 404 on /challenge == CF passed. Cancel so Discourse's
+            // "page does not exist" body never becomes visible.
+            showCompletionOverlay()
+            decisionHandler(.cancel)
+            Task { @MainActor in
+                await self.finishIfFreshClearanceAvailable(
+                    reason: "main frame /challenge returned source 404"
+                )
+            }
+            return
+        }
+        decisionHandler(.allow)
     }
 
     func webView(
@@ -561,12 +644,93 @@ private final class FireCloudflareChallengeViewController: UIViewController, WKN
         else {
             return
         }
+        observedFreshClearance = true
 
-        let stillBlocked = (try? await challengeStillPresent(in: webView)) ?? true
-        guard !stillBlocked else {
+        let pageState = (try? await challengePageState(in: webView)) ?? .activeChallenge
+        switch pageState {
+        case .activeChallenge:
+            hasSeenActiveChallenge = true
+            return
+        case .originFallbackNotFound:
+            // Post-pass Discourse 404 for /challenge — cover and finish.
+            showCompletionOverlay()
+        case .passedNonChallenge:
+            // Non-challenge page (or already covered). Safe to finish.
+            if isBareChallengeURL(webView.url) || hasSeenActiveChallenge {
+                showCompletionOverlay()
+            }
+        }
+
+        finish(.completed(browserUserAgent: webView.customUserAgent, freshCfClearance: freshCfClearance))
+    }
+
+    @MainActor
+    private func finishIfFreshClearanceAvailable(reason: String) async {
+        guard !finished else { return }
+        guard let webView else { return }
+        let cookies: [HTTPCookie] = await withCheckedContinuation { continuation in
+            webView.configuration.websiteDataStore.httpCookieStore.getAllCookies { cookies in
+                continuation.resume(returning: cookies)
+            }
+        }
+        guard
+            let freshCfClearance = freshCloudflareClearanceValue(
+                from: cookies,
+                comparedTo: baselineSnapshot
+            )
+        else {
+            // Keep overlay up and let polling retry once Set-Cookie settles.
             return
         }
+        observedFreshClearance = true
+        FireAPMManager.shared.recordBreadcrumb(
+            level: "info",
+            target: "auth.cf",
+            message: "challenge complete via \(reason)"
+        )
         finish(.completed(browserUserAgent: webView.customUserAgent, freshCfClearance: freshCfClearance))
+    }
+
+    @MainActor
+    private func noteActiveChallengeIfPresent(in webView: WKWebView) async {
+        let state = (try? await challengePageState(in: webView)) ?? .passedNonChallenge
+        if state == .activeChallenge {
+            hasSeenActiveChallenge = true
+        }
+    }
+
+    @MainActor
+    private func showCompletionOverlay() {
+        guard let completionOverlay else { return }
+        completionOverlay.isHidden = false
+        view.bringSubviewToFront(completionOverlay)
+    }
+
+    private func isBareChallengeURL(_ url: URL?) -> Bool {
+        guard let url else { return false }
+        guard let host = url.host?.lowercased(), host.contains("linux.do") else {
+            return false
+        }
+        let path = url.path.lowercased().trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        // bare `/challenge` only — ignore query-bearing challenge platform URLs
+        return path == "challenge" && (url.query?.isEmpty ?? true)
+    }
+
+    private static func hasCloudflareMitigatedChallenge(_ response: HTTPURLResponse?) -> Bool {
+        guard let response else { return false }
+        for (key, value) in response.allHeaderFields {
+            guard String(describing: key).caseInsensitiveCompare("cf-mitigated") == .orderedSame else {
+                continue
+            }
+            return String(describing: value).localizedCaseInsensitiveContains("challenge")
+        }
+        return false
+    }
+
+    private enum ChallengePageState {
+        case activeChallenge
+        case originFallbackNotFound
+        case passedNonChallenge
     }
 
     private func freshCloudflareClearanceValue(
@@ -606,7 +770,7 @@ private final class FireCloudflareChallengeViewController: UIViewController, WKN
         )
     }
 
-    private func challengeStillPresent(in webView: WKWebView) async throws -> Bool {
+    private func challengePageState(in webView: WKWebView) async throws -> ChallengePageState {
         let value = try await webView.evaluateJavaScript(
             """
             (function() {
@@ -615,6 +779,18 @@ private final class FireCloudflareChallengeViewController: UIViewController, WKN
                 var html = (document.documentElement && document.documentElement.outerHTML || '')
                   .slice(0, 12000)
                   .toLowerCase();
+                var originNotFound =
+                  html.indexOf('page-not-found') !== -1 ||
+                  html.indexOf('discourse-no-results') !== -1 ||
+                  html.indexOf('"errortype":"notfound"') !== -1 ||
+                  html.indexOf('404-body') !== -1 ||
+                  html.indexOf('exist or is private') !== -1 ||
+                  html.indexOf('page you requested') !== -1 ||
+                  title.indexOf('page not found') !== -1 ||
+                  title.indexOf('oops') !== -1;
+                if (originNotFound) {
+                  return 'origin_404';
+                }
                 var active = html.indexOf('cf_chl_opt') !== -1 ||
                   html.indexOf('cf-turnstile') !== -1 ||
                   html.indexOf('challenge-running') !== -1 ||
@@ -623,23 +799,20 @@ private final class FireCloudflareChallengeViewController: UIViewController, WKN
                   (title.indexOf('just a moment') !== -1) ||
                   (html.indexOf('just a moment') !== -1 &&
                     (html.indexOf('cloudflare') !== -1 || html.indexOf('cf-challenge') !== -1));
-                var originNotFound =
-                  html.indexOf('page-not-found') !== -1 ||
-                  html.indexOf('discourse-no-results') !== -1 ||
-                  html.indexOf('"errortype":"notfound"') !== -1 ||
-                  html.indexOf('404-body') !== -1 ||
-                  html.indexOf('exist or is private') !== -1 ||
-                  html.indexOf('page you requested') !== -1;
-                if (originNotFound) {
-                  return false;
-                }
-                return active;
+                return active ? 'active' : 'passed';
               } catch (error) {
-                return true;
+                return 'active';
               }
             })();
             """
         )
-        return value as? Bool ?? true
+        switch (value as? String)?.lowercased() {
+        case "origin_404":
+            return .originFallbackNotFound
+        case "passed":
+            return .passedNonChallenge
+        default:
+            return .activeChallenge
+        }
     }
 }

--- a/native/ios-app/Sources/FireAppSession/FireCloudflareChallengeCoordinator.swift
+++ b/native/ios-app/Sources/FireAppSession/FireCloudflareChallengeCoordinator.swift
@@ -81,6 +81,18 @@ final class FireCloudflareChallengeCoordinator: NSObject, @unchecked Sendable {
     private func complete(
         request: CloudflareChallengeRequestState
     ) async -> CloudflareChallengeResultState {
+        // Background/silent traffic must not steal focus. Rust only starts a new
+        // challenge for foreground requests; this is a defensive host-side gate.
+        guard request.isForeground else {
+            return CloudflareChallengeResultState(
+                completed: false,
+                userCancelled: false,
+                freshCfClearance: nil,
+                cookies: [],
+                browserUserAgent: nil
+            )
+        }
+
         guard let presenter = topPresenter() else {
             return CloudflareChallengeResultState(
                 completed: false,
@@ -604,6 +616,9 @@ private final class FireCloudflareChallengeViewController: UIViewController, WKN
                   .slice(0, 12000)
                   .toLowerCase();
                 return html.indexOf('cf_chl_opt') !== -1 ||
+                  html.indexOf('cf-turnstile') !== -1 ||
+                  html.indexOf('challenge-running') !== -1 ||
+                  html.indexOf('challenge-stage') !== -1 ||
                   (html.indexOf('challenge-platform') !== -1 && html.indexOf('cloudflare') !== -1) ||
                   (title.indexOf('just a moment') !== -1) ||
                   (html.indexOf('just a moment') !== -1 &&

--- a/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
+++ b/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
@@ -135,6 +135,20 @@ public actor FireSessionStore {
         try core.session().unregisterCloudflareChallengeHandler()
     }
 
+    public func registerCloudflareClearanceResolvedHandler(
+        _ handler: any CloudflareClearanceResolvedHandler
+    ) throws {
+        try core.session().registerCloudflareClearanceResolvedHandler(handler: handler)
+    }
+
+    public func unregisterCloudflareClearanceResolvedHandler() throws {
+        try core.session().unregisterCloudflareClearanceResolvedHandler()
+    }
+
+    public func cloudflareClearanceResolvedGeneration() throws -> UInt64 {
+        try core.session().cloudflareClearanceResolvedGeneration()
+    }
+
     public func registerCookieSelfHealingHandler(
         _ handler: any CookieSelfHealingHandler
     ) throws {

--- a/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
+++ b/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
@@ -355,6 +355,20 @@ public actor FireSessionStore {
         return state
     }
 
+    public func cloudflareClearanceIsTrusted() throws -> Bool {
+        try core.session().cloudflareClearanceIsTrusted()
+    }
+
+    public func noteCloudflareClearanceRejected() throws {
+        try core.session().noteCloudflareClearanceRejected()
+    }
+
+    public func finalizeLoginReady() async throws -> SessionState {
+        let state = try await core.session().finalizeLoginReady()
+        try persistCurrentSessionIfNeeded()
+        return state
+    }
+
     public func classifyWebViewLoginResult(
         _ result: WebViewLoginJsResultState
     ) throws -> WebViewLoginDecisionState {

--- a/native/ios-app/Sources/FireAppSession/FireWebViewBrowserProfile.swift
+++ b/native/ios-app/Sources/FireAppSession/FireWebViewBrowserProfile.swift
@@ -193,6 +193,37 @@ enum FireLoginScripts {
         "(function(){return window.__rawPreloaded||null;})()"
     }
 
+    /// Active Cloudflare interstitial markers (aligned with challenge completion).
+    static var hasActiveCloudflareChallenge: String {
+        """
+        (function() {
+          try {
+            var title = (document.title || '').toLowerCase();
+            var html = ((document.documentElement && document.documentElement.outerHTML) || '')
+              .slice(0, 12000)
+              .toLowerCase();
+            var active = html.indexOf('cf_chl_opt') !== -1 ||
+              html.indexOf('cf-turnstile') !== -1 ||
+              html.indexOf('challenge-running') !== -1 ||
+              html.indexOf('challenge-stage') !== -1 ||
+              (html.indexOf('challenge-platform') !== -1 && html.indexOf('cloudflare') !== -1) ||
+              title.indexOf('just a moment') !== -1 ||
+              (html.indexOf('just a moment') !== -1 &&
+                (html.indexOf('cloudflare') !== -1 || html.indexOf('cf-challenge') !== -1));
+            var originNotFound =
+              html.indexOf('page-not-found') !== -1 ||
+              html.indexOf('discourse-no-results') !== -1 ||
+              html.indexOf('"errortype":"notfound"') !== -1 ||
+              html.indexOf('404-body') !== -1;
+            if (originNotFound) return false;
+            return active;
+          } catch (error) {
+            return false;
+          }
+        })();
+        """
+    }
+
     static func minimalLoginHTML(
         hcaptchaSiteKey: String,
         hcaptchaCreateEndpoint: String? = nil

--- a/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
+++ b/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
@@ -293,6 +293,7 @@ protocol FireLoginSessionStoring: Sendable {
         _ captured: FireCapturedLoginState,
         allowLowConfidenceSessionCookies: Bool
     ) async throws -> LoginFinalizationResultState
+    func finalizeLoginReady() async throws -> SessionState
     func syncLoginContext(_ captured: FireCapturedLoginState) async throws -> SessionState
     func refreshBootstrapIfNeeded() async throws -> SessionState
     func refreshCsrfTokenIfNeeded() async throws -> SessionState

--- a/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
+++ b/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
@@ -369,11 +369,14 @@ public final class FireWebViewLoginCoordinator {
             captured,
             allowLowConfidenceSessionCookies: false
         )
-        if finalized.session.loginPhase == .ready {
+        let hasAuthCookies = finalized.session.readiness.hasLoginCookie
+            || !(finalized.session.cookies.tToken?.isEmpty ?? true)
+        guard finalized.success || hasAuthCookies else {
             return finalized.session
         }
-
-        return try await sessionStore.refreshBootstrapIfNeeded()
+        // fluxdo LoginReady: bootstrap with timeout, never block home entry once
+        // auth cookies are present.
+        return try await sessionStore.finalizeLoginReady()
     }
 
     public func captureJsLoginState(

--- a/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
+++ b/native/ios-app/Sources/FireAppSession/FireWebViewLoginCoordinator.swift
@@ -357,6 +357,8 @@ public final class FireWebViewLoginCoordinator {
         guard readiness.isReady else {
             throw FireWebViewLoginCoordinatorError.loginSyncNotReady(readiness)
         }
+        // Prefer current-page bootstrap when present; otherwise finalize cookies
+        // first and let refreshBootstrapIfNeeded hydrate site metadata.
         return try await completeLogin(captured)
     }
 
@@ -925,8 +927,11 @@ public final class FireWebViewLoginCoordinator {
         let hasBootstrapHTML =
             preferredBootstrapScore >= FireBootstrapHTMLHeuristics.reusableLoginBootstrapScoreThreshold
 
+        // Align with fluxdo WebView OAuth completion:
+        // username + session cookies are enough to finalize. Bootstrap HTML is
+        // preferred but can be refreshed over HTTP after cookie handoff.
         return FireLoginSyncReadiness(
-            isReady: hasUsername && hasAuthCookies && hasBootstrapHTML,
+            isReady: hasUsername && hasAuthCookies,
             username: normalizedUsername,
             hasAuthCookies: hasAuthCookies,
             hasBootstrapHTML: hasBootstrapHTML,

--- a/native/ios-app/Tests/Unit/FireRichTextParagraphBoundaryTests.swift
+++ b/native/ios-app/Tests/Unit/FireRichTextParagraphBoundaryTests.swift
@@ -42,7 +42,15 @@ final class FireRichTextParagraphBoundaryTests: XCTestCase {
         let html = "<hr><p>After divider</p>"
         let text = renderedText(html)
 
-        XCTAssertEqual(text, "----------\n\nAfter divider")
+        // Dividers render as a thin hairline (NBSP spacer), not dashed ASCII.
+        XCTAssertTrue(text.contains("After divider"))
+        XCTAssertFalse(text.contains("----------"))
+        XCTAssertFalse(text.contains("\n\n\n"), "Divider must not inject extra blank paragraphs.")
+        // Exactly one block boundary between divider spacer and following paragraph.
+        XCTAssertTrue(
+            text.contains("\u{00A0}\n\nAfter divider") || text.hasSuffix("After divider"),
+            "Unexpected divider spacing: \(text.debugDescription)"
+        )
     }
 
     func testMultipleHeadingsDoNotAccumulateNewlines() {

--- a/native/ios-app/Tests/Unit/FireTopicDetailStoreTests.swift
+++ b/native/ios-app/Tests/Unit/FireTopicDetailStoreTests.swift
@@ -542,7 +542,7 @@ final class FireTopicDetailStoreTests: XCTestCase {
 
         XCTAssertEqual(
             calls,
-            [.finalizeLoginFromWebView]
+            [.finalizeLoginFromWebView, .finalizeLoginReady]
         )
         XCTAssertEqual(finalizedCapture, captured)
         XCTAssertNil(finalState.cookies.csrfToken)
@@ -614,7 +614,7 @@ final class FireTopicDetailStoreTests: XCTestCase {
     }
 
     @MainActor
-    func testCompleteLoginRollsBackPartialSessionWhenBootstrapRefreshChallenges() async throws {
+    func testCompleteLoginKeepsCookiesWhenLoginReadyBootstrapChallenges() async throws {
         let captured = FireCapturedLoginState(
             currentURL: "https://linux.do/",
             username: "alice",
@@ -682,21 +682,20 @@ final class FireTopicDetailStoreTests: XCTestCase {
         )
         let coordinator = FireWebViewLoginCoordinator(loginSessionStore: store)
 
-        do {
-            _ = try await coordinator.completeLogin(captured)
-            XCTFail("Expected CloudflareChallenge during bootstrap refresh")
-        } catch {
-            XCTAssertTrue(error is FireUniFfiError)
-        }
+        // fluxdo LoginReady finally: trusted cookies still enter home even if
+        // bootstrap/CF refresh is incomplete.
+        let finalState = try await coordinator.completeLogin(captured)
         let calls = await store.callsSnapshot()
 
         XCTAssertEqual(
             calls,
             [
                 .finalizeLoginFromWebView,
-                .refreshBootstrapIfNeeded,
+                .finalizeLoginReady,
             ]
         )
+        XCTAssertEqual(finalState.cookies.tToken, "token")
+        XCTAssertTrue(finalState.readiness.canReadAuthenticatedApi)
     }
 
     func testReplyContextRowsAppendMissingNestedRepliesWithDepth() {
@@ -925,6 +924,7 @@ private actor MockLoginSessionStore: FireLoginSessionStoring {
     enum Call: Equatable {
         case currentSessionSnapshot
         case finalizeLoginFromWebView
+        case finalizeLoginReady
         case applyPlatformCookies
         case completeCloudflareChallenge
         case syncLoginContext
@@ -985,6 +985,15 @@ private actor MockLoginSessionStore: FireLoginSessionStoring {
             tTokenVerified: true,
             fingerprintWaitNeeded: true
         )
+    }
+
+    func finalizeLoginReady() async throws -> SessionState {
+        calls.append(.finalizeLoginReady)
+        if let bootstrapError {
+            // Keep login-ready finally semantics: still return cookies even if bootstrap fails.
+            return finalizationResult
+        }
+        return bootstrapResult
     }
 
     func syncLoginContext(_ captured: FireCapturedLoginState) async throws -> SessionState {

--- a/native/ios-app/Tests/Unit/FireTopicDetailStoreTests.swift
+++ b/native/ios-app/Tests/Unit/FireTopicDetailStoreTests.swift
@@ -678,7 +678,7 @@ final class FireTopicDetailStoreTests: XCTestCase {
         let store = MockLoginSessionStore(
             finalizationResult: partialState,
             bootstrapResult: partialState,
-            bootstrapError: FireUniFfiError.CloudflareChallenge
+            bootstrapError: FireUniFfiError.CloudflareChallenge(reason: "required")
         )
         let coordinator = FireWebViewLoginCoordinator(loginSessionStore: store)
 

--- a/native/ios-app/Tests/Unit/FireTopicPresentationTests.swift
+++ b/native/ios-app/Tests/Unit/FireTopicPresentationTests.swift
@@ -670,12 +670,15 @@ final class FireTopicPresentationTests: XCTestCase {
     }
 
     func testRenderContentCompactsQuotedReplyPreview() throws {
+        // Reply-quotes keep a 4-line compact preview (body blockquotes stay full-length).
         let content = fireRenderContentFixture(#"""
             <aside class="quote" data-username="alice" data-post="12" data-topic="987">
               <blockquote>
                 <p>First quoted line</p>
                 <p>Second quoted line</p>
-                <p>Third quoted line should be hidden</p>
+                <p>Third quoted line</p>
+                <p>Fourth quoted line</p>
+                <p>Fifth quoted line should be hidden</p>
               </blockquote>
             </aside>
             """#)
@@ -685,7 +688,9 @@ final class FireTopicPresentationTests: XCTestCase {
 
         XCTAssertTrue(text.contains("First quoted line"))
         XCTAssertTrue(text.contains("Second quoted line"))
-        XCTAssertFalse(text.contains("Third quoted line should be hidden"))
+        XCTAssertTrue(text.contains("Third quoted line"))
+        XCTAssertTrue(text.contains("Fourth quoted line"))
+        XCTAssertFalse(text.contains("Fifth quoted line should be hidden"))
         XCTAssertTrue(text.contains("引用"))
         XCTAssertEqual(
             attributedText.attribute(.fireQuotePreviewBlock, at: 0, effectiveRange: nil) as? Bool,

--- a/rust/crates/fire-core/src/app_state_refresher.rs
+++ b/rust/crates/fire-core/src/app_state_refresher.rs
@@ -29,23 +29,41 @@ impl AppStateRefresher {
         self.refresh_all_with_handler(trigger, None).await
     }
 
+    /// Bypass the normal debounce window (used after Cloudflare success).
+    pub async fn refresh_all_forced(&self, trigger: RefreshTrigger) -> Result<(), FireCoreError> {
+        self.refresh_all_with_handler_inner(trigger, None, true)
+            .await
+    }
+
     pub async fn refresh_all_with_handler(
         &self,
         trigger: RefreshTrigger,
         observer: Option<AppStateRefreshObserver>,
     ) -> Result<(), FireCoreError> {
+        self.refresh_all_with_handler_inner(trigger, observer, false)
+            .await
+    }
+
+    async fn refresh_all_with_handler_inner(
+        &self,
+        trigger: RefreshTrigger,
+        observer: Option<AppStateRefreshObserver>,
+        force: bool,
+    ) -> Result<(), FireCoreError> {
         {
             let mut last = self.last_refresh.lock().unwrap();
-            if let Some(instant) = *last {
-                if instant.elapsed() < DEBOUNCE_DURATION {
-                    info!("app state refresh debounced, skipping");
-                    return Ok(());
+            if !force {
+                if let Some(instant) = *last {
+                    if instant.elapsed() < DEBOUNCE_DURATION {
+                        info!("app state refresh debounced, skipping");
+                        return Ok(());
+                    }
                 }
             }
             *last = Some(Instant::now());
         }
 
-        info!(?trigger, "starting app state refresh batch 1 (core)");
+        info!(?trigger, force, "starting app state refresh batch 1 (core)");
         let should_schedule_secondary = match self.refresh_core_batch(&trigger).await {
             Ok(should_schedule_secondary) => should_schedule_secondary,
             Err(error) => {

--- a/rust/crates/fire-core/src/cookies.rs
+++ b/rust/crates/fire-core/src/cookies.rs
@@ -85,12 +85,17 @@ impl CookieJar for FireSessionCookieJar {
                 "cf_clearance" => patch.cf_clearance = Some(cookie.value.clone()),
                 _ => {}
             }
-            let replay_domain = cookie
-                .domain
-                .as_deref()
-                .map(|d| d.trim_start_matches('.').to_string())
-                .unwrap_or_default();
-            replay_entries.push((value.to_string(), cookie.name.clone(), replay_domain));
+            // cf_clearance must not be replayed jar → WebView. Only browser/WebView
+            // authored clearance is trustworthy; Set-Cookie replay can drop
+            // Partitioned and create a ghost variant.
+            if !cookie.name.eq_ignore_ascii_case("cf_clearance") {
+                let replay_domain = cookie
+                    .domain
+                    .as_deref()
+                    .map(|d| d.trim_start_matches('.').to_string())
+                    .unwrap_or_default();
+                replay_entries.push((value.to_string(), cookie.name.clone(), replay_domain));
+            }
             patch.platform_cookies.push(cookie);
         }
 

--- a/rust/crates/fire-core/src/core/auth.rs
+++ b/rust/crates/fire-core/src/core/auth.rs
@@ -1,3 +1,6 @@
+use std::future::Future;
+use std::sync::OnceLock;
+
 use fire_models::{
     AuthRuntimeSignal, AuthRuntimeSignalKind, AuthRuntimeSignalSource, AuthRuntimeSignalStrength,
     BootstrapArtifacts, CookieSnapshot, PassiveLogoutTrigger, ProbeResult, SessionSnapshot,
@@ -5,6 +8,7 @@ use fire_models::{
 };
 use http::{Method, StatusCode};
 use serde_json::Value;
+use tokio::runtime::{Builder, Handle, Runtime};
 use tracing::{debug, info, warn};
 
 use super::{
@@ -46,23 +50,63 @@ impl FireCore {
         }
     }
 
-    /// Force one bootstrap rebuild after CF success when already logged in.
+    /// After CF success: publish resolved generation, force bootstrap + full
+    /// app-state refresh when logged in, then notify platform subscribers
+    /// (MessageBus restart / banner clear / login continue).
+    /// Safe to call from sync UniFFI paths (falls back when no Tokio handle).
     pub(crate) fn schedule_post_challenge_session_rebuild(&self) {
+        // Manual path bumps here; network path bumps in finish(true) right after.
+        let generation_hint = self.publish_clearance_resolved_if_idle();
         let has_login = self.snapshot().cookies.has_login_session();
-        if !has_login {
-            return;
-        }
         let core = self.clone();
-        tokio::spawn(async move {
+        spawn_post_challenge_task(async move {
+            // Allow network finish(true) to publish generation before we notify.
+            tokio::time::sleep(std::time::Duration::from_millis(30)).await;
+
+            if !has_login {
+                let generation = core
+                    .cloudflare_clearance_resolved_generation()
+                    .max(generation_hint);
+                core.notify_clearance_resolved(generation);
+                return;
+            }
+
+            // Let cookie merge settle before the rebuild wave.
+            let settle = {
+                let runtime = core
+                    .cloudflare_challenge_runtime
+                    .lock()
+                    .expect("cloudflare challenge runtime mutex poisoned");
+                runtime.trust_settle_remaining()
+            };
+            if let Some(remaining) = settle {
+                tokio::time::sleep(remaining).await;
+            }
+
             match core.refresh_bootstrap().await {
                 Ok(_) => {
                     info!("post-challenge bootstrap rebuild complete");
-                    core.state_observers().notify_session(core.snapshot());
                 }
                 Err(error) => {
                     warn!(error = %error, "post-challenge bootstrap rebuild failed");
                 }
             }
+            core.state_observers().notify_session(core.snapshot());
+
+            // Force a full loginCompleted-style batch so CF mid-refresh does not
+            // leave home/notifications stuck on a partial failure.
+            if let Err(error) = core
+                .app_state_refresher()
+                .refresh_all_forced(fire_models::RefreshTrigger::CloudflareResolved)
+                .await
+            {
+                warn!(error = %error, "post-challenge app state refresh failed");
+            }
+
+            let generation = core
+                .cloudflare_clearance_resolved_generation()
+                .max(generation_hint);
+            core.notify_clearance_resolved(generation);
         });
     }
 
@@ -565,5 +609,27 @@ impl FireCore {
             }
             StrikeDecision::Accumulated { .. } | StrikeDecision::Ignore => None,
         }
+    }
+}
+
+fn post_challenge_runtime() -> &'static Runtime {
+    static RUNTIME: OnceLock<Runtime> = OnceLock::new();
+    RUNTIME.get_or_init(|| {
+        Builder::new_multi_thread()
+            .enable_all()
+            .thread_name("fire-post-challenge")
+            .build()
+            .expect("failed to create post-challenge runtime")
+    })
+}
+
+fn spawn_post_challenge_task<F>(future: F)
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    if let Ok(handle) = Handle::try_current() {
+        handle.spawn(future);
+    } else {
+        post_challenge_runtime().spawn(future);
     }
 }

--- a/rust/crates/fire-core/src/core/auth.rs
+++ b/rust/crates/fire-core/src/core/auth.rs
@@ -21,6 +21,51 @@ use crate::{
 };
 
 impl FireCore {
+    /// After cookie handoff during login: try bootstrap refresh with a hard
+    /// timeout, but never leave the UI stuck if bootstrap is slow. Cookie auth
+    /// alone is enough to enter the app (fluxdo LoginReady finally semantics).
+    pub async fn finalize_login_ready(&self) -> Result<SessionSnapshot, FireCoreError> {
+        const LOGIN_READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(8);
+
+        self.clear_cloudflare_clearance_rejected();
+
+        if !self.snapshot().cookies.has_login_session() {
+            return Ok(self.snapshot());
+        }
+
+        match tokio::time::timeout(LOGIN_READY_TIMEOUT, self.refresh_bootstrap_if_needed()).await {
+            Ok(Ok(snapshot)) => Ok(snapshot),
+            Ok(Err(error)) => {
+                warn!(error = %error, "login-ready bootstrap refresh failed; continuing with cookies");
+                Ok(self.snapshot())
+            }
+            Err(_) => {
+                warn!("login-ready bootstrap refresh timed out; continuing with cookies");
+                Ok(self.snapshot())
+            }
+        }
+    }
+
+    /// Force one bootstrap rebuild after CF success when already logged in.
+    pub(crate) fn schedule_post_challenge_session_rebuild(&self) {
+        let has_login = self.snapshot().cookies.has_login_session();
+        if !has_login {
+            return;
+        }
+        let core = self.clone();
+        tokio::spawn(async move {
+            match core.refresh_bootstrap().await {
+                Ok(_) => {
+                    info!("post-challenge bootstrap rebuild complete");
+                    core.state_observers().notify_session(core.snapshot());
+                }
+                Err(error) => {
+                    warn!(error = %error, "post-challenge bootstrap rebuild failed");
+                }
+            }
+        });
+    }
+
     pub async fn refresh_bootstrap_if_needed(&self) -> Result<SessionSnapshot, FireCoreError> {
         let current = self.snapshot();
         let readiness = current.readiness();

--- a/rust/crates/fire-core/src/core/cf_challenge.rs
+++ b/rust/crates/fire-core/src/core/cf_challenge.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use fire_models::{CloudflareChallengeRequest, CloudflareChallengeResult};
+use tokio::sync::watch;
 
 use super::FireCore;
 
@@ -14,7 +15,26 @@ pub(crate) type FireCloudflareChallengeFuture =
 pub(crate) type FireCloudflareChallengeHandlerFn =
     Arc<dyn Fn(CloudflareChallengeRequest) -> FireCloudflareChallengeFuture + Send + Sync>;
 
-const CLOUDFLARE_CHALLENGE_FAILURE_COOLDOWN: Duration = Duration::from_secs(15);
+const CLOUDFLARE_CHALLENGE_FAILURE_COOLDOWN: Duration = Duration::from_secs(30);
+const CLOUDFLARE_CHALLENGE_FAILURES_BEFORE_COOLDOWN: u32 = 3;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CloudflareChallengeJoinOutcome {
+    Succeeded,
+    Failed,
+}
+
+#[derive(Debug)]
+pub(crate) enum CloudflareChallengeBegin {
+    /// This caller owns the platform challenge presentation.
+    Start,
+    /// Another caller already owns the challenge; wait then retry locally.
+    Join(watch::Receiver<Option<CloudflareChallengeJoinOutcome>>),
+    /// Recent failures are cooling down and this caller may not bypass.
+    Cooldown,
+    /// Background/silent traffic must not open a new challenge UI.
+    BackgroundSuppressed,
+}
 
 #[derive(Clone, Default)]
 pub(crate) struct FireCloudflareChallengeHandlerRegistry {
@@ -44,34 +64,70 @@ impl FireCloudflareChallengeHandlerRegistry {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Default)]
 pub(crate) struct FireCloudflareChallengeRuntime {
     pub(crate) in_progress: bool,
     pub(crate) cooldown_until: Option<Instant>,
+    consecutive_failures: u32,
+    join_tx: Option<watch::Sender<Option<CloudflareChallengeJoinOutcome>>>,
+    join_rx: Option<watch::Receiver<Option<CloudflareChallengeJoinOutcome>>>,
 }
 
 impl FireCloudflareChallengeRuntime {
-    pub(crate) fn can_start(&self, bypass_cooldown: bool) -> bool {
-        if bypass_cooldown {
-            return !self.in_progress;
+    pub(crate) fn begin_or_join(&mut self, is_foreground: bool) -> CloudflareChallengeBegin {
+        if self.in_progress {
+            return self
+                .join_rx
+                .clone()
+                .map(CloudflareChallengeBegin::Join)
+                // Owner is tearing down; treat as a soft challenge failure.
+                .unwrap_or(CloudflareChallengeBegin::BackgroundSuppressed);
         }
-        self.cooldown_until
-            .is_none_or(|until| Instant::now() >= until)
-            && !self.in_progress
-    }
 
-    pub(crate) fn begin(&mut self) {
+        let in_cooldown = self
+            .cooldown_until
+            .is_some_and(|until| Instant::now() < until);
+        if in_cooldown && !is_foreground {
+            return CloudflareChallengeBegin::Cooldown;
+        }
+        if !is_foreground {
+            // Silent/background traffic never opens a new challenge surface.
+            // It may only join an already-running foreground verification.
+            return CloudflareChallengeBegin::BackgroundSuppressed;
+        }
+
+        let (tx, rx) = watch::channel(None);
         self.in_progress = true;
         self.cooldown_until = None;
+        self.join_tx = Some(tx);
+        self.join_rx = Some(rx);
+        CloudflareChallengeBegin::Start
     }
 
     pub(crate) fn finish(&mut self, success: bool) {
         self.in_progress = false;
-        self.cooldown_until = if success {
-            None
+        if success {
+            self.consecutive_failures = 0;
+            self.cooldown_until = None;
         } else {
-            Some(Instant::now() + CLOUDFLARE_CHALLENGE_FAILURE_COOLDOWN)
-        };
+            self.consecutive_failures = self.consecutive_failures.saturating_add(1);
+            self.cooldown_until =
+                if self.consecutive_failures >= CLOUDFLARE_CHALLENGE_FAILURES_BEFORE_COOLDOWN {
+                    Some(Instant::now() + CLOUDFLARE_CHALLENGE_FAILURE_COOLDOWN)
+                } else {
+                    None
+                };
+        }
+
+        if let Some(tx) = self.join_tx.take() {
+            let outcome = if success {
+                CloudflareChallengeJoinOutcome::Succeeded
+            } else {
+                CloudflareChallengeJoinOutcome::Failed
+            };
+            let _ = tx.send(Some(outcome));
+        }
+        self.join_rx = None;
     }
 }
 

--- a/rust/crates/fire-core/src/core/cf_challenge.rs
+++ b/rust/crates/fire-core/src/core/cf_challenge.rs
@@ -136,10 +136,7 @@ impl FireCloudflareChallengeRuntime {
         if success {
             self.consecutive_failures = 0;
             self.cooldown_until = None;
-            self.clearance_rejected_at = None;
-            self.trust_settle_until = Some(Instant::now() + TRUST_SETTLE_WINDOW);
-            self.resolved_generation = self.resolved_generation.saturating_add(1);
-            let _ = self.resolved_tx.send(self.resolved_generation);
+            let _ = self.publish_resolved();
         } else {
             self.consecutive_failures = self.consecutive_failures.saturating_add(1);
             self.cooldown_until =
@@ -159,6 +156,19 @@ impl FireCloudflareChallengeRuntime {
             let _ = tx.send(Some(outcome));
         }
         self.join_rx = None;
+    }
+
+    /// Publish a new clearance-resolved generation (manual or network success).
+    pub(crate) fn publish_resolved(&mut self) -> u64 {
+        self.clearance_rejected_at = None;
+        self.trust_settle_until = Some(Instant::now() + TRUST_SETTLE_WINDOW);
+        self.resolved_generation = self.resolved_generation.saturating_add(1);
+        let _ = self.resolved_tx.send(self.resolved_generation);
+        self.resolved_generation
+    }
+
+    pub(crate) fn in_progress(&self) -> bool {
+        self.in_progress
     }
 
     pub(crate) fn mark_clearance_rejected(&mut self) {
@@ -184,13 +194,44 @@ impl FireCloudflareChallengeRuntime {
         }
     }
 
-    #[allow(dead_code)] // Reserved for platform/login-ready subscribers.
+    #[allow(dead_code)] // Available for internal awaiters / tests.
     pub(crate) fn subscribe_resolved(&self) -> watch::Receiver<u64> {
         self.resolved_tx.subscribe()
     }
 
     pub(crate) fn resolved_generation(&self) -> u64 {
         self.resolved_generation
+    }
+}
+
+pub(crate) type FireClearanceResolvedHandlerFn =
+    Arc<dyn Fn(fire_models::CloudflareClearanceResolvedEvent) + Send + Sync>;
+
+#[derive(Clone, Default)]
+pub(crate) struct FireClearanceResolvedHandlerRegistry {
+    inner: Arc<Mutex<Option<FireClearanceResolvedHandlerFn>>>,
+}
+
+impl FireClearanceResolvedHandlerRegistry {
+    pub(crate) fn set(&self, handler: FireClearanceResolvedHandlerFn) {
+        *self
+            .inner
+            .lock()
+            .expect("clearance resolved handler mutex poisoned") = Some(handler);
+    }
+
+    pub(crate) fn clear(&self) {
+        *self
+            .inner
+            .lock()
+            .expect("clearance resolved handler mutex poisoned") = None;
+    }
+
+    pub(crate) fn get(&self) -> Option<FireClearanceResolvedHandlerFn> {
+        self.inner
+            .lock()
+            .expect("clearance resolved handler mutex poisoned")
+            .clone()
     }
 }
 
@@ -213,10 +254,7 @@ impl FireCore {
     /// Local jar has clearance and it has not been rejected by CF recently.
     pub fn cloudflare_clearance_is_trusted(&self) -> bool {
         let has_clearance = {
-            let session = self
-                .session
-                .read()
-                .expect("session mutex poisoned");
+            let session = self.session.read().expect("session mutex poisoned");
             session.snapshot.cookies.has_cloudflare_clearance()
         };
         if !has_clearance {
@@ -244,14 +282,57 @@ impl FireCore {
             .expect("cloudflare challenge runtime mutex poisoned");
         runtime.clear_clearance_rejected();
     }
-}
 
+    pub fn cloudflare_clearance_resolved_generation(&self) -> u64 {
+        self.cloudflare_challenge_runtime
+            .lock()
+            .expect("cloudflare challenge runtime mutex poisoned")
+            .resolved_generation()
+    }
+
+    pub fn set_cloudflare_clearance_resolved_handler<F>(&self, handler: F)
+    where
+        F: Fn(fire_models::CloudflareClearanceResolvedEvent) + Send + Sync + 'static,
+    {
+        self.clearance_resolved_handler
+            .set(Arc::new(handler) as FireClearanceResolvedHandlerFn);
+    }
+
+    pub fn clear_cloudflare_clearance_resolved_handler(&self) {
+        self.clearance_resolved_handler.clear();
+    }
+
+    /// Mark clearance resolved for paths that never entered the network join gate
+    /// (manual login preflight / platform-owned challenge).
+    pub(crate) fn publish_clearance_resolved_if_idle(&self) -> u64 {
+        let mut runtime = self
+            .cloudflare_challenge_runtime
+            .lock()
+            .expect("cloudflare challenge runtime mutex poisoned");
+        if runtime.in_progress() {
+            // Network owner will publish via finish(true).
+            runtime.resolved_generation()
+        } else {
+            runtime.publish_resolved()
+        }
+    }
+
+    pub(crate) fn notify_clearance_resolved(&self, generation: u64) {
+        let snapshot = self.snapshot();
+        let event = fire_models::CloudflareClearanceResolvedEvent {
+            generation,
+            has_login_session: snapshot.cookies.has_login_session(),
+            can_open_message_bus: snapshot.readiness().can_open_message_bus,
+        };
+        if let Some(handler) = self.clearance_resolved_handler.get() {
+            handler(event);
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::thread;
-    use std::time::Duration;
 
     #[test]
     fn recently_rejected_expires() {

--- a/rust/crates/fire-core/src/core/cf_challenge.rs
+++ b/rust/crates/fire-core/src/core/cf_challenge.rs
@@ -17,6 +17,11 @@ pub(crate) type FireCloudflareChallengeHandlerFn =
 
 const CLOUDFLARE_CHALLENGE_FAILURE_COOLDOWN: Duration = Duration::from_secs(30);
 const CLOUDFLARE_CHALLENGE_FAILURES_BEFORE_COOLDOWN: u32 = 3;
+/// After CF rejects a clearance, do not treat local jar clearance as trusted.
+pub(crate) const CLEARANCE_REJECTED_WINDOW: Duration = Duration::from_secs(120);
+/// Brief settle window after a successful challenge so first-wave requests see
+/// the merged jar before racing out.
+pub(crate) const TRUST_SETTLE_WINDOW: Duration = Duration::from_millis(400);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum CloudflareChallengeJoinOutcome {
@@ -64,13 +69,35 @@ impl FireCloudflareChallengeHandlerRegistry {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub(crate) struct FireCloudflareChallengeRuntime {
     pub(crate) in_progress: bool,
     pub(crate) cooldown_until: Option<Instant>,
     consecutive_failures: u32,
+    clearance_rejected_at: Option<Instant>,
+    trust_settle_until: Option<Instant>,
     join_tx: Option<watch::Sender<Option<CloudflareChallengeJoinOutcome>>>,
     join_rx: Option<watch::Receiver<Option<CloudflareChallengeJoinOutcome>>>,
+    /// Monotonic counter bumped on each successful challenge completion.
+    resolved_generation: u64,
+    resolved_tx: watch::Sender<u64>,
+}
+
+impl Default for FireCloudflareChallengeRuntime {
+    fn default() -> Self {
+        let (resolved_tx, _) = watch::channel(0);
+        Self {
+            in_progress: false,
+            cooldown_until: None,
+            consecutive_failures: 0,
+            clearance_rejected_at: None,
+            trust_settle_until: None,
+            join_tx: None,
+            join_rx: None,
+            resolved_generation: 0,
+            resolved_tx,
+        }
+    }
 }
 
 impl FireCloudflareChallengeRuntime {
@@ -109,6 +136,10 @@ impl FireCloudflareChallengeRuntime {
         if success {
             self.consecutive_failures = 0;
             self.cooldown_until = None;
+            self.clearance_rejected_at = None;
+            self.trust_settle_until = Some(Instant::now() + TRUST_SETTLE_WINDOW);
+            self.resolved_generation = self.resolved_generation.saturating_add(1);
+            let _ = self.resolved_tx.send(self.resolved_generation);
         } else {
             self.consecutive_failures = self.consecutive_failures.saturating_add(1);
             self.cooldown_until =
@@ -129,6 +160,38 @@ impl FireCloudflareChallengeRuntime {
         }
         self.join_rx = None;
     }
+
+    pub(crate) fn mark_clearance_rejected(&mut self) {
+        self.clearance_rejected_at = Some(Instant::now());
+    }
+
+    pub(crate) fn clear_clearance_rejected(&mut self) {
+        self.clearance_rejected_at = None;
+    }
+
+    pub(crate) fn is_clearance_recently_rejected(&self) -> bool {
+        self.clearance_rejected_at
+            .is_some_and(|at| Instant::now().duration_since(at) < CLEARANCE_REJECTED_WINDOW)
+    }
+
+    pub(crate) fn trust_settle_remaining(&self) -> Option<Duration> {
+        let until = self.trust_settle_until?;
+        let now = Instant::now();
+        if now >= until {
+            None
+        } else {
+            Some(until.saturating_duration_since(now))
+        }
+    }
+
+    #[allow(dead_code)] // Reserved for platform/login-ready subscribers.
+    pub(crate) fn subscribe_resolved(&self) -> watch::Receiver<u64> {
+        self.resolved_tx.subscribe()
+    }
+
+    pub(crate) fn resolved_generation(&self) -> u64 {
+        self.resolved_generation
+    }
 }
 
 impl FireCore {
@@ -145,5 +208,69 @@ impl FireCore {
 
     pub fn clear_cloudflare_challenge_handler(&self) {
         self.cloudflare_challenge_handler.clear();
+    }
+
+    /// Local jar has clearance and it has not been rejected by CF recently.
+    pub fn cloudflare_clearance_is_trusted(&self) -> bool {
+        let has_clearance = {
+            let session = self
+                .session
+                .read()
+                .expect("session mutex poisoned");
+            session.snapshot.cookies.has_cloudflare_clearance()
+        };
+        if !has_clearance {
+            return false;
+        }
+        let runtime = self
+            .cloudflare_challenge_runtime
+            .lock()
+            .expect("cloudflare challenge runtime mutex poisoned");
+        !runtime.is_clearance_recently_rejected()
+    }
+
+    pub fn note_cloudflare_clearance_rejected(&self) {
+        let mut runtime = self
+            .cloudflare_challenge_runtime
+            .lock()
+            .expect("cloudflare challenge runtime mutex poisoned");
+        runtime.mark_clearance_rejected();
+    }
+
+    pub fn clear_cloudflare_clearance_rejected(&self) {
+        let mut runtime = self
+            .cloudflare_challenge_runtime
+            .lock()
+            .expect("cloudflare challenge runtime mutex poisoned");
+        runtime.clear_clearance_rejected();
+    }
+}
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread;
+    use std::time::Duration;
+
+    #[test]
+    fn recently_rejected_expires() {
+        let mut runtime = FireCloudflareChallengeRuntime::default();
+        assert!(!runtime.is_clearance_recently_rejected());
+        runtime.mark_clearance_rejected();
+        assert!(runtime.is_clearance_recently_rejected());
+        runtime.clear_clearance_rejected();
+        assert!(!runtime.is_clearance_recently_rejected());
+    }
+
+    #[test]
+    fn finish_success_clears_reject_and_sets_settle() {
+        let mut runtime = FireCloudflareChallengeRuntime::default();
+        runtime.mark_clearance_rejected();
+        let _ = runtime.begin_or_join(true);
+        runtime.finish(true);
+        assert!(!runtime.is_clearance_recently_rejected());
+        assert!(runtime.trust_settle_remaining().is_some());
+        assert_eq!(runtime.resolved_generation(), 1);
     }
 }

--- a/rust/crates/fire-core/src/core/mod.rs
+++ b/rust/crates/fire-core/src/core/mod.rs
@@ -155,6 +155,7 @@ pub struct FireCore {
     csrf_refresh: Arc<TokioMutex<()>>,
     cloudflare_challenge_handler: cf_challenge::FireCloudflareChallengeHandlerRegistry,
     cloudflare_challenge_runtime: Arc<Mutex<cf_challenge::FireCloudflareChallengeRuntime>>,
+    clearance_resolved_handler: cf_challenge::FireClearanceResolvedHandlerRegistry,
     cookie_self_healing_handler: cookie_healing::FireCookieSelfHealingHandlerRegistry,
     preloaded_data: OnceLock<Arc<crate::preloaded_data::PreloadedDataService>>,
     app_state_refresher: OnceLock<Arc<crate::app_state_refresher::AppStateRefresher>>,
@@ -231,6 +232,8 @@ impl FireCore {
             cloudflare_challenge_handler:
                 cf_challenge::FireCloudflareChallengeHandlerRegistry::default(),
             cloudflare_challenge_runtime,
+            clearance_resolved_handler: cf_challenge::FireClearanceResolvedHandlerRegistry::default(
+            ),
             cookie_self_healing_handler:
                 cookie_healing::FireCookieSelfHealingHandlerRegistry::default(),
             preloaded_data: OnceLock::new(),

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -517,6 +517,17 @@ impl FireNetworkLayer {
             .extensions()
             .get::<FireSkipCloudflareBlock>()
             .is_some();
+        if !skip_cloudflare_block {
+            let settle = self
+                .cloudflare_challenge_runtime
+                .lock()
+                .expect("cloudflare challenge runtime mutex poisoned")
+                .trust_settle_remaining();
+            if let Some(remaining) = settle {
+                // Let jar merges become visible before the first post-challenge wave.
+                tokio::time::sleep(remaining).await;
+            }
+        }
         if !skip_cloudflare_block
             && self
                 .cloudflare_challenge_runtime
@@ -965,6 +976,8 @@ impl FireCore {
                     operation: Some(operation.to_string()),
                     status: Some(status.as_u16()),
                 });
+                // Local clearance (if any) was just rejected by the edge.
+                self.note_cloudflare_clearance_rejected();
                 self.capture_turnstile_sitekey_from_challenge_body(&body_text);
                 let handler = match self.cloudflare_challenge_handler.get() {
                     Some(handler) => handler,
@@ -1068,6 +1081,12 @@ impl FireCore {
                             .unwrap_or(CloudflareChallengeFailureReason::Failed),
                     });
                 }
+
+                // Rebuild session trust after a successful challenge: force one
+                // bootstrap refresh when already logged in (non-blocking for the
+                // original retry path).
+                self.schedule_post_challenge_session_rebuild();
+
                 return self
                     .retry_after_cloudflare_challenge(operation, retry_request, options)
                     .await;

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -27,11 +27,11 @@ use super::{
 };
 use crate::{
     cookies::{FireSessionCookieJar, FIRE_REQUEST_EPOCH, FIRE_REQUEST_TRACE_ID},
-    error::CloudflareChallengeFailureReason,
     diagnostics::{
         FireDiagnosticsStore, FireNetworkTraceCancellationGuard,
         FireNetworkTraceEventListenerFactory,
     },
+    error::CloudflareChallengeFailureReason,
     error::FireCoreError,
     sync_utils::{read_rwlock, write_rwlock},
 };
@@ -1077,15 +1077,12 @@ impl FireCore {
                 if !accepted {
                     return Err(FireCoreError::CloudflareChallenge {
                         operation,
-                        reason: failure_reason
-                            .unwrap_or(CloudflareChallengeFailureReason::Failed),
+                        reason: failure_reason.unwrap_or(CloudflareChallengeFailureReason::Failed),
                     });
                 }
 
-                // Rebuild session trust after a successful challenge: force one
-                // bootstrap refresh when already logged in (non-blocking for the
-                // original retry path).
-                self.schedule_post_challenge_session_rebuild();
+                // complete_cloudflare_challenge already schedules post-challenge
+                // bootstrap rebuild when a login session is present.
 
                 return self
                     .retry_after_cloudflare_challenge(operation, retry_request, options)
@@ -1872,7 +1869,7 @@ pub(crate) fn extract_turnstile_sitekey(body: &str) -> Option<String> {
         if let Some(index) = body.find(pattern) {
             let rest = &body[index + pattern.len()..];
             let end = rest
-                .find(|ch| matches!(ch, '"' | '\'' | ' ' | '<' | '>' | ',' | '}' | '\n' | '\r'))
+                .find(['"', '\'', ' ', '<', '>', ',', '}', '\n', '\r'])
                 .unwrap_or(rest.len());
             let candidate = rest[..end].trim();
             if candidate.len() >= 10 && candidate.is_ascii() {

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -267,6 +267,30 @@ pub(crate) struct FireSkipCsrfHeader;
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct FireSkipCloudflareBlock;
 
+struct CloudflareChallengeFinishGuard {
+    runtime: Arc<Mutex<super::cf_challenge::FireCloudflareChallengeRuntime>>,
+    finished: bool,
+}
+
+impl CloudflareChallengeFinishGuard {
+    fn finish(&mut self, success: bool) {
+        if self.finished {
+            return;
+        }
+        self.finished = true;
+        self.runtime
+            .lock()
+            .expect("cloudflare challenge runtime mutex poisoned")
+            .finish(success);
+    }
+}
+
+impl Drop for CloudflareChallengeFinishGuard {
+    fn drop(&mut self) {
+        self.finish(false);
+    }
+}
+
 #[derive(Clone, Copy, Debug, Default)]
 pub(crate) struct FireSkipCookieSelfHeal;
 
@@ -946,16 +970,37 @@ impl FireCore {
                         return Ok((trace_id, response_from_parts(parts, body)));
                     }
                 };
-                {
+
+                let begin = {
                     let mut runtime = self
                         .cloudflare_challenge_runtime
                         .lock()
                         .expect("cloudflare challenge runtime mutex poisoned");
-                    if !runtime.can_start(is_foreground) {
+                    runtime.begin_or_join(is_foreground)
+                };
+
+                match begin {
+                    super::cf_challenge::CloudflareChallengeBegin::Cooldown
+                    | super::cf_challenge::CloudflareChallengeBegin::BackgroundSuppressed => {
                         return Err(FireCoreError::CloudflareChallenge { operation });
                     }
-                    runtime.begin();
+                    super::cf_challenge::CloudflareChallengeBegin::Join(join_rx) => {
+                        return self
+                            .await_shared_cloudflare_challenge_and_retry(
+                                operation,
+                                join_rx,
+                                retry_request,
+                                options,
+                            )
+                            .await;
+                    }
+                    super::cf_challenge::CloudflareChallengeBegin::Start => {}
                 }
+
+                let mut finish_guard = CloudflareChallengeFinishGuard {
+                    runtime: Arc::clone(&self.cloudflare_challenge_runtime),
+                    finished: false,
+                };
 
                 let challenge_result = handler(CloudflareChallengeRequest {
                     operation: operation.to_string(),
@@ -965,8 +1010,9 @@ impl FireCore {
                     session_epoch: self.current_session_epoch(),
                 })
                 .await;
-                let resolved = if !challenge_result.completed || challenge_result.user_cancelled {
-                    Err(FireCoreError::CloudflareChallenge { operation })
+
+                let accepted = if !challenge_result.completed || challenge_result.user_cancelled {
+                    false
                 } else {
                     let fresh_clearance = challenge_result
                         .fresh_cf_clearance
@@ -980,47 +1026,29 @@ impl FireCore {
                     // accepted challenge result even if it matches Rust's
                     // previous scalar value; the retry still proves whether it
                     // is usable for the Rust network path.
-                    if fresh_clearance.is_none() {
-                        Err(FireCoreError::CloudflareChallenge { operation })
-                    } else {
+                    if let Some(fresh_clearance) = fresh_clearance {
                         let session = self.complete_cloudflare_challenge(
                             challenge_result.cookies,
-                            fresh_clearance.clone(),
+                            Some(fresh_clearance.clone()),
                             challenge_result.browser_user_agent,
                         );
-                        let has_accepted_clearance = session.cookies.cf_clearance.as_deref()
-                            == fresh_clearance.as_deref()
-                            && session.cookies.has_cloudflare_clearance();
-                        if !has_accepted_clearance {
-                            Err(FireCoreError::CloudflareChallenge { operation })
-                        } else if let Some(mut retry_request) = retry_request {
-                            retry_request
-                                .extensions_mut()
-                                .insert(FireRequestEpoch(self.current_session_epoch()));
-                            retry_request
-                                .extensions_mut()
-                                .insert(FireSkipCloudflareBlock);
-                            let retry = trace_request(&self.diagnostics, operation, retry_request);
-                            self.network
-                                .execute_traced_with_options(
-                                    retry,
-                                    FireCallProfile::DefaultApi,
-                                    options,
-                                )
-                                .await
-                        } else {
-                            Err(FireCoreError::CloudflareChallenge { operation })
-                        }
+                        session.cookies.cf_clearance.as_deref() == Some(fresh_clearance.as_str())
+                            && session.cookies.has_cloudflare_clearance()
+                    } else {
+                        false
                     }
                 };
-                {
-                    let mut runtime = self
-                        .cloudflare_challenge_runtime
-                        .lock()
-                        .expect("cloudflare challenge runtime mutex poisoned");
-                    runtime.finish(resolved.is_ok());
+
+                // Publish join outcome before the owner retries so concurrent CF
+                // victims can replay in parallel with a shared clearance.
+                finish_guard.finish(accepted);
+
+                if !accepted {
+                    return Err(FireCoreError::CloudflareChallenge { operation });
                 }
-                return resolved;
+                return self
+                    .retry_after_cloudflare_challenge(operation, retry_request, options)
+                    .await;
             }
         } else {
             response
@@ -1043,6 +1071,55 @@ impl FireCore {
         }
 
         Ok((trace_id, response))
+    }
+
+    async fn await_shared_cloudflare_challenge_and_retry(
+        &self,
+        operation: &'static str,
+        mut join_rx: tokio::sync::watch::Receiver<
+            Option<super::cf_challenge::CloudflareChallengeJoinOutcome>,
+        >,
+        retry_request: Option<Request<RequestBody>>,
+        options: CallOptions,
+    ) -> Result<(u64, Response<ResponseBody>), FireCoreError> {
+        loop {
+            let current = *join_rx.borrow();
+            if let Some(outcome) = current {
+                return match outcome {
+                    super::cf_challenge::CloudflareChallengeJoinOutcome::Succeeded => {
+                        self.retry_after_cloudflare_challenge(operation, retry_request, options)
+                            .await
+                    }
+                    super::cf_challenge::CloudflareChallengeJoinOutcome::Failed => {
+                        Err(FireCoreError::CloudflareChallenge { operation })
+                    }
+                };
+            }
+            if join_rx.changed().await.is_err() {
+                return Err(FireCoreError::CloudflareChallenge { operation });
+            }
+        }
+    }
+
+    async fn retry_after_cloudflare_challenge(
+        &self,
+        operation: &'static str,
+        retry_request: Option<Request<RequestBody>>,
+        options: CallOptions,
+    ) -> Result<(u64, Response<ResponseBody>), FireCoreError> {
+        let Some(mut retry_request) = retry_request else {
+            return Err(FireCoreError::CloudflareChallenge { operation });
+        };
+        retry_request
+            .extensions_mut()
+            .insert(FireRequestEpoch(self.current_session_epoch()));
+        retry_request
+            .extensions_mut()
+            .insert(FireSkipCloudflareBlock);
+        let retry = trace_request(&self.diagnostics, operation, retry_request);
+        self.network
+            .execute_traced_with_options(retry, FireCallProfile::DefaultApi, options)
+            .await
     }
 
     async fn maybe_self_heal_response(
@@ -1702,6 +1779,9 @@ fn is_cookie_self_healing_response(status: StatusCode, headers: &HeaderMap, body
 pub(crate) fn is_cloudflare_challenge_body(body: &str) -> bool {
     let normalized = body.to_ascii_lowercase();
     normalized.contains("cf_chl_opt")
+        || normalized.contains("cf-turnstile")
+        || normalized.contains("challenge-running")
+        || normalized.contains("challenge-stage")
         || (normalized.contains("challenge-platform") && normalized.contains("cloudflare"))
         || (normalized.contains("just a moment")
             && (normalized.contains("cloudflare") || normalized.contains("cf-challenge")))

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -27,12 +27,13 @@ use super::{
 };
 use crate::{
     cookies::{FireSessionCookieJar, FIRE_REQUEST_EPOCH, FIRE_REQUEST_TRACE_ID},
+    error::CloudflareChallengeFailureReason,
     diagnostics::{
         FireDiagnosticsStore, FireNetworkTraceCancellationGuard,
         FireNetworkTraceEventListenerFactory,
     },
     error::FireCoreError,
-    sync_utils::read_rwlock,
+    sync_utils::{read_rwlock, write_rwlock},
 };
 
 // Discourse strips `data-preloaded` for crawler-style requests, so the shared
@@ -964,6 +965,7 @@ impl FireCore {
                     operation: Some(operation.to_string()),
                     status: Some(status.as_u16()),
                 });
+                self.capture_turnstile_sitekey_from_challenge_body(&body_text);
                 let handler = match self.cloudflare_challenge_handler.get() {
                     Some(handler) => handler,
                     None => {
@@ -980,9 +982,17 @@ impl FireCore {
                 };
 
                 match begin {
-                    super::cf_challenge::CloudflareChallengeBegin::Cooldown
-                    | super::cf_challenge::CloudflareChallengeBegin::BackgroundSuppressed => {
-                        return Err(FireCoreError::CloudflareChallenge { operation });
+                    super::cf_challenge::CloudflareChallengeBegin::Cooldown => {
+                        return Err(FireCoreError::CloudflareChallenge {
+                            operation,
+                            reason: CloudflareChallengeFailureReason::Cooldown,
+                        });
+                    }
+                    super::cf_challenge::CloudflareChallengeBegin::BackgroundSuppressed => {
+                        return Err(FireCoreError::CloudflareChallenge {
+                            operation,
+                            reason: CloudflareChallengeFailureReason::BackgroundSuppressed,
+                        });
                     }
                     super::cf_challenge::CloudflareChallengeBegin::Join(join_rx) => {
                         return self
@@ -1011,7 +1021,15 @@ impl FireCore {
                 })
                 .await;
 
-                let accepted = if !challenge_result.completed || challenge_result.user_cancelled {
+                let failure_reason = if challenge_result.user_cancelled {
+                    Some(CloudflareChallengeFailureReason::Cancelled)
+                } else if !challenge_result.completed {
+                    Some(CloudflareChallengeFailureReason::Failed)
+                } else {
+                    None
+                };
+
+                let accepted = if failure_reason.is_some() {
                     false
                 } else {
                     let fresh_clearance = challenge_result
@@ -1044,7 +1062,11 @@ impl FireCore {
                 finish_guard.finish(accepted);
 
                 if !accepted {
-                    return Err(FireCoreError::CloudflareChallenge { operation });
+                    return Err(FireCoreError::CloudflareChallenge {
+                        operation,
+                        reason: failure_reason
+                            .unwrap_or(CloudflareChallengeFailureReason::Failed),
+                    });
                 }
                 return self
                     .retry_after_cloudflare_challenge(operation, retry_request, options)
@@ -1091,14 +1113,38 @@ impl FireCore {
                             .await
                     }
                     super::cf_challenge::CloudflareChallengeJoinOutcome::Failed => {
-                        Err(FireCoreError::CloudflareChallenge { operation })
+                        Err(FireCoreError::CloudflareChallenge {
+                            operation,
+                            reason: CloudflareChallengeFailureReason::Failed,
+                        })
                     }
                 };
             }
             if join_rx.changed().await.is_err() {
-                return Err(FireCoreError::CloudflareChallenge { operation });
+                return Err(FireCoreError::CloudflareChallenge {
+                    operation,
+                    reason: CloudflareChallengeFailureReason::Failed,
+                });
             }
         }
+    }
+
+    fn capture_turnstile_sitekey_from_challenge_body(&self, body: &str) {
+        let Some(sitekey) = extract_turnstile_sitekey(body) else {
+            return;
+        };
+        let mut session = write_rwlock(&self.session, "session");
+        let current = session
+            .snapshot
+            .bootstrap
+            .turnstile_sitekey
+            .as_deref()
+            .map(str::trim)
+            .filter(|value| !value.is_empty());
+        if current.is_some() {
+            return;
+        }
+        session.snapshot.bootstrap.turnstile_sitekey = Some(sitekey);
     }
 
     async fn retry_after_cloudflare_challenge(
@@ -1108,7 +1154,10 @@ impl FireCore {
         options: CallOptions,
     ) -> Result<(u64, Response<ResponseBody>), FireCoreError> {
         let Some(mut retry_request) = retry_request else {
-            return Err(FireCoreError::CloudflareChallenge { operation });
+            return Err(FireCoreError::CloudflareChallenge {
+                operation,
+                reason: CloudflareChallengeFailureReason::Failed,
+            });
         };
         retry_request
             .extensions_mut()
@@ -1532,7 +1581,10 @@ pub(crate) fn classify_http_status_error(
     body: String,
 ) -> FireCoreError {
     if is_cloudflare_challenge_response(status, headers, &body) {
-        FireCoreError::CloudflareChallenge { operation }
+        FireCoreError::CloudflareChallenge {
+            operation,
+            reason: CloudflareChallengeFailureReason::Required,
+        }
     } else if let Some(message) = not_logged_in_message(status, &body) {
         FireCoreError::LoginRequired { operation, message }
     } else {
@@ -1785,6 +1837,31 @@ pub(crate) fn is_cloudflare_challenge_body(body: &str) -> bool {
         || (normalized.contains("challenge-platform") && normalized.contains("cloudflare"))
         || (normalized.contains("just a moment")
             && (normalized.contains("cloudflare") || normalized.contains("cf-challenge")))
+}
+
+pub(crate) fn extract_turnstile_sitekey(body: &str) -> Option<String> {
+    const PATTERNS: &[&str] = &[
+        "data-sitekey=\"",
+        "data-sitekey='",
+        "sitekey:\"",
+        "sitekey:'",
+        "\"sitekey\":\"",
+        "'sitekey':'",
+    ];
+
+    for pattern in PATTERNS {
+        if let Some(index) = body.find(pattern) {
+            let rest = &body[index + pattern.len()..];
+            let end = rest
+                .find(|ch| matches!(ch, '"' | '\'' | ' ' | '<' | '>' | ',' | '}' | '\n' | '\r'))
+                .unwrap_or(rest.len());
+            let candidate = rest[..end].trim();
+            if candidate.len() >= 10 && candidate.is_ascii() {
+                return Some(candidate.to_string());
+            }
+        }
+    }
+    None
 }
 
 pub(crate) fn is_cloudflare_challenge_response(
@@ -2078,5 +2155,14 @@ mod tests {
                 .copied(),
             Some(FireRequestEpoch(7))
         ));
+    }
+
+    #[test]
+    fn extract_turnstile_sitekey_reads_data_sitekey_attribute() {
+        let body = r#"<div class="cf-turnstile" data-sitekey="0x4AAAAAAAbcdefghijk"></div>"#;
+        assert_eq!(
+            extract_turnstile_sitekey(body).as_deref(),
+            Some("0x4AAAAAAAbcdefghijk")
+        );
     }
 }

--- a/rust/crates/fire-core/src/core/session.rs
+++ b/rust/crates/fire-core/src/core/session.rs
@@ -193,7 +193,7 @@ impl FireCore {
                 .is_some_and(|value| !value.trim().is_empty()),
             "completing cloudflare challenge via platform cookie sync"
         );
-        self.update_session_advancing_epoch_if_auth_changed(
+        let snapshot = self.update_session_advancing_epoch_if_auth_changed(
             "complete cloudflare challenge",
             FireAuthChangeSource::PlatformSync,
             |session| {
@@ -218,7 +218,10 @@ impl FireCore {
                     "applied cloudflare challenge result"
                 );
             },
-        )
+        );
+        // A confirmed clearance means previous rejects no longer apply.
+        self.clear_cloudflare_clearance_rejected();
+        snapshot
     }
 
     pub fn merge_platform_cookies(&self, cookies: Vec<PlatformCookie>) -> SessionSnapshot {

--- a/rust/crates/fire-core/src/core/session.rs
+++ b/rust/crates/fire-core/src/core/session.rs
@@ -158,6 +158,9 @@ fn non_empty_string(value: impl AsRef<str>) -> Option<String> {
 fn looks_like_cloudflare_challenge(body: &str) -> bool {
     let lower = body.to_ascii_lowercase();
     lower.contains("cf_chl_opt")
+        || lower.contains("cf-turnstile")
+        || lower.contains("challenge-running")
+        || lower.contains("challenge-stage")
         || (lower.contains("challenge-platform") && lower.contains("cloudflare"))
         || (lower.contains("just a moment") && lower.contains("cloudflare"))
         || lower.contains("cf-mitigated")

--- a/rust/crates/fire-core/src/core/session.rs
+++ b/rust/crates/fire-core/src/core/session.rs
@@ -219,8 +219,9 @@ impl FireCore {
                 );
             },
         );
-        // A confirmed clearance means previous rejects no longer apply.
-        self.clear_cloudflare_clearance_rejected();
+        // Manual + network completion share the same post-challenge rebuild
+        // (resolved generation, bootstrap, app-state batch, platform bus).
+        self.schedule_post_challenge_session_rebuild();
         snapshot
     }
 
@@ -743,6 +744,14 @@ impl FireCore {
     }
 }
 
+fn is_cloudflare_related_cookie_name(name: &str) -> bool {
+    let lower = name.trim().to_ascii_lowercase();
+    lower == "cf_clearance"
+        || lower == "_cfuvid"
+        || lower.starts_with("cf_")
+        || lower.starts_with("__cf")
+}
+
 fn filter_cloudflare_challenge_cookies(
     cookies: Vec<PlatformCookie>,
     fresh_cf_clearance: Option<&str>,
@@ -751,9 +760,14 @@ fn filter_cloudflare_challenge_cookies(
     let fresh_cf_clearance = fresh_cf_clearance
         .map(str::trim)
         .filter(|value| !value.is_empty());
+    // Challenge completion must never rewrite Discourse identity cookies.
+    // Only CF edge cookies flow WV → jar on this path (fluxdo excludes auth).
     let mut filtered = cookies
         .into_iter()
         .filter(|cookie| {
+            if !is_cloudflare_related_cookie_name(&cookie.name) {
+                return false;
+            }
             if cookie.name.eq_ignore_ascii_case("cf_clearance") {
                 return fresh_cf_clearance.is_some_and(|fresh| cookie.value.trim() == fresh);
             }

--- a/rust/crates/fire-core/src/core/topics.rs
+++ b/rust/crates/fire-core/src/core/topics.rs
@@ -332,16 +332,13 @@ impl FireCore {
             )
             .await?;
 
-        let body_post = match detail
-            .post_stream
-            .posts
-            .iter()
-            .find(|post| post.post_number == 1)
-            .cloned()
-        {
-            Some(post) => post,
-            None => self.fetch_post_by_number(query.topic_id, 1).await?,
-        };
+        // Mid-topic opens (`/t/{id}/{N}.json` from notifications) only embed a
+        // nearby posts chunk. OP/body is often absent from that chunk on large
+        // topics. Resolve body via stream head + post_ids[] first — never hard
+        // fail solely on posts.json?post_number=1 missing the OP payload.
+        let body_post = self
+            .resolve_topic_body_post(query.topic_id, &detail)
+            .await?;
         if detail.post_stream.stream.is_empty() && body_post.id > 0 {
             detail.post_stream.stream.push(body_post.id);
         }
@@ -354,8 +351,12 @@ impl FireCore {
                 .any(|post| post.post_number == *post_number)
         }) {
             detail.post_stream.posts.push(
-                self.fetch_post_by_number(query.topic_id, target_post_number)
-                    .await?,
+                self.resolve_topic_post_by_number(
+                    query.topic_id,
+                    target_post_number,
+                    &detail.post_stream.stream,
+                )
+                .await?,
             );
         }
         if !detail
@@ -766,6 +767,140 @@ impl FireCore {
             return;
         }
         session.merge_posts(posts.iter().cloned());
+    }
+
+    /// Resolve the topic body/OP used as tree root.
+    ///
+    /// Prefer payloads already in the detail chunk, then stream-head via
+    /// `post_ids[]`, then number-based / root-detail fallbacks.
+    async fn resolve_topic_body_post(
+        &self,
+        topic_id: u64,
+        detail: &TopicDetail,
+    ) -> Result<TopicPost, FireCoreError> {
+        if let Some(post) = detail
+            .post_stream
+            .posts
+            .iter()
+            .find(|post| post.post_number == 1)
+            .cloned()
+        {
+            return Ok(post);
+        }
+
+        if let Some(first_id) = detail
+            .post_stream
+            .stream
+            .first()
+            .copied()
+            .filter(|post_id| *post_id > 0)
+        {
+            let posts = self.fetch_topic_posts(topic_id, vec![first_id]).await?;
+            if let Some(post) = posts.into_iter().find(|post| post.id == first_id) {
+                return Ok(post);
+            }
+        }
+
+        if let Ok(post) = self
+            .resolve_topic_post_by_number(topic_id, 1, &detail.post_stream.stream)
+            .await
+        {
+            return Ok(post);
+        }
+
+        // Last resort: unanchored topic detail always starts near the beginning.
+        let root = self
+            .fetch_topic_detail_base(
+                TopicDetailQuery {
+                    topic_id,
+                    post_number: None,
+                    track_visit: false,
+                    force_load: true,
+                    filter: None,
+                    username_filters: None,
+                    filter_top_level_replies: false,
+                },
+                false,
+            )
+            .await?;
+        if let Some(post) = root
+            .post_stream
+            .posts
+            .iter()
+            .find(|post| post.post_number == 1)
+            .cloned()
+        {
+            return Ok(post);
+        }
+        root.post_stream
+            .posts
+            .into_iter()
+            .min_by_key(|post| post.post_number)
+            .ok_or_else(|| FireCoreError::ResponseDeserialize {
+                operation: "resolve topic body post",
+                source: invalid_json(
+                    "topic detail did not include a body/original post payload".to_string(),
+                ),
+            })
+    }
+
+    async fn resolve_topic_post_by_number(
+        &self,
+        topic_id: u64,
+        post_number: u32,
+        stream_ids: &[u64],
+    ) -> Result<TopicPost, FireCoreError> {
+        // 1) Number-window posts.json (fast path when Discourse returns the floor).
+        if let Ok(post) = self.fetch_post_by_number(topic_id, post_number).await {
+            return Ok(post);
+        }
+
+        // 2) Anchored topic detail around the floor — more reliable than posts.json
+        // for some large/complex topics where the number window omits the exact post.
+        let anchored = self
+            .fetch_topic_detail_base(
+                TopicDetailQuery {
+                    topic_id,
+                    post_number: Some(post_number),
+                    track_visit: false,
+                    force_load: true,
+                    filter: None,
+                    username_filters: None,
+                    filter_top_level_replies: false,
+                },
+                false,
+            )
+            .await?;
+        if let Some(post) = anchored
+            .post_stream
+            .posts
+            .into_iter()
+            .find(|post| post.post_number == post_number)
+        {
+            return Ok(post);
+        }
+
+        // 3) If stream is known and dense enough that index ~= post_number-1, try id.
+        // This is best-effort only (deleted posts create gaps).
+        if post_number > 0 {
+            let index = usize::try_from(post_number.saturating_sub(1)).unwrap_or(usize::MAX);
+            if let Some(post_id) = stream_ids.get(index).copied().filter(|id| *id > 0) {
+                let posts = self.fetch_topic_posts(topic_id, vec![post_id]).await?;
+                if let Some(post) = posts
+                    .into_iter()
+                    .find(|post| post.id == post_id || post.post_number == post_number)
+                {
+                    return Ok(post);
+                }
+            }
+        }
+
+        Err(FireCoreError::ResponseDeserialize {
+            operation: "resolve topic post by number",
+            source: invalid_json(format!(
+                "topic post stream did not contain post number {post_number}"
+            )),
+        })
     }
 
     async fn fetch_post_by_number(

--- a/rust/crates/fire-core/src/error.rs
+++ b/rust/crates/fire-core/src/error.rs
@@ -1,8 +1,37 @@
-use std::{io, path::PathBuf};
+use std::{fmt, io, path::PathBuf};
 
 use mars_xlog::XlogError;
 use openwire::WireError;
 use thiserror::Error;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloudflareChallengeFailureReason {
+    Required,
+    InProgress,
+    Cooldown,
+    Cancelled,
+    Failed,
+    BackgroundSuppressed,
+}
+
+impl CloudflareChallengeFailureReason {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Required => "required",
+            Self::InProgress => "in_progress",
+            Self::Cooldown => "cooldown",
+            Self::Cancelled => "cancelled",
+            Self::Failed => "failed",
+            Self::BackgroundSuppressed => "background_suppressed",
+        }
+    }
+}
+
+impl fmt::Display for CloudflareChallengeFailureReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
 
 #[derive(Debug, Error)]
 pub enum FireCoreError {
@@ -29,8 +58,11 @@ pub enum FireCoreError {
     },
     #[error("{operation} response was discarded because the session changed")]
     StaleSessionResponse { operation: &'static str },
-    #[error("{operation} requires Cloudflare challenge verification")]
-    CloudflareChallenge { operation: &'static str },
+    #[error("{operation} requires Cloudflare challenge verification ({reason})")]
+    CloudflareChallenge {
+        operation: &'static str,
+        reason: CloudflareChallengeFailureReason,
+    },
     #[error("{operation} blocked during Cloudflare challenge verification")]
     CloudflareChallengeInProgress { operation: &'static str },
     #[error("failed to parse {operation} response: {source}")]

--- a/rust/crates/fire-core/src/lib.rs
+++ b/rust/crates/fire-core/src/lib.rs
@@ -31,7 +31,7 @@ pub use diagnostics::{
     NetworkTraceBodyPage, NetworkTraceDetail, NetworkTraceEvent, NetworkTraceHeader,
     NetworkTraceOutcome, NetworkTraceSummary,
 };
-pub use error::FireCoreError;
+pub use error::{CloudflareChallengeFailureReason, FireCoreError};
 pub use fire_models::LoginFinalizationResult;
 pub use logging::{FireHostLogLevel, FireLogger, FireLoggerConfig};
 pub use presentation::{

--- a/rust/crates/fire-core/src/rich_text.rs
+++ b/rust/crates/fire-core/src/rich_text.rs
@@ -94,6 +94,11 @@ impl CookedHtmlBuilder {
         }
 
         let classes = element.attr("class").unwrap_or_default();
+        // Polls are rendered by native Poll UI from structured post.polls.
+        // Walking their cooked children leaks option lists + vote labels into body text.
+        if is_poll_container(tag, classes) {
+            return;
+        }
         let kind = node_kind_for_element(tag, classes);
         let next_text_mode = if tag == "pre" {
             TextMode::Preformatted
@@ -489,6 +494,19 @@ fn node_kind_for_element(tag: &str, classes: &str) -> Option<CookedHtmlNodeKind>
     }
 }
 
+fn is_poll_container(tag: &str, classes: &str) -> bool {
+    let has_class = |target: &str| {
+        classes
+            .split_whitespace()
+            .any(|class| class.eq_ignore_ascii_case(target))
+    };
+    // Discourse poll markup variants seen in the wild.
+    has_class("poll")
+        || has_class("poll-container")
+        || has_class("poll-area")
+        || (tag.eq_ignore_ascii_case("div") && has_class("polls"))
+}
+
 fn starts_plain_text_block(kind: Option<CookedHtmlNodeKind>) -> bool {
     matches!(
         kind,
@@ -571,6 +589,32 @@ mod tests {
             .iter()
             .any(|node| node.kind == CookedHtmlNodeKind::Strong));
         assert!(document
+            .nodes
+            .iter()
+            .any(|node| node.kind == CookedHtmlNodeKind::ListItem));
+    }
+
+    #[test]
+    fn skips_poll_container_markup_so_native_poll_ui_is_not_duplicated() {
+        let document = parse_cooked_html(
+            r#"
+            <p>开个贴看看</p>
+            <div class="poll" data-poll-name="poll">
+              <ul>
+                <li data-poll-option-id="1">0-10</li>
+                <li data-poll-option-id="2">11-20</li>
+                <li data-poll-option-id="7">61以上</li>
+              </ul>
+              <div class="poll-info">1175 投票人</div>
+            </div>
+            <p>补充说明</p>
+            "#,
+        );
+
+        assert_eq!(document.plain_text, "开个贴看看\n\n补充说明");
+        assert!(!document.plain_text.contains("0-10"));
+        assert!(!document.plain_text.contains("投票人"));
+        assert!(!document
             .nodes
             .iter()
             .any(|node| node.kind == CookedHtmlNodeKind::ListItem));

--- a/rust/crates/fire-core/tests/app_state_refresher.rs
+++ b/rust/crates/fire-core/tests/app_state_refresher.rs
@@ -207,3 +207,44 @@ async fn refresh_all_uses_rust_owned_current_home_topic_list_scope() {
     assert!(requests[1].contains("tags%5B%5D=ios"));
     assert!(requests[1].contains("match_all_tags=true"));
 }
+
+#[tokio::test]
+async fn refresh_all_forced_bypasses_debounce() {
+    let server = TestServer::spawn(vec![
+        raw_text_response(200, &sample_home_html()),
+        raw_json_response(200, "application/json", &sample_latest_json()),
+        raw_json_response(200, "application/json", "{}"),
+        raw_json_response(200, "application/json", &sample_latest_json()),
+        raw_json_response(200, "application/json", &sample_latest_json()),
+        raw_json_response(200, "application/json", &notification_page_json()),
+        raw_text_response(200, &sample_home_html()),
+        raw_json_response(200, "application/json", &sample_latest_json()),
+        raw_json_response(200, "application/json", "{}"),
+        raw_json_response(200, "application/json", &sample_latest_json()),
+        raw_json_response(200, "application/json", &sample_latest_json()),
+        raw_json_response(200, "application/json", &notification_page_json()),
+    ])
+    .await
+    .expect("server");
+    let core = FireCore::new(FireCoreConfig {
+        base_url: server.base_url(),
+        workspace_path: None,
+    })
+    .expect("core");
+    core.apply_platform_cookies(login_cookies());
+
+    core.app_state_refresher()
+        .refresh_all(RefreshTrigger::LoginCompleted)
+        .await
+        .expect("first refresh");
+    // Immediate second normal refresh would debounce; forced must run.
+    core.app_state_refresher()
+        .refresh_all_forced(RefreshTrigger::CloudflareResolved)
+        .await
+        .expect("forced refresh");
+
+    tokio::time::sleep(Duration::from_millis(1400)).await;
+    // Two core home + latest pairs at minimum.
+    assert!(server.request_count() >= 4);
+    let _ = server.shutdown_with_requests().await;
+}

--- a/rust/crates/fire-core/tests/network.rs
+++ b/rust/crates/fire-core/tests/network.rs
@@ -551,8 +551,7 @@ async fn fetch_topic_list_surfaces_cloudflare_challenge_error() {
     assert!(matches!(
         error,
         FireCoreError::CloudflareChallenge {
-            operation: "fetch topic list"
-        ,
+            operation: "fetch topic list",
             ..
         }
     ));
@@ -1046,10 +1045,9 @@ async fn foreground_retry_bypasses_cloudflare_failure_cooldown() {
         assert!(matches!(
             error,
             FireCoreError::CloudflareChallenge {
-            operation: "fetch topic list"
-            ,
-            ..
-        }
+                operation: "fetch topic list",
+                ..
+            }
         ));
     }
     let requests = server.shutdown_with_requests().await;
@@ -1147,8 +1145,7 @@ async fn fetch_topic_list_does_not_self_heal_cloudflare_challenge_without_handle
     assert!(matches!(
         error,
         FireCoreError::CloudflareChallenge {
-            operation: "fetch topic list"
-        ,
+            operation: "fetch topic list",
             ..
         }
     ));
@@ -1277,8 +1274,7 @@ async fn fetch_topic_list_surfaces_rate_limited_cloudflare_challenge_error() {
     assert!(matches!(
         error,
         FireCoreError::CloudflareChallenge {
-            operation: "fetch topic list"
-        ,
+            operation: "fetch topic list",
             ..
         }
     ));
@@ -1310,8 +1306,7 @@ async fn fetch_topic_list_accepts_cf_mitigated_challenge_without_html_content_ty
     assert!(matches!(
         error,
         FireCoreError::CloudflareChallenge {
-            operation: "fetch topic list"
-        ,
+            operation: "fetch topic list",
             ..
         }
     ));
@@ -2577,8 +2572,7 @@ async fn fetch_topic_ai_summary_surfaces_cloudflare_challenge() {
     assert!(matches!(
         error,
         FireCoreError::CloudflareChallenge {
-            operation: "fetch topic ai summary"
-        ,
+            operation: "fetch topic ai summary",
             ..
         }
     ));
@@ -4006,8 +4000,7 @@ async fn create_reply_surfaces_cloudflare_challenge_error() {
     assert!(matches!(
         error,
         FireCoreError::CloudflareChallenge {
-            operation: "create reply"
-        ,
+            operation: "create reply",
             ..
         }
     ));

--- a/rust/crates/fire-core/tests/network.rs
+++ b/rust/crates/fire-core/tests/network.rs
@@ -552,6 +552,8 @@ async fn fetch_topic_list_surfaces_cloudflare_challenge_error() {
         error,
         FireCoreError::CloudflareChallenge {
             operation: "fetch topic list"
+        ,
+            ..
         }
     ));
 }
@@ -1044,8 +1046,10 @@ async fn foreground_retry_bypasses_cloudflare_failure_cooldown() {
         assert!(matches!(
             error,
             FireCoreError::CloudflareChallenge {
-                operation: "fetch topic list"
-            }
+            operation: "fetch topic list"
+            ,
+            ..
+        }
         ));
     }
     let requests = server.shutdown_with_requests().await;
@@ -1144,6 +1148,8 @@ async fn fetch_topic_list_does_not_self_heal_cloudflare_challenge_without_handle
         error,
         FireCoreError::CloudflareChallenge {
             operation: "fetch topic list"
+        ,
+            ..
         }
     ));
     assert_eq!(calls.load(Ordering::SeqCst), 0);
@@ -1272,6 +1278,8 @@ async fn fetch_topic_list_surfaces_rate_limited_cloudflare_challenge_error() {
         error,
         FireCoreError::CloudflareChallenge {
             operation: "fetch topic list"
+        ,
+            ..
         }
     ));
 }
@@ -1303,6 +1311,8 @@ async fn fetch_topic_list_accepts_cf_mitigated_challenge_without_html_content_ty
         error,
         FireCoreError::CloudflareChallenge {
             operation: "fetch topic list"
+        ,
+            ..
         }
     ));
 }
@@ -2568,6 +2578,8 @@ async fn fetch_topic_ai_summary_surfaces_cloudflare_challenge() {
         error,
         FireCoreError::CloudflareChallenge {
             operation: "fetch topic ai summary"
+        ,
+            ..
         }
     ));
 }
@@ -3995,6 +4007,8 @@ async fn create_reply_surfaces_cloudflare_challenge_error() {
         error,
         FireCoreError::CloudflareChallenge {
             operation: "create reply"
+        ,
+            ..
         }
     ));
 }

--- a/rust/crates/fire-core/tests/network.rs
+++ b/rust/crates/fire-core/tests/network.rs
@@ -2127,6 +2127,112 @@ async fn fetch_topic_detail_source_snapshot_tracks_visit_headers_and_force_load_
 }
 
 #[tokio::test]
+async fn fetch_topic_detail_source_snapshot_recovers_missing_body_via_stream_head_post_ids() {
+    // Notification deep-links open `/t/{id}/{N}.json`. Large topics return a
+    // nearby posts chunk without OP/post #1. Body must be recovered from
+    // stream[0] via post_ids[] instead of hard-failing posts.json?post_number=1.
+    let target_post_number = 200_u32;
+    let body_post = json!({
+        "id": 1001,
+        "username": "op",
+        "cooked": "<p>Original post</p>",
+        "post_number": 1,
+        "reply_to_post_number": null,
+        "reply_count": 5
+    });
+    let target_post = json!({
+        "id": 1200,
+        "username": "replier",
+        "cooked": "<p>Deep reply</p>",
+        "post_number": target_post_number,
+        "reply_to_post_number": 1,
+        "reply_count": 0
+    });
+    let stream = (1_u64..=220).map(|n| 1000 + n).collect::<Vec<_>>();
+    let mid_topic_payload = json!({
+        "id": 123,
+        "title": "Large topic",
+        "slug": "large-topic",
+        "posts_count": 220,
+        "post_stream": {
+            "posts": [target_post.clone()],
+            "stream": stream
+        }
+    });
+    let body_by_ids = json!({
+        "post_stream": {
+            "posts": [body_post.clone()],
+            "stream": [1001]
+        }
+    });
+    // Remaining initial stream ids (1002..1010) after body recovery.
+    let initial_batch_posts = (2_u32..=10)
+        .map(|post_number| {
+            json!({
+                "id": 1000 + u64::from(post_number),
+                "username": format!("u{post_number}"),
+                "cooked": format!("<p>r{post_number}</p>"),
+                "post_number": post_number,
+                "reply_to_post_number": 1,
+                "reply_count": 0
+            })
+        })
+        .collect::<Vec<_>>();
+    let initial_batch = json!({
+        "post_stream": {
+            "posts": initial_batch_posts,
+            "stream": (1002_u64..=1010).collect::<Vec<_>>()
+        }
+    });
+
+    let server = TestServer::spawn(vec![
+        raw_json_response(200, "application/json", &mid_topic_payload.to_string()),
+        // resolve_topic_body_post: stream head via post_ids[]
+        raw_json_response(200, "application/json", &body_by_ids.to_string()),
+        // initial batch hydration for missing stream ids
+        raw_json_response(200, "application/json", &initial_batch.to_string()),
+    ])
+    .await
+    .expect("server");
+    let core = FireCore::new(FireCoreConfig {
+        base_url: server.base_url(),
+        workspace_path: None,
+    })
+    .expect("core");
+
+    let snapshot = core
+        .fetch_topic_detail_source_snapshot(TopicDetailSourceQuery {
+            topic_id: 123,
+            target_post_number: Some(target_post_number),
+            allow_suggested_unread_root: false,
+            track_visit: true,
+            force_load: true,
+            initial_batch_size: 10,
+            load_more_batch_size: 10,
+            max_auto_batches_per_gesture: 3,
+            max_auto_posts_per_gesture: 120,
+        })
+        .await
+        .expect("topic source snapshot should recover missing body");
+    let requests = server.shutdown_with_requests().await;
+
+    assert_eq!(snapshot.body.post.post_number, 1);
+    assert_eq!(snapshot.body.post.id, 1001);
+    assert!(snapshot
+        .loaded_posts
+        .iter()
+        .any(|post| post.post_number == target_post_number));
+    assert!(requests[0].contains("GET /t/123/200.json"));
+    assert!(
+        requests.iter().any(|request| {
+            request.contains("GET /t/123/posts.json") && request.contains("post_ids%5B%5D=1001")
+                || request.contains("post_ids[]=1001")
+        }),
+        "expected OP recovery via post_ids[] stream head, requests={requests:?}"
+    );
+}
+
+#[tokio::test]
 async fn fetch_topic_detail_source_snapshot_preserves_target_anchor_and_source_cursor() {
     let target_post_number = 14_u32;
     let mut detail_payload: Value =

--- a/rust/crates/fire-core/tests/network.rs
+++ b/rust/crates/fire-core/tests/network.rs
@@ -865,6 +865,7 @@ async fn business_request_is_blocked_while_cloudflare_challenge_is_in_progress()
     });
     challenge_started.notified().await;
 
+    // New outbound traffic that has not yet hit CF is frozen at dispatch.
     let blocked = core
         .fetch_topic_list(TopicListQuery {
             kind: TopicListKind::Latest,
@@ -889,6 +890,112 @@ async fn business_request_is_blocked_while_cloudflare_challenge_is_in_progress()
 
     assert_eq!(response.rows.len(), 1);
     assert_eq!(requests.len(), 2);
+}
+
+#[tokio::test]
+async fn concurrent_cloudflare_challenges_join_and_retry_after_shared_success() {
+    let challenge_body =
+        r#"<html><head><title>Just a moment...</title></head><body>__cf_chl_opt</body></html>"#;
+    let server = TestServer::spawn_scripted(vec![
+        // Delay both CF bodies so the two clients are already in-flight before
+        // either enters the challenge owner/join path.
+        TestServerStep::delayed(
+            raw_cloudflare_challenge_response(403, challenge_body),
+            Duration::from_millis(80),
+        ),
+        TestServerStep::delayed(
+            raw_cloudflare_challenge_response(403, challenge_body),
+            Duration::from_millis(80),
+        ),
+        TestServerStep::immediate(raw_json_response(
+            200,
+            "application/json",
+            &sample_latest_json(),
+        )),
+        TestServerStep::immediate(raw_json_response(
+            200,
+            "application/json",
+            &sample_latest_json(),
+        )),
+    ])
+    .await
+    .expect("server");
+    let core = FireCore::new(FireCoreConfig {
+        base_url: server.base_url(),
+        workspace_path: None,
+    })
+    .expect("core");
+    let challenge_calls = Arc::new(AtomicUsize::new(0));
+    let challenge_started = Arc::new(Notify::new());
+    let release_challenge = Arc::new(Notify::new());
+    {
+        let challenge_calls = Arc::clone(&challenge_calls);
+        let challenge_started = Arc::clone(&challenge_started);
+        let release_challenge = Arc::clone(&release_challenge);
+        core.set_cloudflare_challenge_handler(move |_| {
+            let challenge_calls = Arc::clone(&challenge_calls);
+            let challenge_started = Arc::clone(&challenge_started);
+            let release_challenge = Arc::clone(&release_challenge);
+            async move {
+                challenge_calls.fetch_add(1, Ordering::SeqCst);
+                challenge_started.notify_waiters();
+                release_challenge.notified().await;
+                fire_models::CloudflareChallengeResult {
+                    completed: true,
+                    user_cancelled: false,
+                    fresh_cf_clearance: Some("joined-clearance".into()),
+                    cookies: vec![PlatformCookie {
+                        name: "cf_clearance".into(),
+                        value: "joined-clearance".into(),
+                        domain: Some("linux.do".into()),
+                        path: Some("/".into()),
+                        expires_at_unix_ms: None,
+                        same_site: None,
+                    }],
+                    browser_user_agent: None,
+                }
+            }
+        });
+    }
+
+    let first_core = core.clone();
+    let first = tokio::spawn(async move {
+        first_core
+            .fetch_topic_list(TopicListQuery {
+                kind: TopicListKind::Latest,
+                ..TopicListQuery::default()
+            })
+            .await
+    });
+    let second_core = core.clone();
+    let second = tokio::spawn(async move {
+        second_core
+            .fetch_topic_list(TopicListQuery {
+                kind: TopicListKind::Latest,
+                ..TopicListQuery::default()
+            })
+            .await
+    });
+
+    challenge_started.notified().await;
+    // Let the second CF victim reach the shared join wait.
+    sleep(Duration::from_millis(40)).await;
+    release_challenge.notify_waiters();
+
+    let first_response = first
+        .await
+        .expect("first task")
+        .expect("first request should succeed after shared challenge");
+    let second_response = second
+        .await
+        .expect("second task")
+        .expect("joined request should retry after shared challenge");
+    let requests = server.shutdown_with_requests().await;
+
+    assert_eq!(first_response.rows.len(), 1);
+    assert_eq!(second_response.rows.len(), 1);
+    assert_eq!(challenge_calls.load(Ordering::SeqCst), 1);
+    assert_eq!(requests.len(), 4);
 }
 
 #[tokio::test]

--- a/rust/crates/fire-core/tests/notifications.rs
+++ b/rust/crates/fire-core/tests/notifications.rs
@@ -540,6 +540,8 @@ async fn fetch_recent_notifications_keeps_cloudflare_challenge_background() {
         error,
         FireCoreError::CloudflareChallenge {
             operation: "fetch recent notifications"
+        ,
+            ..
         }
     ));
     assert_eq!(requests.len(), 1);

--- a/rust/crates/fire-core/tests/notifications.rs
+++ b/rust/crates/fire-core/tests/notifications.rs
@@ -539,8 +539,7 @@ async fn fetch_recent_notifications_keeps_cloudflare_challenge_background() {
     assert!(matches!(
         error,
         FireCoreError::CloudflareChallenge {
-            operation: "fetch recent notifications"
-        ,
+            operation: "fetch recent notifications",
             ..
         }
     ));

--- a/rust/crates/fire-core/tests/session_flow.rs
+++ b/rust/crates/fire-core/tests/session_flow.rs
@@ -159,6 +159,93 @@ fn cloudflare_completion_preserves_auth_when_webview_batch_lacks_forum_session()
 }
 
 #[test]
+fn cloudflare_completion_ignores_stale_auth_cookies_from_challenge_webview() {
+    let core = FireCore::new(FireCoreConfig::default()).expect("core");
+    let _ = core.sync_login_context(LoginSyncInput {
+        username: Some("alice".into()),
+        home_html: Some(sample_home_html()),
+        csrf_token: Some("csrf-token".into()),
+        current_url: Some("https://linux.do/".into()),
+        browser_user_agent: Some("FireTests/1.0".into()),
+        cookies: vec![
+            PlatformCookie {
+                name: "_t".into(),
+                value: "good-token".into(),
+                domain: Some("linux.do".into()),
+                path: Some("/".into()),
+                expires_at_unix_ms: None,
+                same_site: None,
+            },
+            PlatformCookie {
+                name: "_forum_session".into(),
+                value: "good-forum".into(),
+                domain: Some("linux.do".into()),
+                path: Some("/".into()),
+                expires_at_unix_ms: None,
+                same_site: None,
+            },
+            PlatformCookie {
+                name: "cf_clearance".into(),
+                value: "old-clearance".into(),
+                domain: Some("linux.do".into()),
+                path: Some("/".into()),
+                expires_at_unix_ms: None,
+                same_site: Some("None".into()),
+            },
+        ],
+    });
+
+    let snapshot = core.complete_cloudflare_challenge(
+        vec![
+            PlatformCookie {
+                name: "_t".into(),
+                value: "stale-token".into(),
+                domain: Some("linux.do".into()),
+                path: Some("/".into()),
+                expires_at_unix_ms: None,
+                same_site: None,
+            },
+            PlatformCookie {
+                name: "_forum_session".into(),
+                value: "stale-forum".into(),
+                domain: Some("linux.do".into()),
+                path: Some("/".into()),
+                expires_at_unix_ms: None,
+                same_site: None,
+            },
+            PlatformCookie {
+                name: "_cfuvid".into(),
+                value: "cfuvid".into(),
+                domain: Some(".linux.do".into()),
+                path: Some("/".into()),
+                expires_at_unix_ms: None,
+                same_site: Some("None".into()),
+            },
+            PlatformCookie {
+                name: "cf_clearance".into(),
+                value: "fresh-clearance".into(),
+                domain: Some(".linux.do".into()),
+                path: Some("/".into()),
+                expires_at_unix_ms: None,
+                same_site: Some("None".into()),
+            },
+        ],
+        Some("fresh-clearance".into()),
+        Some("FireTests/1.0".into()),
+    );
+
+    assert_eq!(snapshot.cookies.t_token.as_deref(), Some("good-token"));
+    assert_eq!(
+        snapshot.cookies.forum_session.as_deref(),
+        Some("good-forum")
+    );
+    assert_eq!(
+        snapshot.cookies.cf_clearance.as_deref(),
+        Some("fresh-clearance")
+    );
+}
+
+#[test]
 fn untrusted_platform_bulk_read_does_not_overwrite_newer_canonical_cookie() {
     let core = FireCore::new(FireCoreConfig::default()).expect("core");
     let mut trusted = CanonicalCookie::new("_t", "fresh", "https://linux.do/");
@@ -1181,4 +1268,74 @@ fn resolve_workspace_path_rejects_parent_segments() {
         Err(FireCoreError::InvalidWorkspaceRelativePath { .. }) => {}
         other => panic!("unexpected resolve result: {other:?}"),
     }
+}
+
+#[test]
+fn complete_cloudflare_challenge_notifies_clearance_resolved_handler() {
+    use fire_models::CloudflareClearanceResolvedEvent;
+    use std::sync::{Arc, Mutex};
+
+    let core = FireCore::new(FireCoreConfig::default()).expect("core");
+    let _ = core.sync_login_context(LoginSyncInput {
+        username: Some("alice".into()),
+        home_html: Some(sample_home_html()),
+        csrf_token: Some("csrf-token".into()),
+        current_url: Some("https://linux.do/".into()),
+        browser_user_agent: Some("FireTests/1.0".into()),
+        cookies: vec![
+            PlatformCookie {
+                name: "_t".into(),
+                value: "token".into(),
+                domain: Some("linux.do".into()),
+                path: Some("/".into()),
+                expires_at_unix_ms: None,
+                same_site: None,
+            },
+            PlatformCookie {
+                name: "_forum_session".into(),
+                value: "forum".into(),
+                domain: Some("linux.do".into()),
+                path: Some("/".into()),
+                expires_at_unix_ms: None,
+                same_site: None,
+            },
+        ],
+    });
+
+    let events = Arc::new(Mutex::new(Vec::<CloudflareClearanceResolvedEvent>::new()));
+    let observed = events.clone();
+    core.set_cloudflare_clearance_resolved_handler(move |event| {
+        observed.lock().expect("events").push(event);
+    });
+
+    let before = core.cloudflare_clearance_resolved_generation();
+    let _ = core.complete_cloudflare_challenge(
+        vec![PlatformCookie {
+            name: "cf_clearance".into(),
+            value: "fresh-clearance".into(),
+            domain: Some(".linux.do".into()),
+            path: Some("/".into()),
+            expires_at_unix_ms: None,
+            same_site: Some("None".into()),
+        }],
+        Some("fresh-clearance".into()),
+        Some("FireTests/1.0".into()),
+    );
+
+    // Generation advances immediately for idle (manual) completion.
+    assert!(core.cloudflare_clearance_resolved_generation() > before);
+
+    // Handler may fire after async rebuild settles; wait briefly.
+    for _ in 0..50 {
+        if !events.lock().expect("events").is_empty() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    let seen = events.lock().expect("events").clone();
+    assert!(
+        !seen.is_empty(),
+        "expected clearance-resolved handler notification"
+    );
+    assert!(seen.iter().any(|event| event.has_login_session));
 }

--- a/rust/crates/fire-core/tests/session_flow.rs
+++ b/rust/crates/fire-core/tests/session_flow.rs
@@ -191,27 +191,27 @@ fn webview_priming_payload_exports_canonical_set_cookie_actions() {
     clearance.domain = Some(".linux.do".into());
     clearance.secure = true;
     clearance.same_site = CookieSameSite::None;
+    let mut auth = CanonicalCookie::new("_t", "token", "https://linux.do/");
+    auth.secure = true;
     let _ = core.apply_cookies(CookieSnapshot {
-        canonical_cookies: vec![clearance],
+        canonical_cookies: vec![clearance, auth],
         ..CookieSnapshot::default()
     });
 
     let payload = core.webview_priming_payload(Some("https://linux.do/".into()));
 
-    assert_eq!(payload.len(), 2);
-    assert!(matches!(
-        &payload[0],
-        WebViewCookieAction::DeleteByName { url, name }
-            if url == "https://linux.do/" && name == "cf_clearance"
-    ));
-    let WebViewCookieAction::SetRaw { url, set_cookie } = &payload[1] else {
-        panic!("expected raw set-cookie action");
-    };
-    assert_eq!(url, "https://linux.do/");
-    assert!(set_cookie.contains("cf_clearance=clear"));
-    assert!(set_cookie.contains("Domain=.linux.do"));
-    assert!(set_cookie.contains("Secure"));
-    assert!(set_cookie.contains("SameSite=None"));
+    // cf_clearance is WebView-authored only and must never be primed back.
+    assert!(!payload.iter().any(|action| match action {
+        WebViewCookieAction::DeleteByName { name, .. } => name == "cf_clearance",
+        WebViewCookieAction::SetRaw { set_cookie, .. } => set_cookie.contains("cf_clearance="),
+        WebViewCookieAction::DeleteExact { name, .. } => name == "cf_clearance",
+    }));
+    assert!(payload.iter().any(|action| {
+        matches!(
+            action,
+            WebViewCookieAction::SetRaw { set_cookie, .. } if set_cookie.contains("_t=token")
+        )
+    }));
 }
 
 #[test]

--- a/rust/crates/fire-models/src/cookie.rs
+++ b/rust/crates/fire-models/src/cookie.rs
@@ -309,7 +309,10 @@ impl CanonicalCookieStore {
                     right_domain_len.cmp(&left_domain_len)
                 })
                 .then_with(|| right.host_only.cmp(&left.host_only))
-                .then_with(|| left.creation_time_unix_ms.cmp(&right.creation_time_unix_ms))
+                // Prefer the newest clearance/session variant when path/domain tie.
+                .then_with(|| right.expires_at_unix_ms.cmp(&left.expires_at_unix_ms))
+                .then_with(|| right.version.cmp(&left.version))
+                .then_with(|| right.creation_time_unix_ms.cmp(&left.creation_time_unix_ms))
         });
         matching
     }
@@ -700,6 +703,12 @@ impl CookieSnapshot {
             if cookie.value.trim().is_empty() {
                 continue;
             }
+            // cf_clearance is WebView-authored only. Never prime jar copies back into
+            // the browser store — Set-Cookie replay can drop Partitioned and create a
+            // ghost variant that native traffic may send forever.
+            if is_cloudflare_clearance_cookie_name(&cookie.name) {
+                continue;
+            }
             if is_critical_cookie_name(&cookie.name)
                 && seen_critical_names
                     .iter()
@@ -731,7 +740,12 @@ impl CookieSnapshot {
         let variants = matching_webview_cookie_infos(webview_cookies, name);
         let canonical = self.canonical_cookie_for_request(uri, name);
         let selected_winner = select_sweep_winner(uri, canonical.as_ref(), &variants);
-        let actions = if variants.len() <= 1
+
+        // cf_clearance sweep is read-only against WebView: pick the freshest browser
+        // variant for jar sync, but never delete/rewrite the browser store.
+        let actions = if is_cloudflare_clearance_cookie_name(name) {
+            Vec::new()
+        } else if variants.len() <= 1
             && variants_match_selected_winner(&variants, selected_winner.as_ref())
         {
             Vec::new()
@@ -790,6 +804,10 @@ impl CookieSnapshot {
 
         let mut actions = Vec::new();
         for name in names {
+            // Leave browser-authored cf_clearance alone during nuclear reset.
+            if is_cloudflare_clearance_cookie_name(&name) {
+                continue;
+            }
             let variants = matching_webview_cookie_infos(webview_cookies, &name);
             actions.extend(delete_actions_for_variants(uri, &variants));
         }
@@ -810,7 +828,15 @@ impl CookieSnapshot {
             }
             CookieSweepIntent::EnsureUnique => {
                 let variants = matching_webview_cookie_infos(webview_cookies, name);
-                let [variant] = variants.as_slice() else {
+                let winner_info = if is_cloudflare_clearance_cookie_name(name) {
+                    select_freshest_webview_cookie_info(&variants)
+                } else {
+                    match variants.as_slice() {
+                        [variant] => Some(*variant),
+                        _ => None,
+                    }
+                };
+                let Some(variant) = winner_info else {
                     return;
                 };
                 let canonical_template = self.canonical_cookie_for_request(uri, name);
@@ -992,9 +1018,13 @@ fn latest_non_empty_platform_cookie_value(
     let now_unix_ms = current_unix_ms();
     cookies
         .iter()
-        .rev()
-        .find(|cookie| {
+        .filter(|cookie| {
             cookie.name == name && !cookie.value.is_empty() && !cookie.is_expired_at(now_unix_ms)
+        })
+        .max_by(|left, right| {
+            left.expires_at_unix_ms
+                .unwrap_or(0)
+                .cmp(&right.expires_at_unix_ms.unwrap_or(0))
         })
         .map(|cookie| cookie.value.clone())
 }
@@ -1128,6 +1158,30 @@ fn is_critical_cookie_name(name: &str) -> bool {
     )
 }
 
+fn is_cloudflare_clearance_cookie_name(name: &str) -> bool {
+    name.eq_ignore_ascii_case("cf_clearance")
+}
+
+fn select_freshest_webview_cookie_info<'a>(
+    variants: &[&'a WebViewCookieInfo],
+) -> Option<&'a WebViewCookieInfo> {
+    variants
+        .iter()
+        .copied()
+        .filter(|cookie| !cookie.value.trim().is_empty())
+        .max_by(|left, right| webview_cookie_freshness_score(left).cmp(&webview_cookie_freshness_score(right)))
+}
+
+fn webview_cookie_freshness_score(cookie: &WebViewCookieInfo) -> (u8, i64, usize) {
+    let now_unix_ms = current_unix_ms();
+    let unexpired = cookie
+        .expires_at_unix_ms
+        .is_none_or(|expires_at_unix_ms| expires_at_unix_ms > now_unix_ms) as u8;
+    // Later expiresDate wins for cf_clearance multi-variant selection.
+    let expiry = cookie.expires_at_unix_ms.unwrap_or(0);
+    (unexpired, expiry, cookie.value.len())
+}
+
 fn matching_webview_cookie_infos<'a>(
     cookies: &'a [WebViewCookieInfo],
     name: &str,
@@ -1143,6 +1197,19 @@ fn select_sweep_winner(
     canonical: Option<&CanonicalCookie>,
     variants: &[&WebViewCookieInfo],
 ) -> Option<CanonicalCookie> {
+    // Browser store is authoritative for cf_clearance. Prefer the freshest WebView
+    // variant by expiresDate even when a jar canonical still exists.
+    if canonical.is_some_and(|cookie| is_cloudflare_clearance_cookie_name(&cookie.name))
+        || variants
+            .first()
+            .is_some_and(|cookie| is_cloudflare_clearance_cookie_name(&cookie.name))
+    {
+        if let Some(winner) = select_freshest_webview_cookie_info(variants) {
+            return canonical_cookie_from_webview_info(winner, uri, canonical);
+        }
+        return canonical.cloned();
+    }
+
     let Some(canonical) = canonical else {
         return variants
             .iter()
@@ -1689,36 +1756,35 @@ mod tests {
     }
 
     #[test]
-    fn webview_priming_payload_reconstructs_canonical_metadata() {
+    fn webview_priming_payload_skips_cloudflare_clearance() {
         let uri = url::Url::parse("https://linux.do/").expect("url");
         let mut snapshot = CookieSnapshot::default();
-        let mut cookie = CanonicalCookie::new("cf_clearance", "fresh", "https://linux.do/");
-        cookie.host_only = false;
-        cookie.domain = Some(".linux.do".into());
-        cookie.secure = true;
-        cookie.same_site = CookieSameSite::None;
-        cookie.partitioned = true;
-        snapshot.merge_canonical_cookies(&uri, &[cookie], CookieTrust::Trusted);
+        let mut clearance = CanonicalCookie::new("cf_clearance", "fresh", "https://linux.do/");
+        clearance.host_only = false;
+        clearance.domain = Some(".linux.do".into());
+        clearance.secure = true;
+        clearance.same_site = CookieSameSite::None;
+        clearance.partitioned = true;
+        let session = CanonicalCookie::new("_t", "token", "https://linux.do/");
+        snapshot.merge_canonical_cookies(&uri, &[clearance, session], CookieTrust::Trusted);
 
         let payload = snapshot.webview_priming_payload(&uri);
 
-        assert_eq!(payload.len(), 2);
-        assert!(matches!(
-            &payload[0],
-            WebViewCookieAction::DeleteByName { name, .. } if name == "cf_clearance"
-        ));
-        let WebViewCookieAction::SetRaw { set_cookie, .. } = &payload[1] else {
-            panic!("expected set action");
-        };
-        assert!(set_cookie.contains("cf_clearance=fresh"));
-        assert!(set_cookie.contains("Domain=.linux.do"));
-        assert!(set_cookie.contains("Secure"));
-        assert!(set_cookie.contains("SameSite=None"));
-        assert!(set_cookie.contains("Partitioned"));
+        assert!(!payload.iter().any(|action| match action {
+            WebViewCookieAction::DeleteByName { name, .. } => name == "cf_clearance",
+            WebViewCookieAction::SetRaw { set_cookie, .. } => set_cookie.contains("cf_clearance="),
+            WebViewCookieAction::DeleteExact { name, .. } => name == "cf_clearance",
+        }));
+        assert!(payload.iter().any(|action| {
+            matches!(
+                action,
+                WebViewCookieAction::SetRaw { set_cookie, .. } if set_cookie.contains("_t=token")
+            )
+        }));
     }
 
     #[test]
-    fn sweep_plan_picks_non_canonical_webview_variant_when_multiple_exist() {
+    fn sweep_plan_for_cloudflare_clearance_is_read_only_and_picks_freshest_webview_variant() {
         let uri = url::Url::parse("https://linux.do/").expect("url");
         let mut snapshot = CookieSnapshot::default();
         let mut canonical = CanonicalCookie::new("cf_clearance", "old", "https://linux.do/");
@@ -1728,6 +1794,8 @@ mod tests {
         canonical.same_site = CookieSameSite::None;
         snapshot.merge_canonical_cookies(&uri, &[canonical], CookieTrust::Trusted);
 
+        let older_expires = current_unix_ms() + 60_000;
+        let newer_expires = current_unix_ms() + 120_000;
         let plan = snapshot.cookie_sweep_plan(
             &uri,
             "cf_clearance",
@@ -1741,7 +1809,7 @@ mod tests {
                     secure: Some(true),
                     http_only: None,
                     same_site: Some(CookieSameSite::None),
-                    expires_at_unix_ms: None,
+                    expires_at_unix_ms: Some(older_expires),
                 },
                 WebViewCookieInfo {
                     name: "cf_clearance".into(),
@@ -1752,7 +1820,7 @@ mod tests {
                     secure: Some(true),
                     http_only: None,
                     same_site: Some(CookieSameSite::None),
-                    expires_at_unix_ms: None,
+                    expires_at_unix_ms: Some(newer_expires),
                 },
             ],
         );
@@ -1763,15 +1831,47 @@ mod tests {
                 .map(|cookie| cookie.value.as_str()),
             Some("new-webview")
         );
-        assert!(plan.actions.iter().any(|action| {
-            matches!(
-                action,
-                WebViewCookieAction::SetRaw { set_cookie, .. }
-                    if set_cookie.contains("cf_clearance=new-webview")
-                        && set_cookie.contains("SameSite=None")
-                        && set_cookie.contains("Secure")
-            )
-        }));
+        assert!(plan.actions.is_empty(), "cf_clearance sweep must not rewrite WebView");
+    }
+
+    #[test]
+    fn commit_clearance_sweep_promotes_freshest_webview_variant_without_uniqueness() {
+        let uri = url::Url::parse("https://linux.do/").expect("url");
+        let mut snapshot = CookieSnapshot::default();
+        let older_expires = current_unix_ms() + 60_000;
+        let newer_expires = current_unix_ms() + 120_000;
+
+        snapshot.commit_cookie_sweep_result(
+            &uri,
+            "cf_clearance",
+            CookieSweepIntent::EnsureUnique,
+            &[
+                WebViewCookieInfo {
+                    name: "cf_clearance".into(),
+                    value: "older".into(),
+                    domain: Some(".linux.do".into()),
+                    path: Some("/".into()),
+                    host_only: Some(false),
+                    secure: Some(true),
+                    http_only: None,
+                    same_site: Some(CookieSameSite::None),
+                    expires_at_unix_ms: Some(older_expires),
+                },
+                WebViewCookieInfo {
+                    name: "cf_clearance".into(),
+                    value: "newer".into(),
+                    domain: Some(".linux.do".into()),
+                    path: Some("/".into()),
+                    host_only: Some(false),
+                    secure: Some(true),
+                    http_only: None,
+                    same_site: Some(CookieSameSite::None),
+                    expires_at_unix_ms: Some(newer_expires),
+                },
+            ],
+        );
+
+        assert_eq!(snapshot.cf_clearance.as_deref(), Some("newer"));
     }
 
     #[test]

--- a/rust/crates/fire-models/src/cookie.rs
+++ b/rust/crates/fire-models/src/cookie.rs
@@ -743,10 +743,9 @@ impl CookieSnapshot {
 
         // cf_clearance sweep is read-only against WebView: pick the freshest browser
         // variant for jar sync, but never delete/rewrite the browser store.
-        let actions = if is_cloudflare_clearance_cookie_name(name) {
-            Vec::new()
-        } else if variants.len() <= 1
-            && variants_match_selected_winner(&variants, selected_winner.as_ref())
+        let actions = if is_cloudflare_clearance_cookie_name(name)
+            || (variants.len() <= 1
+                && variants_match_selected_winner(&variants, selected_winner.as_ref()))
         {
             Vec::new()
         } else {
@@ -1169,14 +1168,17 @@ fn select_freshest_webview_cookie_info<'a>(
         .iter()
         .copied()
         .filter(|cookie| !cookie.value.trim().is_empty())
-        .max_by(|left, right| webview_cookie_freshness_score(left).cmp(&webview_cookie_freshness_score(right)))
+        .max_by(|left, right| {
+            webview_cookie_freshness_score(left).cmp(&webview_cookie_freshness_score(right))
+        })
 }
 
 fn webview_cookie_freshness_score(cookie: &WebViewCookieInfo) -> (u8, i64, usize) {
     let now_unix_ms = current_unix_ms();
     let unexpired = cookie
         .expires_at_unix_ms
-        .is_none_or(|expires_at_unix_ms| expires_at_unix_ms > now_unix_ms) as u8;
+        .is_none_or(|expires_at_unix_ms| expires_at_unix_ms > now_unix_ms)
+        as u8;
     // Later expiresDate wins for cf_clearance multi-variant selection.
     let expiry = cookie.expires_at_unix_ms.unwrap_or(0);
     (unexpired, expiry, cookie.value.len())
@@ -1831,7 +1833,10 @@ mod tests {
                 .map(|cookie| cookie.value.as_str()),
             Some("new-webview")
         );
-        assert!(plan.actions.is_empty(), "cf_clearance sweep must not rewrite WebView");
+        assert!(
+            plan.actions.is_empty(),
+            "cf_clearance sweep must not rewrite WebView"
+        );
     }
 
     #[test]

--- a/rust/crates/fire-models/src/session.rs
+++ b/rust/crates/fire-models/src/session.rs
@@ -634,6 +634,15 @@ pub enum RefreshTrigger {
     LoginCompleted,
     LogoutCompleted,
     SessionRestored,
+    /// Full session rebuild after a successful Cloudflare challenge.
+    CloudflareResolved,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloudflareClearanceResolvedEvent {
+    pub generation: u64,
+    pub has_login_session: bool,
+    pub can_open_message_bus: bool,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/rust/crates/fire-uniffi-session/src/lib.rs
+++ b/rust/crates/fire-uniffi-session/src/lib.rs
@@ -11,11 +11,12 @@ pub mod records;
 pub use records::{
     format_probe_result, AppStateRefreshEventState, AppStateRefreshHandler, AuthRecoveryHintState,
     BootstrapState, CanonicalCookieState, CloudflareChallengeHandler,
-    CloudflareChallengeRequestState, CloudflareChallengeResultState, CookieReplayEntryState,
-    CookieSameSiteState, CookieSelfHealingHandler, CookieSelfHealingPhaseState,
-    CookieSelfHealingRequestState, CookieSelfHealingResultState, CookieSourceState, CookieState,
-    CookieSweepIntentState, CookieSweepPlanState, CurrentUserSnapshotState,
-    HomeTopicListScopeState, LoginFailureKindState, LoginFailureState,
+    CloudflareChallengeRequestState, CloudflareChallengeResultState,
+    CloudflareClearanceResolvedEventState, CloudflareClearanceResolvedHandler,
+    CookieReplayEntryState, CookieSameSiteState, CookieSelfHealingHandler,
+    CookieSelfHealingPhaseState, CookieSelfHealingRequestState, CookieSelfHealingResultState,
+    CookieSourceState, CookieState, CookieSweepIntentState, CookieSweepPlanState,
+    CurrentUserSnapshotState, HomeTopicListScopeState, LoginFailureKindState, LoginFailureState,
     LoginFinalizationResultState, LoginPhaseState, LoginStateDeterminationState, LoginSyncState,
     NuclearResetPlanState, PassiveLogoutTriggerState, PlatformCookieState, PreloadedDataStateState,
     RefreshBatchState, RefreshTriggerState, SecondFactorRequirementState, SessionPersistenceState,
@@ -164,6 +165,41 @@ impl FireSessionHandle {
             &self.shared.core,
             "unregister_cloudflare_challenge_handler",
             |inner| inner.clear_cloudflare_challenge_handler(),
+        )
+    }
+
+    pub fn register_cloudflare_clearance_resolved_handler(
+        &self,
+        handler: Arc<dyn CloudflareClearanceResolvedHandler>,
+    ) -> Result<(), FireUniFfiError> {
+        run_infallible(
+            &self.shared.panic_state,
+            &self.shared.core,
+            "register_cloudflare_clearance_resolved_handler",
+            move |inner| {
+                let handler = handler.clone();
+                inner.set_cloudflare_clearance_resolved_handler(move |event| {
+                    handler.on_clearance_resolved(event.into());
+                });
+            },
+        )
+    }
+
+    pub fn unregister_cloudflare_clearance_resolved_handler(&self) -> Result<(), FireUniFfiError> {
+        run_infallible(
+            &self.shared.panic_state,
+            &self.shared.core,
+            "unregister_cloudflare_clearance_resolved_handler",
+            |inner| inner.clear_cloudflare_clearance_resolved_handler(),
+        )
+    }
+
+    pub fn cloudflare_clearance_resolved_generation(&self) -> Result<u64, FireUniFfiError> {
+        run_infallible(
+            &self.shared.panic_state,
+            &self.shared.core,
+            "cloudflare_clearance_resolved_generation",
+            |inner| inner.cloudflare_clearance_resolved_generation(),
         )
     }
 

--- a/rust/crates/fire-uniffi-session/src/lib.rs
+++ b/rust/crates/fire-uniffi-session/src/lib.rs
@@ -327,6 +327,27 @@ impl FireSessionHandle {
         )
     }
 
+    /// True when jar has cf_clearance and CF has not recently rejected it.
+    pub fn cloudflare_clearance_is_trusted(&self) -> Result<bool, FireUniFfiError> {
+        run_infallible(
+            &self.shared.panic_state,
+            &self.shared.core,
+            "cloudflare_clearance_is_trusted",
+            |inner| inner.cloudflare_clearance_is_trusted(),
+        )
+    }
+
+    pub fn note_cloudflare_clearance_rejected(&self) -> Result<(), FireUniFfiError> {
+        run_infallible(
+            &self.shared.panic_state,
+            &self.shared.core,
+            "note_cloudflare_clearance_rejected",
+            |inner| {
+                inner.note_cloudflare_clearance_rejected();
+            },
+        )
+    }
+
     pub fn apply_bootstrap(
         &self,
         bootstrap: BootstrapState,
@@ -564,6 +585,18 @@ impl FireSessionHandle {
                     .into()
             },
         )
+    }
+
+    /// Post-cookie login handoff: bootstrap with timeout, never block home entry
+    /// when auth cookies are already present.
+    pub async fn finalize_login_ready(&self) -> Result<SessionState, FireUniFfiError> {
+        let inner = self.shared.core.clone();
+        let panic_state = self.shared.panic_state.clone();
+        let snapshot = run_on_ffi_runtime("finalize_login_ready", panic_state, async move {
+            inner.finalize_login_ready().await
+        })
+        .await?;
+        Ok(SessionState::from_snapshot(snapshot))
     }
 
     pub fn cookie_replay_queue(&self) -> Result<Vec<CookieReplayEntryState>, FireUniFfiError> {

--- a/rust/crates/fire-uniffi-session/src/records.rs
+++ b/rust/crates/fire-uniffi-session/src/records.rs
@@ -1099,6 +1099,7 @@ pub enum RefreshTriggerState {
     LoginCompleted,
     LogoutCompleted,
     SessionRestored,
+    CloudflareResolved,
 }
 
 impl From<RefreshTriggerState> for fire_models::RefreshTrigger {
@@ -1107,6 +1108,7 @@ impl From<RefreshTriggerState> for fire_models::RefreshTrigger {
             RefreshTriggerState::LoginCompleted => Self::LoginCompleted,
             RefreshTriggerState::LogoutCompleted => Self::LogoutCompleted,
             RefreshTriggerState::SessionRestored => Self::SessionRestored,
+            RefreshTriggerState::CloudflareResolved => Self::CloudflareResolved,
         }
     }
 }
@@ -1117,6 +1119,24 @@ impl From<fire_models::RefreshTrigger> for RefreshTriggerState {
             fire_models::RefreshTrigger::LoginCompleted => Self::LoginCompleted,
             fire_models::RefreshTrigger::LogoutCompleted => Self::LogoutCompleted,
             fire_models::RefreshTrigger::SessionRestored => Self::SessionRestored,
+            fire_models::RefreshTrigger::CloudflareResolved => Self::CloudflareResolved,
+        }
+    }
+}
+
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct CloudflareClearanceResolvedEventState {
+    pub generation: u64,
+    pub has_login_session: bool,
+    pub can_open_message_bus: bool,
+}
+
+impl From<fire_models::CloudflareClearanceResolvedEvent> for CloudflareClearanceResolvedEventState {
+    fn from(value: fire_models::CloudflareClearanceResolvedEvent) -> Self {
+        Self {
+            generation: value.generation,
+            has_login_session: value.has_login_session,
+            can_open_message_bus: value.can_open_message_bus,
         }
     }
 }
@@ -1162,6 +1182,11 @@ pub trait CloudflareChallengeHandler: Send + Sync {
         &self,
         request: CloudflareChallengeRequestState,
     ) -> CloudflareChallengeResultState;
+}
+
+#[uniffi::export(with_foreign)]
+pub trait CloudflareClearanceResolvedHandler: Send + Sync {
+    fn on_clearance_resolved(&self, event: CloudflareClearanceResolvedEventState);
 }
 
 #[uniffi::export(with_foreign)]

--- a/rust/crates/fire-uniffi-types/src/error.rs
+++ b/rust/crates/fire-uniffi-types/src/error.rs
@@ -14,8 +14,8 @@ pub enum FireUniFfiError {
     StaleSessionResponse { operation: String },
     #[error("network error: {details}")]
     Network { details: String },
-    #[error("request requires Cloudflare challenge verification")]
-    CloudflareChallenge,
+    #[error("request requires Cloudflare challenge verification ({reason})")]
+    CloudflareChallenge { reason: String },
     #[error("{operation} failed with HTTP {status}: {body}")]
     HttpStatus {
         operation: String,
@@ -55,8 +55,14 @@ impl From<FireCoreError> for FireUniFfiError {
             FireCoreError::StaleSessionResponse { operation } => Self::StaleSessionResponse {
                 operation: operation.to_string(),
             },
-            FireCoreError::CloudflareChallenge { .. }
-            | FireCoreError::CloudflareChallengeInProgress { .. } => Self::CloudflareChallenge,
+            FireCoreError::CloudflareChallenge { reason, .. } => Self::CloudflareChallenge {
+                reason: reason.as_str().to_string(),
+            },
+            FireCoreError::CloudflareChallengeInProgress { .. } => Self::CloudflareChallenge {
+                reason: fire_core::CloudflareChallengeFailureReason::InProgress
+                    .as_str()
+                    .to_string(),
+            },
             FireCoreError::HttpStatus {
                 operation,
                 status,

--- a/rust/crates/fire-uniffi/src/lib.rs
+++ b/rust/crates/fire-uniffi/src/lib.rs
@@ -349,9 +349,14 @@ mod tests {
     fn maps_cloudflare_challenge_errors_to_dedicated_variant() {
         let error = FireUniFfiError::from(fire_core::FireCoreError::CloudflareChallenge {
             operation: "create reply",
+            reason: fire_core::CloudflareChallengeFailureReason::Required,
         });
 
-        assert!(matches!(error, FireUniFfiError::CloudflareChallenge));
+        assert!(matches!(
+            error,
+            FireUniFfiError::CloudflareChallenge { reason }
+                if reason == "required"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Align Fire login / Cloudflare challenge recovery with fluxdo end-to-end:
  - login-ready finally (trusted cookies enter home; bootstrap is timed/non-blocking)
  - clearance trust (`recently rejected` + trust settle)
  - post-challenge force bootstrap + full app-state refresh (`CloudflareResolved`)
  - clearance-resolved bus for platform MessageBus restart / CF banner clear
- Fix challenge WebView UX: bare `/challenge` post-pass Discourse **404** is a success signal and must be covered by “正在完成验证…” overlay (no more “page does not exist” flash)
- Password login dialog active CF polling; OAuth/login surface shared recovery path
- iOS topic search bar Auto Layout conflict when hidden (zero-size frame vs internal padding)
- CI fixes: clippy `if_same_then_else` / `manual_pattern_char_comparison`, UniFFI CF error mapping test

## Key behavior
| Area | Change |
|---|---|
| Login ready | `finalize_login_ready` 8s timeout; platforms navigate home without awaiting full app refresh |
| Clearance trust | `clearance_rejected_at` + `cloudflare_clearance_is_trusted()` for preflight |
| Challenge complete | CF cookies only; no auth cookie clobber |
| Post-challenge | force bootstrap + `refresh_all_forced(CloudflareResolved)` + resolved handler notify |
| Challenge UI | `/challenge` 404 covered + treated as pass |
| MessageBus | iOS/Android restart after clearance resolved |

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p fire-models -p fire-core -p fire-uniffi --all-targets --no-deps -- -D warnings`
- [x] `cargo clippy ... --release -- -D warnings`
- [x] `cargo test -p fire-models -p fire-store -p fire-core -p fire-uniffi --all-targets`
- [x] iOS `xcodebuild` build succeeded earlier in this workstream
- [ ] Device: password login with CF preflight / CSRF recover
- [ ] Device: complete CF challenge — should show overlay, not Discourse 404, then dismiss
- [ ] Device: after CF while logged in, home/MessageBus recover without stuck banner
- [ ] Device: topic detail search bar open/close without constraint spam