### PR TITLE
fix(ios): restore v0.1.3 TestFlight signing baseline

### DIFF
--- a/docs/release/testflight-setup.md
+++ b/docs/release/testflight-setup.md
@@ -35,9 +35,12 @@ reviewers see the published file.
 - [x] App icons present; marketing 1024px non-transparent / no alpha
 - [x] `ITSAppUsesNonExemptEncryption = false` in `Configs/Fire-Info.plist`
 - [x] Photo save purpose string (`NSPhotoLibraryAddUsageDescription`)
-- [x] Push entitlement declared (`aps-environment` in `Fire.entitlements`)
 - [x] Archive/upload script (`scripts/ios/archive_release.sh`)
 - [x] Public privacy policy URL on GitHub `main` (`privacy-policy.md` + `public-urls.md`)
+- [x] Signing baseline aligned with **v0.1.3**: main app entitlements are
+  Associated Domains only; **Widget is not embedded** in the Fire archive until
+  App Group + extension profiles exist. Push (`aps-environment`) and App Groups
+  stay out of `Fire.entitlements` so the existing `Fire App Store` profile works.
 - [ ] Production bundle ID + team used for the upload (not `.dev` / `.local.release` unless intentional)
 - [ ] Apple Developer identifiers: app, widget, App Group `group.com.fire.app`, Push, associated domain `applinks:linux.do` if advertised
 - [ ] `linux.do` AASA file if universal links are advertised

--- a/native/ios-app/Fire.entitlements
+++ b/native/ios-app/Fire.entitlements
@@ -2,16 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<!-- Xcode/distribution profiles rewrite development → production on App Store archives. -->
-	<key>aps-environment</key>
-	<string>development</string>
+	<!-- Match v0.1.3 TestFlight-capable profile: Associated Domains only.
+	     Push (aps-environment) and App Groups are intentionally omitted until
+	     the App Store provisioning profile is regenerated with those capabilities.
+	     Widget extension remains in the repo but is not embedded in the app target. -->
 	<key>com.apple.developer.associated-domains</key>
 	<array>
 		<string>applinks:linux.do</string>
-	</array>
-	<key>com.apple.security.application-groups</key>
-	<array>
-		<string>group.com.fire.app</string>
 	</array>
 </dict>
 </plist>

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -17,7 +17,6 @@
 		0738F9AD86263ECE2016A8D4 /* FireTagPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7BA62EEC87348A069D789A7E /* FireTagPickerSheet.swift */; };
 		0829CF9A9EE33EA119F94468 /* FireWidgetData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4543C11B22E10FA9DA852E16 /* FireWidgetData.swift */; };
 		087AF23CD1F909A1BFC87312 /* FireNetworkDiagnosticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92C90A87682AF244F048541F /* FireNetworkDiagnosticsView.swift */; };
-		09340405972C7DF44FD0647D /* FireWidgetExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = F7F4881067D974AA645C77FC /* FireWidgetExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		0964DB91A22F07DD40FE1ADA /* FireTopicDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 457CCC7AE29267A8B9448BA7 /* FireTopicDetailViewController.swift */; };
 		09DEF34E484D68FE6A3A1AC5 /* FireTheme.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0AA3F1257384BF109634D21 /* FireTheme.swift */; };
 		0AABB8FE83B25A7D6D7C67FC /* FireCfClearanceRefreshService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F01E5248AEF9002E2919AC0F /* FireCfClearanceRefreshService.swift */; };
@@ -228,13 +227,6 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		58F14EC73C1DCE647A140445 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 9AB7FC66AC31A04F54C77B79 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = BEC723EF3D036CE24703367A;
-			remoteInfo = FireWidgetExtension;
-		};
 		DC8D43819C61EEBADFD56ED4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 9AB7FC66AC31A04F54C77B79 /* Project object */;
@@ -254,17 +246,6 @@
 				720F0DB93AF559449C8EAAE3 /* AsyncDisplayKit.xcframework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		75DF669F973EF65EE19DD83A /* Embed Foundation Extensions */ = {
-			isa = PBXCopyFilesBuildPhase;
-			buildActionMask = 2147483647;
-			dstPath = "";
-			dstSubfolderSpec = 13;
-			files = (
-				09340405972C7DF44FD0647D /* FireWidgetExtension.appex in Embed Foundation Extensions */,
-			);
-			name = "Embed Foundation Extensions";
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXCopyFilesBuildPhase section */
@@ -1119,13 +1100,11 @@
 				C48ECD0BE135A9DCE10B1CAA /* Sources */,
 				043FD04CB8BAE2AA45BABDB6 /* Resources */,
 				1E5D1534135BDBC408E23F3B /* Frameworks */,
-				75DF669F973EF65EE19DD83A /* Embed Foundation Extensions */,
 				4A9FC8DFEC9FFF4BC7C594AA /* Embed Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				A8BDB1DF623B1288CC69CF97 /* PBXTargetDependency */,
 			);
 			name = Fire;
 			packageProductDependencies = (
@@ -1495,11 +1474,6 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		A8BDB1DF623B1288CC69CF97 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = BEC723EF3D036CE24703367A /* FireWidgetExtension */;
-			targetProxy = 58F14EC73C1DCE647A140445 /* PBXContainerItemProxy */;
-		};
 		FAD67CF76E1A43CF274706B3 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 87BF3D86E2CA36A3D645AA33 /* Fire */;

--- a/native/ios-app/project.yml
+++ b/native/ios-app/project.yml
@@ -93,8 +93,11 @@ targets:
       - framework: LocalPackages/TextureCore/Artifacts/AsyncDisplayKit.xcframework
         embed: true
         codeSign: true
-      - target: FireWidgetExtension
-        embed: true
+      # FireWidgetExtension is kept in-repo for future work, but not embedded in
+      # the shipping app until App Group + extension provisioning matches the
+      # App Store profile (v0.1.3 TestFlight baseline had no widget target).
+      # - target: FireWidgetExtension
+      #   embed: true
     settings:
       base:
         CODE_SIGN_STYLE: $(FIRE_CODE_SIGN_STYLE)
@@ -144,6 +147,9 @@ targets:
           - $(SRCROOT)/Generated/fire_uniffiFFI/fire_uniffiFFI.h
           - $(SRCROOT)/Generated/fire_uniffiFFI/module.modulemap
           - $(SRCROOT)/Generated/lib/$(PLATFORM_NAME)/libfire_uniffi.a
+  # Optional local-only target. Not part of the Fire app archive / TestFlight
+  # product while disabled above. Re-enable embed + App Group on the main app
+  # entitlements together when widget provisioning is ready.
   FireWidgetExtension:
     type: app-extension
     platform: iOS


### PR DESCRIPTION
## Summary
- Align shipping iOS signing with **v0.1.3** (last known good TestFlight archive).
- `Fire.entitlements`: Associated Domains only (remove `aps-environment` + App Groups).
- Do **not** embed `FireWidgetExtension` in the Fire app target (code kept in repo).
- Document the baseline in `docs/release/testflight-setup.md`.

## Why
CI TestFlight archive failed because profile \`Fire App Store\` lacked App Groups / Push, and the widget extension required an App Groups profile. v0.1.3 did not ship those entitlements or a widget target.

## Test plan
- [ ] Re-run **iOS TestFlight** workflow with \`upload_to_testflight=true\`
- [ ] Confirm archive succeeds past signing
- [ ] Install internal build; smoke login + topic detail
- [ ] Confirm no widget is embedded in the IPA (expected)