### PR TITLE
fix(session): realign CSRF after Cloudflare challenge rebuild

### DIFF
--- a/docs/knowledge/discourse-cloudflare-challenge-guide.md
+++ b/docs/knowledge/discourse-cloudflare-challenge-guide.md
@@ -204,12 +204,28 @@ After a successful challenge:
 4. If the user already has a login session, force bootstrap rebuild **and** a full
    app-state refresh batch (`CloudflareResolved`, bypassing normal debounce).
    Manual challenge completion and network-owned completion share this path.
-5. Publish join success so concurrent CF victims can retry.
-6. Broadcast a clearance-resolved event (`generation`, `has_login_session`,
+5. After bootstrap (success or soft failure), if auth cookies are still present,
+   **force** a `/session/csrf` refresh before notifying hosts. Do not rely only
+   on home HTML `<meta name="csrf-token">`:
+   - bootstrap `Set-Cookie` can rotate `_forum_session` / `_t` and clear the
+     cached CSRF via auth-rotation (`stale_csrf_cleared`)
+   - home HTML after challenge may omit the csrf meta (interstitial residue,
+     redirect, or partial page), leaving `can_write_authenticated_api` false
+   - `refresh_csrf_token_if_needed` is not enough here when a pre-challenge
+     token is still present but no longer valid for the rotated session
+   Soft-fail CSRF refresh; write paths still have BAD CSRF clear+retry as a
+   last resort. Challenge failure itself is never a logout signal.
+6. Publish join success so concurrent CF victims can retry.
+7. Broadcast a clearance-resolved event (`generation`, `has_login_session`,
    `can_open_message_bus`) so hosts can:
    - clear CF error banners
    - restart MessageBus when readiness allows
    - continue login finalize / retry login JS when mid-login
+
+Note: post-challenge bootstrap / app-state refresh may be the first authenticated
+requests after a long idle. If the server already expired `_t` / `_forum_session`,
+auth-strike passive logout is correct behavior (session was already dead; CF did
+not clear login cookies). Surface that as session expiry, not as challenge failure.
 
 ### Login-ready handoff
 

--- a/rust/crates/fire-core/src/core/auth.rs
+++ b/rust/crates/fire-core/src/core/auth.rs
@@ -91,6 +91,23 @@ impl FireCore {
                     warn!(error = %error, "post-challenge bootstrap rebuild failed");
                 }
             }
+
+            // Bootstrap alone is not enough to keep writes healthy after CF:
+            // Set-Cookie may rotate `_forum_session`/`_t` (stale CSRF cleared),
+            // while home HTML may omit `<meta name="csrf-token">` (interstitial /
+            // redirect / partial page). Force a `/session/csrf` realign so
+            // `can_write_authenticated_api` recovers before hosts act on the
+            // clearance-resolved event. Failures stay soft — BAD CSRF retry
+            // remains the last line of defense.
+            if core.snapshot().cookies.can_authenticate_requests() {
+                match core.refresh_csrf_token().await {
+                    Ok(_) => info!("post-challenge CSRF realigned"),
+                    Err(error) => {
+                        warn!(error = %error, "post-challenge CSRF refresh failed")
+                    }
+                }
+            }
+
             core.state_observers().notify_session(core.snapshot());
 
             // Force a full loginCompleted-style batch so CF mid-refresh does not

--- a/rust/crates/fire-core/tests/network.rs
+++ b/rust/crates/fire-core/tests/network.rs
@@ -3998,6 +3998,141 @@ async fn create_reply_cloudflare_retry_rebuilds_stale_csrf_header() {
     );
 }
 
+/// Post-challenge rebuild must force `/session/csrf` after bootstrap when home
+/// HTML lacks csrf meta and Set-Cookie rotated the forum session (which clears
+/// the cached CSRF via auth rotation). Without this, writes stay blocked on
+/// `can_write_authenticated_api == false` until a later opportunistic refresh.
+#[tokio::test]
+async fn complete_cloudflare_challenge_realigns_csrf_after_bootstrap_without_meta() {
+    let home_without_csrf = r#"
+<!doctype html>
+<html>
+  <head>
+    <meta name="shared_session_key" content="shared-session">
+    <meta name="current-username" content="alice">
+    <meta name="discourse-base-uri" content="/">
+  </head>
+  <body>
+    <div id="data-discourse-setup" data-preloaded="{&quot;currentUser&quot;:{&quot;id&quot;:1,&quot;username&quot;:&quot;alice&quot;},&quot;siteSettings&quot;:{&quot;long_polling_base_url&quot;:&quot;https://linux.do&quot;},&quot;site&quot;:{&quot;categories&quot;:[],&quot;top_tags&quot;:[],&quot;can_tag_topics&quot;:false}}"></div>
+  </body>
+</html>
+"#;
+    let rotating_home = format!(
+        "HTTP/1.1 200 TEST\r\nContent-Type: text/html\r\nContent-Length: {}\r\nSet-Cookie: _forum_session=rotated-forum; path=/; SameSite=Lax\r\nConnection: close\r\n\r\n{home_without_csrf}",
+        home_without_csrf.len()
+    );
+    let home_again = format!(
+        "HTTP/1.1 200 TEST\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{home_without_csrf}",
+        home_without_csrf.len()
+    );
+    let responses = vec![
+        // schedule_post_challenge: refresh_bootstrap
+        rotating_home,
+        // schedule_post_challenge: forced refresh_csrf_token
+        raw_json_response(200, "application/json", r#"{"csrf":"fresh-csrf"}"#),
+        // refresh_all_forced core: refresh_bootstrap again
+        home_again,
+        // refresh_all_forced core: home topic list
+        raw_json_response(200, "application/json", &sample_latest_json()),
+    ];
+    let server = TestServer::spawn(responses).await.expect("server");
+    let core = FireCore::new(FireCoreConfig {
+        base_url: server.base_url(),
+        workspace_path: None,
+    })
+    .expect("core");
+
+    let _ = core.sync_login_context(LoginSyncInput {
+        username: Some("alice".into()),
+        home_html: None,
+        csrf_token: Some("stale-csrf".into()),
+        current_url: Some(server.base_url()),
+        browser_user_agent: Some("FireTests/1.0".into()),
+        cookies: vec![
+            PlatformCookie {
+                name: "_t".into(),
+                value: "token".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+                same_site: None,
+            },
+            PlatformCookie {
+                name: "_forum_session".into(),
+                value: "forum".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+                same_site: None,
+            },
+            PlatformCookie {
+                name: "cf_clearance".into(),
+                value: "old-clearance".into(),
+                domain: None,
+                path: None,
+                expires_at_unix_ms: None,
+                same_site: None,
+            },
+        ],
+    });
+    assert_eq!(
+        core.snapshot().cookies.csrf_token.as_deref(),
+        Some("stale-csrf")
+    );
+    assert!(core.snapshot().readiness().can_write_authenticated_api);
+
+    let _ = core.complete_cloudflare_challenge(
+        vec![PlatformCookie {
+            name: "cf_clearance".into(),
+            value: "fresh-clearance".into(),
+            domain: Some("linux.do".into()),
+            path: Some("/".into()),
+            expires_at_unix_ms: None,
+            same_site: Some("None".into()),
+        }],
+        Some("fresh-clearance".into()),
+        Some("FireTests/1.0".into()),
+    );
+
+    // Post-challenge task: 30ms + trust settle (~400ms) + bootstrap + csrf.
+    let mut realigned = false;
+    for _ in 0..80 {
+        let snapshot = core.snapshot();
+        if snapshot.cookies.csrf_token.as_deref() == Some("fresh-csrf")
+            && snapshot.cookies.forum_session.as_deref() == Some("rotated-forum")
+            && snapshot.readiness().can_write_authenticated_api
+        {
+            realigned = true;
+            break;
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+
+    let requests = server.shutdown_with_requests().await;
+    let snapshot = core.snapshot();
+
+    assert!(
+        realigned,
+        "expected post-challenge CSRF realign; csrf={:?} forum={:?} can_write={}",
+        snapshot.cookies.csrf_token,
+        snapshot.cookies.forum_session,
+        snapshot.readiness().can_write_authenticated_api
+    );
+    assert_eq!(snapshot.cookies.t_token.as_deref(), Some("token"));
+    assert_eq!(
+        snapshot.cookies.cf_clearance.as_deref(),
+        Some("fresh-clearance")
+    );
+    assert!(
+        requests.iter().any(|request| {
+            request
+                .to_ascii_lowercase()
+                .contains("get /session/csrf")
+        }),
+        "post-challenge rebuild must call /session/csrf:\n{requests:#?}"
+    );
+}
+
 #[tokio::test]
 async fn create_reply_surfaces_pending_review_state() {
     let responses = vec![raw_json_response(

--- a/rust/crates/fire-core/tests/network.rs
+++ b/rust/crates/fire-core/tests/network.rs
@@ -4124,11 +4124,9 @@ async fn complete_cloudflare_challenge_realigns_csrf_after_bootstrap_without_met
         Some("fresh-clearance")
     );
     assert!(
-        requests.iter().any(|request| {
-            request
-                .to_ascii_lowercase()
-                .contains("get /session/csrf")
-        }),
+        requests
+            .iter()
+            .any(|request| { request.to_ascii_lowercase().contains("get /session/csrf") }),
         "post-challenge rebuild must call /session/csrf:\n{requests:#?}"
     );
 }

--- a/rust/crates/fire-core/tests/session_flow.rs
+++ b/rust/crates/fire-core/tests/session_flow.rs
@@ -1270,32 +1270,47 @@ fn resolve_workspace_path_rejects_parent_segments() {
     }
 }
 
-#[test]
-fn complete_cloudflare_challenge_notifies_clearance_resolved_handler() {
+#[tokio::test]
+async fn complete_cloudflare_challenge_notifies_clearance_resolved_handler() {
     use fire_models::CloudflareClearanceResolvedEvent;
     use std::sync::{Arc, Mutex};
+    use std::time::Duration;
 
-    let core = FireCore::new(FireCoreConfig::default()).expect("core");
+    // Post-challenge rebuild hits bootstrap + forced CSRF + app-state batch.
+    // Point at a local server so the handler is not blocked on real network I/O.
+    let server = common::TestServer::spawn(vec![
+        common::raw_text_response(200, &sample_home_html()),
+        common::raw_json_response(200, "application/json", r#"{"csrf":"csrf-token"}"#),
+        common::raw_text_response(200, &sample_home_html()),
+        common::raw_json_response(200, "application/json", &common::sample_latest_json()),
+    ])
+    .await
+    .expect("server");
+    let core = FireCore::new(FireCoreConfig {
+        base_url: server.base_url(),
+        workspace_path: None,
+    })
+    .expect("core");
     let _ = core.sync_login_context(LoginSyncInput {
         username: Some("alice".into()),
         home_html: Some(sample_home_html()),
         csrf_token: Some("csrf-token".into()),
-        current_url: Some("https://linux.do/".into()),
+        current_url: Some(server.base_url()),
         browser_user_agent: Some("FireTests/1.0".into()),
         cookies: vec![
             PlatformCookie {
                 name: "_t".into(),
                 value: "token".into(),
-                domain: Some("linux.do".into()),
-                path: Some("/".into()),
+                domain: None,
+                path: None,
                 expires_at_unix_ms: None,
                 same_site: None,
             },
             PlatformCookie {
                 name: "_forum_session".into(),
                 value: "forum".into(),
-                domain: Some("linux.do".into()),
-                path: Some("/".into()),
+                domain: None,
+                path: None,
                 expires_at_unix_ms: None,
                 same_site: None,
             },
@@ -1313,7 +1328,7 @@ fn complete_cloudflare_challenge_notifies_clearance_resolved_handler() {
         vec![PlatformCookie {
             name: "cf_clearance".into(),
             value: "fresh-clearance".into(),
-            domain: Some(".linux.do".into()),
+            domain: None,
             path: Some("/".into()),
             expires_at_unix_ms: None,
             same_site: Some("None".into()),
@@ -1325,14 +1340,15 @@ fn complete_cloudflare_challenge_notifies_clearance_resolved_handler() {
     // Generation advances immediately for idle (manual) completion.
     assert!(core.cloudflare_clearance_resolved_generation() > before);
 
-    // Handler may fire after async rebuild settles; wait briefly.
-    for _ in 0..50 {
+    // Handler fires after async rebuild (settle + bootstrap + CSRF + app-state).
+    for _ in 0..80 {
         if !events.lock().expect("events").is_empty() {
             break;
         }
-        std::thread::sleep(std::time::Duration::from_millis(50));
+        tokio::time::sleep(Duration::from_millis(50)).await;
     }
     let seen = events.lock().expect("events").clone();
+    let _ = server.shutdown().await;
     assert!(
         !seen.is_empty(),
         "expected clearance-resolved handler notification"


### PR DESCRIPTION
## Summary

- After Cloudflare challenge success, `schedule_post_challenge_session_rebuild` now **force-refreshes** `/session/csrf` when auth cookies are still present, instead of relying only on home HTML `<meta name="csrf-token">`.
- Session notify happens **after** CSRF realign so hosts see a writable session (`can_write_authenticated_api`) before clearance-resolved events.
- Documents the post-challenge CSRF contract and the distinction between true session expiry (passive logout) vs challenge failure.

### Root cause

1. CF completion only merges CF cookies and schedules bootstrap rebuild.
2. Bootstrap `Set-Cookie` can rotate `_forum_session`/`_t`, which clears cached CSRF via `stale_csrf_cleared`.
3. If home HTML lacks csrf meta (interstitial residue / partial page), CSRF stays empty and writes appear broken until BAD CSRF / opportunistic refresh.
4. `refresh_csrf_token_if_needed` is insufficient when a pre-challenge token still exists but no longer matches the rotated session — this path uses **forced** `refresh_csrf_token()`.

### Out of scope (by design)

- Passive logout when server session is already expired during post-challenge API traffic remains correct; CF does not clear login cookies itself.

## Test plan

- [x] `cargo test -p fire-core --test network complete_cloudflare_challenge_realigns_csrf_after_bootstrap_without_meta`
- [x] `cargo test -p fire-core --test session_flow complete_cloudflare_challenge_notifies_clearance_resolved_handler`
- [x] `cargo test -p fire-core --test network --test session_flow --test auth_strike`
- [ ] Manual: log in → trigger CF challenge mid-session → complete challenge → confirm composer/write still works without first-write BAD CSRF
- [ ] Manual: expire server session then complete CF → expect clear “session expired / re-login”, not “CF failed”