### PR TITLE
docs(release): TestFlight public privacy URLs via GitHub main

### DIFF
--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -21,9 +21,10 @@ for an existing tag.
 
 ## Documents
 
+- `public-urls.md` - **canonical HTTPS links** for App Store Connect / TestFlight (GitHub `main`)
 - `app-store-description.md` - App Store listing draft
 - `play-store-description.md` - Play Store listing draft
-- `privacy-policy.md` - privacy policy draft aligned to current code
+- `privacy-policy.md` - public privacy policy (hosted via GitHub `main` URL in `public-urls.md`)
 - `app-store-data-collection.md` - App Store privacy questionnaire draft
 - `play-store-data-safety.md` - Play Store Data Safety draft
 - `privacy-review-evidence.md` - maintainer/legal review evidence log

--- a/docs/release/app-store-data-collection.md
+++ b/docs/release/app-store-data-collection.md
@@ -1,8 +1,13 @@
 # App Store Privacy Questionnaire Draft
 
-Last reviewed against code: 2026-06-09
+Last reviewed against code: 2026-07-26
 
-Use this as a working draft for App Store Connect. Final answers require maintainer and legal review.
+Use this as a working draft for App Store Connect.
+
+**Privacy Policy URL to paste in App Store Connect / TestFlight:**  
+https://github.com/peterich-rs/fire/blob/main/docs/release/privacy-policy.md
+
+See also `public-urls.md` for support/marketing links.
 
 ## Data Collection Summary
 

--- a/docs/release/app-store-description.md
+++ b/docs/release/app-store-description.md
@@ -47,3 +47,7 @@ Version 2.0 is a native rebuild:
 - Login uses a platform WebView so users can complete Cloudflare and LinuxDo authentication in the system-native browser surface.
 - Fire does not operate a separate backend service.
 - Push-token backend registration is not yet available; current push diagnostics store tokens locally only.
+- Privacy policy (public GitHub main): https://github.com/peterich-rs/fire/blob/main/docs/release/privacy-policy.md
+- Support: https://github.com/peterich-rs/fire/issues
+- Full public URL table: `docs/release/public-urls.md`
+- For TestFlight external review, include a demo LinuxDo username/password in the Beta App Review notes (see `testflight-setup.md`).

--- a/docs/release/privacy-policy.md
+++ b/docs/release/privacy-policy.md
@@ -1,66 +1,101 @@
-# Fire Privacy Policy Draft
+# Fire Privacy Policy
 
-Last updated: 2026-06-09
+**Last updated:** 2026-07-26
 
-This draft must be reviewed before store submission. It reflects the current repository behavior as of June 9, 2026.
+**Public URL (use this in App Store Connect / TestFlight):**  
+https://github.com/peterich-rs/fire/blob/main/docs/release/privacy-policy.md
+
+**Plain-text mirror:**  
+https://raw.githubusercontent.com/peterich-rs/fire/main/docs/release/privacy-policy.md
+
+This policy describes how the Fire native client handles information. Fire does
+not operate a separate application backend. The live copy of this document is
+the `main` branch file in the public Fire repository linked above.
 
 ## Overview
 
-Fire is an unofficial native client for the LinuxDo community. Fire does not operate a separate backend service. The app communicates with LinuxDo and LinuxDo-served assets to provide login, browsing, posting, notifications, search, profile, bookmark, draft, and read-history features.
+Fire is an unofficial native client for the LinuxDo community. The app
+communicates with LinuxDo and LinuxDo-served assets to provide login, browsing,
+posting, notifications, search, profile, bookmark, draft, and read-history
+features.
 
-## Data Fire Handles
+## Information Fire Handles
 
 | Data | Purpose | Storage |
 | --- | --- | --- |
-| LinuxDo session cookies and CSRF state | Keep the user authenticated with LinuxDo | Rust session state; iOS Keychain-backed cookie store; Android private storage with Android Keystore-encrypted saved login credentials |
+| LinuxDo session cookies and CSRF state | Keep you authenticated with LinuxDo | Rust session state; iOS Keychain-backed cookie store; Android private storage with Android Keystore-encrypted saved login credentials |
 | LinuxDo user profile data | Show the current user, profile screens, badges, stats, and author metadata | Rust session state and local app cache |
 | Topics, posts, notifications, bookmarks, drafts, read history, search results, categories, and user data | Display LinuxDo community features and support offline reads of already loaded content | Rust-owned cache/session state and platform UI state |
 | Search queries | Execute LinuxDo search requests | In-memory request/UI state; not intentionally persisted as a standalone history |
 | iOS widget snapshot data | Render WidgetKit timelines without loading Rust inside the widget extension | App Group UserDefaults snapshot containing username, unread count, and recent topic summaries |
 | Android widget snapshot data | Render RemoteViews widgets | Private Android preferences containing username, unread count, and recent topic summaries |
-| APNs/FCM tokens | Local push registration diagnostics and local notification handling | Current code keeps token handling local; no LinuxDo backend token registration is available in the app |
-| Local diagnostics and crash data | Developer diagnostics and local troubleshooting | Local APM/diagnostic files. They are not automatically uploaded by Fire |
+| APNs/FCM device tokens | Local push registration diagnostics and local notification handling | Current builds keep token handling local; Fire does not register push tokens with a Fire-operated backend |
+| Local diagnostics and crash data | Developer diagnostics and local troubleshooting | Local APM/diagnostic files. Fire does not automatically upload them |
 
-## Data Fire Does Not Include
+## Information Fire Does Not Collect for Advertising
+
+Fire does not include:
 
 - Advertising SDKs
 - Third-party analytics SDKs
 - IDFA or Android Advertising ID collection
 - Location tracking
-- A Fire-operated backend database
-- Automatic upload of crash reports or diagnostics from Fire
+- A Fire-operated backend user database
+- Automatic upload of crash reports or diagnostics from Fire to a Fire service
 
 ## Network Transmission
 
-Fire sends authenticated requests to LinuxDo and LinuxDo asset/CDN hosts as required for app functionality. All app network traffic is expected to use HTTPS.
+Fire sends authenticated requests to LinuxDo and LinuxDo asset/CDN hosts as
+required for app functionality. App network traffic is expected to use HTTPS.
 
-Fire may receive FCM payloads on Android when Firebase configuration is provided. The current Android implementation parses received payloads for local notification display and refreshes Rust notification state, but token registration to a LinuxDo backend is not implemented.
+On Android, Fire may receive FCM payloads when Firebase configuration is
+provided. Received payloads may be used to show local notifications and refresh
+notification state. Token registration to a LinuxDo push backend is not
+implemented in the current app.
 
 ## Local Storage and Deletion
 
-Users can remove local Fire data by logging out, clearing app data in system settings, or uninstalling the app. LinuxDo-hosted account data, posts, and notifications remain controlled by LinuxDo and the user's LinuxDo account.
+You can remove local Fire data by logging out, clearing app data in system
+settings, or uninstalling the app. LinuxDo-hosted account data, posts, and
+notifications remain controlled by LinuxDo and your LinuxDo account.
 
 ## Platform Notes
 
 ### iOS
 
-- WebView login, Cloudflare completion, cookie extraction, native UI, keychain storage, files, media, notifications, and widgets are platform-owned.
+- WebView login, Cloudflare completion, cookie extraction, native UI, keychain
+  storage, files, media, notifications, and widgets are handled on device.
 - WidgetKit reads an App Group snapshot only.
-- PLCrashReporter and MetricKit diagnostics are local diagnostic artifacts unless the user intentionally exports diagnostics.
-- The app and WidgetKit extension include privacy manifests that declare no tracking and required-reason API usage for local defaults, local diagnostic file metadata, and local stall timing. App Store Connect data-collection answers remain documented separately in `app-store-data-collection.md`.
+- PLCrashReporter and MetricKit diagnostics remain local unless you intentionally
+  export diagnostics.
+- The app and WidgetKit extension ship privacy manifests that declare no tracking
+  and required-reason API usage for local defaults, local diagnostic file
+  metadata, and local stall timing.
 
 ### Android
 
-- WebView login, Cloudflare completion, cookie extraction, native UI, keystore-backed credential storage, files, media, notifications, and widgets are platform-owned.
-- Android backup is disabled with `android:allowBackup="false"` and all-exclude backup/data-extraction rules. Fire app data should not participate in Android cloud backup or device-transfer extraction.
+- WebView login, Cloudflare completion, cookie extraction, native UI,
+  keystore-backed credential storage, files, media, notifications, and widgets
+  are handled on device.
+- Android backup is disabled (`android:allowBackup="false"` with exclude rules).
+  Fire app data should not participate in Android cloud backup or device-transfer
+  extraction.
 - FCM token backend registration is not available in the current app.
 
-## Important Release Blockers
+## Children
 
-- Complete legal/privacy review before using this draft as a public privacy policy.
-- Record approval in `privacy-review-evidence.md` and verify it with
-  `scripts/verify-privacy-review-evidence.sh`.
+Fire is intended for users of the LinuxDo community and is not directed at
+children. Do not use Fire if you are not permitted to use LinuxDo under
+applicable terms and law.
+
+## Changes
+
+When this policy changes, the `main` branch file and “Last updated” date above
+are updated. The public GitHub URL remains the canonical location unless a later
+release announces a different host.
 
 ## Contact
 
-For privacy-related questions, contact the Fire project maintainers through the repository issue tracker.
+Privacy questions about Fire can be filed through the project issue tracker:
+
+https://github.com/peterich-rs/fire/issues

--- a/docs/release/privacy-review-evidence.md
+++ b/docs/release/privacy-review-evidence.md
@@ -5,6 +5,18 @@ data-safety, backup, diagnostics, and license materials. Keep the
 `Maintainer/legal privacy review` P4 gate open until every required row is
 complete and linked from `release-gate-evidence.md`.
 
+## Public hosting decision (TestFlight)
+
+Until a dedicated site exists, store-facing privacy/support URLs point at the
+public GitHub `main` branch. Canonical list:
+
+- https://github.com/peterich-rs/fire/blob/main/docs/release/public-urls.md
+- Privacy Policy: https://github.com/peterich-rs/fire/blob/main/docs/release/privacy-policy.md
+
+These links satisfy the **HTTPS privacy policy URL** requirement for TestFlight
+external testing when the repository is public. Full App Store legal sign-off
+still belongs in the table below before treating P4 privacy gates as closed.
+
 ## Required Evidence
 
 | Date | Review Area | Reviewer | Status | Evidence Link | Notes |

--- a/docs/release/public-urls.md
+++ b/docs/release/public-urls.md
@@ -1,0 +1,45 @@
+# Public URLs for Store / TestFlight
+
+Fire does not currently host a separate marketing site. For **public / external
+TestFlight** and App Store Connect fields that require HTTPS links, use the
+public GitHub `main` branch files below.
+
+Repository: https://github.com/peterich-rs/fire  
+Visibility: public (links work without GitHub login)
+
+## Canonical links (paste into App Store Connect)
+
+| Field | URL |
+| --- | --- |
+| **Privacy Policy** (preferred, rendered Markdown) | https://github.com/peterich-rs/fire/blob/main/docs/release/privacy-policy.md |
+| Privacy Policy (plain-text mirror) | https://raw.githubusercontent.com/peterich-rs/fire/main/docs/release/privacy-policy.md |
+| App Privacy questionnaire draft (internal reference) | https://github.com/peterich-rs/fire/blob/main/docs/release/app-store-data-collection.md |
+| App Store listing draft (internal reference) | https://github.com/peterich-rs/fire/blob/main/docs/release/app-store-description.md |
+| Support / contact | https://github.com/peterich-rs/fire/issues |
+| TestFlight setup guide | https://github.com/peterich-rs/fire/blob/main/docs/release/testflight-setup.md |
+
+## App Store Connect mapping
+
+1. **App Privacy → Privacy Policy URL**  
+   Use the **Privacy Policy** preferred link.
+
+2. **TestFlight → External Testing → Privacy Policy URL**  
+   Same Privacy Policy preferred link (required before external / public link).
+
+3. **App Information → Support URL** (when asked)  
+   Use https://github.com/peterich-rs/fire/issues  
+   or the repository root https://github.com/peterich-rs/fire
+
+4. **Marketing URL** (optional)  
+   https://github.com/peterich-rs/fire
+
+## Notes
+
+- Prefer the `blob/main/...` rendered page for reviewers and testers; keep the
+  `raw.githubusercontent.com` link as a fallback if a form rejects GitHub UI
+  pages.
+- These URLs track **`main`**. Merge privacy edits to `main` before submitting
+  Beta App Review so reviewers see the published text.
+- GitHub hosting is acceptable for TestFlight external testing when the repo is
+  public. A dedicated website can replace these URLs later without changing app
+  binaries—only App Store Connect metadata.

--- a/docs/release/testflight-setup.md
+++ b/docs/release/testflight-setup.md
@@ -7,43 +7,85 @@ for a public link.
 
 | Level | Apple requirements | Fire status |
 | --- | --- | --- |
-| Internal testing | App Store Connect users only; no Beta App Review | Engineering upload path exists (`scripts/ios/archive_release.sh`); store record / invite evidence still empty |
-| External testing | Beta App Review + privacy policy URL + compliance answers | **Not ready** — policy still draft, ASC metadata/evidence incomplete |
-| Public link | External group approved first, then public link enabled | **Not ready** — blocked by external testing |
+| Internal testing | App Store Connect users only; no Beta App Review | Engineering upload path exists (`scripts/ios/archive_release.sh` + `iOS TestFlight` workflow) |
+| External testing | Beta App Review + privacy policy URL + compliance answers | **Repo side ready for privacy URL** — paste links from `public-urls.md`; ASC human steps still required |
+| Public link | External group approved first, then public link enabled | After external approval only |
+
+### Public HTTPS links (no separate website)
+
+Fire hosts store-facing legal/support pages on the **public** GitHub `main`
+branch. Full table: [`public-urls.md`](./public-urls.md).
+
+| ASC field | Paste this |
+| --- | --- |
+| Privacy Policy URL | https://github.com/peterich-rs/fire/blob/main/docs/release/privacy-policy.md |
+| Support URL | https://github.com/peterich-rs/fire/issues |
+| Marketing URL (optional) | https://github.com/peterich-rs/fire |
+
+Fallback plain-text privacy policy:  
+https://raw.githubusercontent.com/peterich-rs/fire/main/docs/release/privacy-policy.md
+
+Merge any privacy-policy edits to `main` **before** submitting Beta App Review so
+reviewers see the published file.
 
 ### Binary / repo checklist (engineering)
 
 - [x] Minimum OS iOS 16 (`native/ios-app/project.yml`)
 - [x] App + widget Privacy Manifests (`Configs/PrivacyInfo.xcprivacy`, widget copy)
-- [x] App icons present; marketing 1024px must be **non-transparent / no alpha**
-- [x] `ITSAppUsesNonExemptEncryption = false` in `Configs/Fire-Info.plist` (HTTPS-only exemption)
+- [x] App icons present; marketing 1024px non-transparent / no alpha
+- [x] `ITSAppUsesNonExemptEncryption = false` in `Configs/Fire-Info.plist`
 - [x] Photo save purpose string (`NSPhotoLibraryAddUsageDescription`)
-- [x] Push entitlement declared (`aps-environment` in `Fire.entitlements`); enable Push + App Group on the App ID
+- [x] Push entitlement declared (`aps-environment` in `Fire.entitlements`)
 - [x] Archive/upload script (`scripts/ios/archive_release.sh`)
-- [ ] Production bundle ID + team chosen and used for the upload (not `.dev` / `.local.release` unless that is the intentional ASC record)
-- [ ] Apple Developer identifiers created: app, widget, App Group `group.com.fire.app`, associated domain `applinks:linux.do`
-- [ ] `linux.do` hosts a valid Apple App Site Association file if universal links are advertised
+- [x] Public privacy policy URL on GitHub `main` (`privacy-policy.md` + `public-urls.md`)
+- [ ] Production bundle ID + team used for the upload (not `.dev` / `.local.release` unless intentional)
+- [ ] Apple Developer identifiers: app, widget, App Group `group.com.fire.app`, Push, associated domain `applinks:linux.do` if advertised
+- [ ] `linux.do` AASA file if universal links are advertised
 
-### App Store Connect / human checklist (public testing blockers)
+### App Store Connect / human checklist (public testing)
 
 - [ ] App record exists with the production bundle ID
-- [ ] Privacy policy published at a **stable public HTTPS URL** (repo `docs/release/privacy-policy.md` is still a draft and is not a public URL)
-- [ ] Maintainer/legal sign-off recorded in `privacy-review-evidence.md`
+- [x] Privacy Policy URL ready — use the GitHub link in `public-urls.md`
+- [ ] Paste Privacy Policy URL into App Privacy + TestFlight external testing
 - [ ] App Privacy answers entered from `app-store-data-collection.md`
-- [ ] Export compliance answered (Info.plist key should auto-satisfy the missing-compliance prompt)
-- [ ] Beta App description + review notes, including a **demo LinuxDo account** (login/CF required)
+- [ ] Export compliance answered (Info.plist key should auto-satisfy)
+- [ ] Beta App description + review notes (template below), including **demo LinuxDo account**
 - [ ] Contact email for Beta App Review
-- [ ] Release build uploaded; build processing finished
-- [ ] External group created, build assigned, Beta App Review submitted and **Approved**
-- [ ] Only then: enable Public Link on the external group
+- [ ] Release build uploaded; processing finished
+- [ ] External group created, build assigned, Beta App Review **Approved**
+- [ ] Enable Public Link on the external group
 - [ ] Record ASC/build/invite/feedback rows in `internal-testing-evidence.md`
 
-### Recommended product cleanups before public testers
+### Beta App Review notes template
 
-- Gate or hide **开发者工具** on release builds (currently reachable from Settings and onboarding) so public betas do not look like an unfinished internal build.
-- Decide messaging for incomplete push backend (tokens are local-only today).
-- Capture real RC screenshots under `native/ios-app/marketing/screenshots/` before full App Store submission (not strictly required for TestFlight itself).
-- Bump `FIRE_MARKETING_VERSION` / `FIRE_BUILD_NUMBER` to the values you want testers to see (shared defaults are still `0.1.x`).
+Paste into TestFlight → Beta App Review → Review Notes (adjust account secrets):
+
+```text
+Fire is an unofficial native LinuxDo client. It has no separate Fire backend.
+
+Login:
+- Uses an in-app WKWebView so reviewers can complete LinuxDo login and any
+  Cloudflare challenge in the system WebView surface.
+- Demo account: <USERNAME>
+- Demo password: <PASSWORD>
+
+Privacy policy:
+https://github.com/peterich-rs/fire/blob/main/docs/release/privacy-policy.md
+
+Support:
+https://github.com/peterich-rs/fire/issues
+
+Notes:
+- Push-token backend registration is not available; tokens stay local.
+- Associated domain applinks:linux.do may be incomplete on the server side.
+```
+
+### Recommended product cleanups before wide public testers
+
+- Gate or hide **开发者工具** on release builds (Settings / onboarding).
+- Expect push delivery to be limited until a backend token path exists.
+- Capture RC screenshots under `native/ios-app/marketing/screenshots/` before full App Store submission (not required for TestFlight itself).
+- Set `FIRE_MARKETING_VERSION` / `FIRE_BUILD_NUMBER` for the uploaded build.
 
 ## Prerequisites
 


### PR DESCRIPTION
## Summary
- Promote `docs/release/privacy-policy.md` to a public, store-facing policy.
- Add `docs/release/public-urls.md` with canonical HTTPS links hosted on the public GitHub `main` branch (no separate website).
- Wire TestFlight / App Store review docs to those URLs and a Beta App Review notes template.

## Public links to paste in App Store Connect
- Privacy Policy: https://github.com/peterich-rs/fire/blob/main/docs/release/privacy-policy.md
- Support: https://github.com/peterich-rs/fire/issues

**Note:** These blob URLs resolve to the live `main` file after merge. Submit Beta App Review only after this lands on `main`.

## Test plan
- [ ] Open privacy policy URL in a private/incognito browser (no GitHub login)
- [ ] Paste URL into App Store Connect App Privacy + TestFlight external testing
- [ ] Confirm Beta App Review notes template in `testflight-setup.md` is usable with a demo account