### PR TITLE
fix(ios): stop stacking Cloudflare challenge sheets

### DIFF
--- a/docs/knowledge/discourse-cloudflare-challenge-guide.md
+++ b/docs/knowledge/discourse-cloudflare-challenge-guide.md
@@ -177,6 +177,34 @@ Hosts should distinguish challenge failure reasons when surfacing UI:
 | `in_progress` | Wait / do not open a second WebView |
 | `background_suppressed` | Do not steal focus; offer manual verify on visible pages |
 
+### Platform host presentation ownership (iOS)
+
+Automatic challenge UI has **one** owner on iOS:
+
+1. **Network-owned present** — Rust detects a CF challenge, `begin_or_join`
+   selects a single owner, and the UniFFI `CloudflareChallengeHandler` presents
+   the WebView. Concurrent victims **join** that verification; new outbound
+   traffic is blocked with `CloudflareChallengeInProgress` (`in_progress`).
+2. **Explicit host present** — login preflight (`ensureCloudflareClearance`),
+   in-login recover, and user-initiated "verify now" actions. These share the
+   same process-wide presentation gate as (1) so they **join** rather than
+   stack a second full-screen modal.
+
+Host request wrappers **must not present** challenge UI:
+
+| Wrapper | Behavior |
+|---|---|
+| Read-path recovery (`performWithCloudflareRecovery`) | On `in_progress`, wait for the active presentation gate (and a short jar settle), then retry once. Other CF reasons rethrow for banners / explicit manual verify |
+| Write-path wrapper (`performWriteWithCloudflareRetry`) | **Passthrough** — do not wait. Rust already fails writes quickly with `in_progress`; hanging the composer is worse than a fast error the user can retry after verify |
+
+Shared presentation gate joiners receive the owner's WebView clearance/cookie
+result and intentionally ignore joiner `sessionEpoch`; each network request
+retries under Rust with its own epoch after the shared challenge finishes.
+
+`InProgress` may be folded into the same UniFFI `CloudflareChallenge` error
+type as other CF failures; hosts must still branch on the reason string and
+must not treat every CF error as "open WebView".
+
 Logged-in clients should also run a hidden Turnstile clearance refresh runtime
 while the app is foregrounded. Challenge response bodies may carry a Turnstile
 `sitekey`; capture it into bootstrap state when missing so refresh can start.

--- a/native/ios-app/App/Services/FireAppServiceHost.swift
+++ b/native/ios-app/App/Services/FireAppServiceHost.swift
@@ -24,6 +24,7 @@ final class FireAppServiceHost {
         try await owner.sessionStoreValue()
     }
 
+    /// Write-path CF passthrough. Does not wait or present challenge UI.
     func performWriteWithCloudflareRetry<T>(
         operationDescription: String = "执行当前操作",
         originURL: URL? = nil,
@@ -36,6 +37,7 @@ final class FireAppServiceHost {
         )
     }
 
+    /// Read-path CF join/retry. Does not present challenge UI.
     func performWithCloudflareRecovery<T>(
         operation: String,
         _ request: @escaping @MainActor () async throws -> T

--- a/native/ios-app/App/ViewModels/FireAppViewModel.swift
+++ b/native/ios-app/App/ViewModels/FireAppViewModel.swift
@@ -1425,14 +1425,29 @@ final class FireAppViewModel: ObservableObject {
         }
     }
 
+    /// Write-path CF wrapper. **Passthrough** — does not wait or present.
+    ///
+    /// Rust already fails writes quickly with `CloudflareChallengeInProgress`
+    /// while a challenge is active. Host-side wait/retry would hang composer
+    /// actions for up to minutes with no UI feedback; callers should surface
+    /// the error and let the user retry after verification.
     func performWriteWithCloudflareRetry<T>(
         operationDescription: String = "执行当前操作",
         originURL: URL? = nil,
         operation: @escaping () async throws -> T
     ) async throws -> T {
+        _ = operationDescription
+        _ = originURL
         return try await operation()
     }
 
+    /// Read-path join/retry helper for Cloudflare errors. **Does not present** UI.
+    ///
+    /// - `in_progress`: wait for the host presentation gate (Rust handler already
+    ///   owns the WebView), settle jar merge, then retry `work` once.
+    /// - other CF reasons: rethrow for banners / explicit manual verify.
+    ///
+    /// `originURL` is retained for call-site compatibility and diagnostics only.
     func performWithCloudflareRecovery<T>(
         operation: String,
         originURL: URL? = nil,
@@ -1444,31 +1459,58 @@ final class FireAppViewModel: ObservableObject {
             guard Self.isCloudflareChallengeError(error) else {
                 throw error
             }
-            guard let sessionStore else {
+            let reason = Self.cloudflareChallengeReason(from: error)
+            switch Self.cloudflareRecoveryAction(forReason: reason) {
+            case .waitThenRetry:
+                FireAPMManager.shared.recordBreadcrumb(
+                    level: "info",
+                    target: "auth.cf",
+                    message: "recovery wait-then-retry operation=\(operation) reason=\(reason) origin=\(originURL?.absoluteString ?? "nil")"
+                )
+                await Self.awaitCloudflareChallengeQuietPeriod()
+                return try await work()
+            case .rethrow:
                 throw error
             }
-            let coordinator = FireCloudflareChallengeCoordinator(sessionStore: sessionStore)
-            let result = await coordinator.completeManualVerification(
-                originURL: originURL?.absoluteString ?? "https://linux.do/"
-            )
-            let fresh = result.freshCfClearance?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-            guard result.completed, !result.userCancelled, !fresh.isEmpty else {
-                throw error
-            }
-            let session = try await sessionStore.completeCloudflareChallenge(
-                cookies: result.cookies,
-                freshCfClearance: fresh,
-                browserUserAgent: result.browserUserAgent
-            )
-            FireCfClearanceRefreshService.shared.updateSession(
-                session,
-                loginCoordinator: FireWebViewLoginCoordinator(sessionStore: sessionStore)
-            )
-            FireCfClearanceRefreshService.shared.setLoginStateConfirmed(
-                session.readiness.hasCurrentUser && session.readiness.canReadAuthenticatedApi
-            )
-            return try await work()
         }
+    }
+
+    /// Host recovery policy for a normalized CF reason token (read path).
+    /// Automatic paths never present UI (`waitThenRetry` / `rethrow` only).
+    enum CloudflareRecoveryAction: Equatable {
+        case waitThenRetry
+        case rethrow
+    }
+
+    nonisolated static func cloudflareRecoveryAction(
+        forReason reason: String
+    ) -> CloudflareRecoveryAction {
+        switch reason {
+        case "in_progress":
+            return .waitThenRetry
+        default:
+            // required / failed / cancelled / cooldown / background_suppressed:
+            // surface to UI. Present only via Rust handler or explicit manual APIs.
+            return .rethrow
+        }
+    }
+
+    /// Wait for an in-flight host challenge presentation, then briefly settle.
+    /// Used on read paths when Rust blocks concurrent traffic with `in_progress`.
+    static func awaitCloudflareChallengeQuietPeriod(
+        appearTimeout: Duration = .seconds(2),
+        presentationTimeout: Duration = .seconds(120),
+        settle: Duration = .milliseconds(500)
+    ) async {
+        await FireCloudflareChallengePresentationGate.awaitPresentationAppearance(
+            timeout: appearTimeout
+        )
+        if FireCloudflareChallengePresentationGate.isPresentationInFlight {
+            await FireCloudflareChallengePresentationGate.awaitActivePresentationIfAny(
+                timeout: presentationTimeout
+            )
+        }
+        try? await Task.sleep(for: settle)
     }
 
     nonisolated static func isCloudflareChallengeError(_ error: Error) -> Bool {

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -112,6 +112,7 @@
 		75A1614BEE58E22036098E46 /* FireSearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52FD2E866B8BC3532AA8274A /* FireSearchView.swift */; };
 		768DC62B26A1D2EF4F545D35 /* FireHomeFeedStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC7384EAE1C43817CAE71D9F /* FireHomeFeedStore.swift */; };
 		772EFD83C4DEB77EAC00FD55 /* FirePostCellLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = B220305F1DFD0C508260CFA9 /* FirePostCellLayout.swift */; };
+		77CCEFA72B8E24723A99D9F7 /* FireCloudflareChallengeRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D74211CDB2098D655F1604A /* FireCloudflareChallengeRecoveryTests.swift */; };
 		78009659A664B236D8AD3434 /* FireBadgeDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF5B6841F5556D86C606379F /* FireBadgeDetailView.swift */; };
 		7848D667BF692B25B4194E57 /* FirePostCellLayoutCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24E7CCCA8B867D5E6B0CE198 /* FirePostCellLayoutCalculator.swift */; };
 		790B44E436B0CF137B1FD8A7 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E69013450F80AEC210D5512D /* Security.framework */; };
@@ -335,6 +336,7 @@
 		54D532ECF928AC54FE11A47C /* FireUIKitToast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireUIKitToast.swift; sourceTree = "<group>"; };
 		577A99743CDCAA0033E2398C /* FireTopicEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicEditorView.swift; sourceTree = "<group>"; };
 		5AE3D99CBA147535E68FB7E6 /* FireTopicDetailSnapshotAssembler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailSnapshotAssembler.swift; sourceTree = "<group>"; };
+		5D74211CDB2098D655F1604A /* FireCloudflareChallengeRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireCloudflareChallengeRecoveryTests.swift; sourceTree = "<group>"; };
 		5DF67696B342C706CB3FAAFB /* FireProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileViewModel.swift; sourceTree = "<group>"; };
 		6073E076839999F32D889101 /* FireSearchTopicsIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSearchTopicsIntent.swift; sourceTree = "<group>"; };
 		627535804DAD392D5972B8FF /* FireNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNavigationState.swift; sourceTree = "<group>"; };
@@ -787,6 +789,7 @@
 			children = (
 				299683BEDEC559B03C136C34 /* FireAppRouteTests.swift */,
 				6D2C1B5E7EE9786EBC541FAF /* FireAvatarURLTests.swift */,
+				5D74211CDB2098D655F1604A /* FireCloudflareChallengeRecoveryTests.swift */,
 				A67A6C835A2196246871D5FD /* FireComposerValidationTests.swift */,
 				BADC2ED47CF65AD5BE795908 /* FireEntityStateTests.swift */,
 				AFECA37BF8132D011E6B5506 /* FireHomeScopePresentationTests.swift */,
@@ -1255,6 +1258,7 @@
 			files = (
 				3330A9C7E4C8BA80778F79EB /* FireAppRouteTests.swift in Sources */,
 				92865B212211D893E4EFB5D2 /* FireAvatarURLTests.swift in Sources */,
+				77CCEFA72B8E24723A99D9F7 /* FireCloudflareChallengeRecoveryTests.swift in Sources */,
 				22D6B9CAC8373C14BBFA616A /* FireComposerValidationTests.swift in Sources */,
 				9B0DABDC5BA87A4CAFF3232D /* FireEntityStateTests.swift in Sources */,
 				648E830146DFA93FD20CC045 /* FireHomeScopePresentationTests.swift in Sources */,

--- a/native/ios-app/Sources/FireAppSession/FireCloudflareChallengeCoordinator.swift
+++ b/native/ios-app/Sources/FireAppSession/FireCloudflareChallengeCoordinator.swift
@@ -2,6 +2,179 @@ import Foundation
 import UIKit
 import WebKit
 
+/// Process-wide single-flight gate for Cloudflare challenge UI.
+///
+/// Network-owned (Rust UniFFI handler) and host-owned (login / manual verify)
+/// presentation share this gate so concurrent callers join one full-screen
+/// WebView instead of stacking modals.
+///
+/// Join semantics: joiners discard their own `CloudflareChallengeRequestState`
+/// (including `sessionEpoch`) and receive the owner's WebView-level result
+/// (`freshCfClearance`, CF cookies, browser UA). That is intentional — clearance
+/// is domain-scoped, not epoch-scoped. Rust retries each joined network request
+/// with that request's own epoch after the shared presentation finishes.
+@MainActor
+enum FireCloudflareChallengePresentationGate {
+    private static var activeGeneration: UInt64 = 0
+    private static var inFlight = false
+    private static var nextWaiterID: UInt64 = 0
+    private static var joiners: [(id: UInt64, continuation: CheckedContinuation<CloudflareChallengeResultState, Never>)] = []
+    private static var appearWaiters: [(id: UInt64, continuation: CheckedContinuation<Void, Never>)] = []
+
+    static var isPresentationInFlight: Bool {
+        inFlight
+    }
+
+    /// Wait until an in-flight presentation finishes (if any). Does not start UI.
+    static func awaitActivePresentationIfAny(
+        timeout: Duration = .seconds(120)
+    ) async {
+        guard inFlight else { return }
+        _ = await joinActivePresentation(timeout: timeout)
+    }
+
+    /// Wait until a presentation becomes active, or `timeout` elapses.
+    /// Event-driven (no polling): resumed when `runExclusive` starts or on timeout.
+    static func awaitPresentationAppearance(timeout: Duration = .seconds(2)) async {
+        if inFlight { return }
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            if inFlight {
+                continuation.resume()
+                return
+            }
+            nextWaiterID &+= 1
+            let id = nextWaiterID
+            appearWaiters.append((id, continuation))
+            Task { @MainActor in
+                try? await Task.sleep(for: timeout)
+                resumeAppearWaiter(id: id)
+            }
+        }
+    }
+
+    /// Run `body` as the sole presenter, or join the active presentation.
+    ///
+    /// `body` runs directly on the caller's MainActor context (no extra `Task`
+    /// hop) so the challenge sheet can present without an idle-queue delay.
+    static func runExclusive(
+        _ body: @MainActor () async -> CloudflareChallengeResultState
+    ) async -> CloudflareChallengeResultState {
+        if inFlight {
+            FireAPMManager.shared.recordBreadcrumb(
+                level: "info",
+                target: "auth.cf",
+                message: "presentation_join gen=\(activeGeneration)"
+            )
+            // Share the owner's WebView cookie/clearance outcome. Joiner request
+            // metadata (operation URL, sessionEpoch) is intentionally unused here;
+            // network joiners retry under Rust with their own epoch after finish.
+            return await joinActivePresentation()
+        }
+
+        inFlight = true
+        activeGeneration &+= 1
+        let generation = activeGeneration
+        notifyPresentationAppeared()
+        FireAPMManager.shared.recordBreadcrumb(
+            level: "info",
+            target: "auth.cf",
+            message: "presentation_start gen=\(generation)"
+        )
+
+        let result = await body()
+
+        if activeGeneration == generation, inFlight {
+            finishPresentation(generation: generation, result: result)
+        }
+        return result
+    }
+
+    /// **TEST ONLY.** Do not call in production.
+    ///
+    /// Clears gate bookkeeping and resumes waiters without cancelling an in-flight
+    /// `presentChallengeSession` WebView. Production use would allow a second
+    /// `runExclusive` while the first sheet is still alive (stacked challenge UI).
+    static func resetForTesting() {
+        let soft = FireCloudflareChallengeCoordinator.softFailureResult()
+        let pendingJoiners = joiners
+        joiners = []
+        let pendingAppear = appearWaiters
+        appearWaiters = []
+        inFlight = false
+        activeGeneration = 0
+        for waiter in pendingJoiners {
+            waiter.continuation.resume(returning: soft)
+        }
+        for waiter in pendingAppear {
+            waiter.continuation.resume()
+        }
+    }
+
+    private static func joinActivePresentation(
+        timeout: Duration? = nil
+    ) async -> CloudflareChallengeResultState {
+        await withCheckedContinuation { (continuation: CheckedContinuation<CloudflareChallengeResultState, Never>) in
+            nextWaiterID &+= 1
+            let id = nextWaiterID
+            joiners.append((id, continuation))
+            if let timeout {
+                Task { @MainActor in
+                    try? await Task.sleep(for: timeout)
+                    resumeJoiner(
+                        id: id,
+                        result: FireCloudflareChallengeCoordinator.softFailureResult()
+                    )
+                }
+            }
+        }
+    }
+
+    private static func finishPresentation(
+        generation: UInt64,
+        result: CloudflareChallengeResultState
+    ) {
+        let pendingJoiners = joiners
+        joiners = []
+        inFlight = false
+        for waiter in pendingJoiners {
+            waiter.continuation.resume(returning: result)
+        }
+        FireAPMManager.shared.recordBreadcrumb(
+            level: "info",
+            target: "auth.cf",
+            message: "presentation_finish gen=\(generation) completed=\(result.completed) cancelled=\(result.userCancelled)"
+        )
+    }
+
+    private static func notifyPresentationAppeared() {
+        let pending = appearWaiters
+        appearWaiters = []
+        for waiter in pending {
+            waiter.continuation.resume()
+        }
+    }
+
+    private static func resumeAppearWaiter(id: UInt64) {
+        guard let index = appearWaiters.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = appearWaiters.remove(at: index)
+        waiter.continuation.resume()
+    }
+
+    private static func resumeJoiner(
+        id: UInt64,
+        result: CloudflareChallengeResultState
+    ) {
+        guard let index = joiners.firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        let waiter = joiners.remove(at: index)
+        waiter.continuation.resume(returning: result)
+    }
+}
+
 final class FireCloudflareChallengeRuntimeHandler: CloudflareChallengeHandler, @unchecked Sendable {
     private let coordinator: FireCloudflareChallengeCoordinator
 
@@ -23,32 +196,32 @@ final class FireCloudflareChallengeCoordinator: NSObject, @unchecked Sendable {
         self.sessionStore = sessionStore
     }
 
+    nonisolated static func softFailureResult(
+        userCancelled: Bool = false
+    ) -> CloudflareChallengeResultState {
+        CloudflareChallengeResultState(
+            completed: false,
+            userCancelled: userCancelled,
+            freshCfClearance: nil,
+            cookies: [],
+            browserUserAgent: nil
+        )
+    }
+
     nonisolated func completeSynchronously(
         request: CloudflareChallengeRequestState
     ) -> CloudflareChallengeResultState {
         if Thread.isMainThread {
-            return CloudflareChallengeResultState(
-                completed: false,
-                userCancelled: false,
-                freshCfClearance: nil,
-                cookies: [],
-                browserUserAgent: nil
-            )
+            // Must not block the main thread with a semaphore. Soft-fail so the
+            // network path surfaces a normal CF error instead of hanging UI.
+            return Self.softFailureResult()
         }
 
         let semaphore = DispatchSemaphore(value: 0)
         let state = LockedChallengeResultState()
         DispatchQueue.main.async { [weak self] in
             guard let self else {
-                state.set(
-                    CloudflareChallengeResultState(
-                        completed: false,
-                        userCancelled: false,
-                        freshCfClearance: nil,
-                        cookies: [],
-                        browserUserAgent: nil
-                    )
-                )
+                state.set(Self.softFailureResult())
                 semaphore.signal()
                 return
             }
@@ -84,23 +257,25 @@ final class FireCloudflareChallengeCoordinator: NSObject, @unchecked Sendable {
         // Background/silent traffic must not steal focus. Rust only starts a new
         // challenge for foreground requests; this is a defensive host-side gate.
         guard request.isForeground else {
-            return CloudflareChallengeResultState(
-                completed: false,
-                userCancelled: false,
-                freshCfClearance: nil,
-                cookies: [],
-                browserUserAgent: nil
-            )
+            return Self.softFailureResult()
         }
 
+        // Join any active presentation (network-owned or manual) so concurrent
+        // callers never stack a second full-screen challenge modal. Joiners share
+        // the owner's WebView clearance/cookie result; sessionEpoch on `request`
+        // is not applied to joiners (Rust retries keep each caller's epoch).
+        return await FireCloudflareChallengePresentationGate.runExclusive {
+            await self.presentChallengeSession(request: request)
+        }
+    }
+
+    /// Owns the single WebView presentation. Only runs under the presentation gate.
+    @MainActor
+    private func presentChallengeSession(
+        request: CloudflareChallengeRequestState
+    ) async -> CloudflareChallengeResultState {
         guard let presenter = topPresenter() else {
-            return CloudflareChallengeResultState(
-                completed: false,
-                userCancelled: false,
-                freshCfClearance: nil,
-                cookies: [],
-                browserUserAgent: nil
-            )
+            return Self.softFailureResult()
         }
 
         let snapshot = try? await sessionStore.snapshot()
@@ -136,13 +311,7 @@ final class FireCloudflareChallengeCoordinator: NSObject, @unchecked Sendable {
         switch outcome {
         case .cancelled:
             await restoreCookies(preservedClearanceCookies, in: cookieStore)
-            return CloudflareChallengeResultState(
-                completed: false,
-                userCancelled: true,
-                freshCfClearance: nil,
-                cookies: [],
-                browserUserAgent: nil
-            )
+            return Self.softFailureResult(userCancelled: true)
         case let .completed(browserUserAgent, freshCfClearance):
             let loginCoordinator = FireWebViewLoginCoordinator(sessionStore: sessionStore)
             let cookies = Self.challengeResultCookies(

--- a/native/ios-app/Tests/Unit/FireCloudflareChallengeRecoveryTests.swift
+++ b/native/ios-app/Tests/Unit/FireCloudflareChallengeRecoveryTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import XCTest
+@testable import Fire
+
+@MainActor
+final class FireCloudflareChallengeRecoveryTests: XCTestCase {
+    override func tearDown() async throws {
+        FireCloudflareChallengePresentationGate.resetForTesting()
+        try await super.tearDown()
+    }
+
+    func testRecoveryActionWaitsOnlyForInProgress() {
+        XCTAssertEqual(
+            FireAppViewModel.cloudflareRecoveryAction(forReason: "in_progress"),
+            .waitThenRetry
+        )
+        for reason in ["required", "failed", "cancelled", "cooldown", "background_suppressed", ""] {
+            XCTAssertEqual(
+                FireAppViewModel.cloudflareRecoveryAction(forReason: reason),
+                .rethrow,
+                "reason \(reason) must not auto-present or wait-retry"
+            )
+        }
+    }
+
+    func testIsCloudflareChallengeErrorStillRecognizesInProgress() {
+        let error = FireUniFfiError.CloudflareChallenge(reason: "in_progress")
+        XCTAssertTrue(FireAppViewModel.isCloudflareChallengeError(error))
+        XCTAssertEqual(FireAppViewModel.cloudflareChallengeReason(from: error), "in_progress")
+    }
+
+    func testPresentationGateJoinsConcurrentCallersWithoutReentry() async {
+        var bodyCount = 0
+        var resumeOwner: (() -> Void)?
+        let ownerStarted = expectation(description: "owner body started")
+
+        let success = CloudflareChallengeResultState(
+            completed: true,
+            userCancelled: false,
+            freshCfClearance: "joined-clearance",
+            cookies: [],
+            browserUserAgent: "TestAgent"
+        )
+
+        let ownerTask = Task { @MainActor in
+            await FireCloudflareChallengePresentationGate.runExclusive {
+                bodyCount += 1
+                await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                    resumeOwner = { continuation.resume() }
+                    ownerStarted.fulfill()
+                }
+                return success
+            }
+        }
+
+        await fulfillment(of: [ownerStarted], timeout: 5)
+        XCTAssertTrue(FireCloudflareChallengePresentationGate.isPresentationInFlight)
+
+        let joinerTask = Task { @MainActor in
+            await FireCloudflareChallengePresentationGate.runExclusive {
+                bodyCount += 1
+                return FireCloudflareChallengeCoordinator.softFailureResult(userCancelled: true)
+            }
+        }
+
+        // Allow the joiner to enter runExclusive and attach as a continuation joiner.
+        await Task.yield()
+        await Task.yield()
+        resumeOwner?()
+
+        let firstResult = await ownerTask.value
+        let secondResult = await joinerTask.value
+
+        XCTAssertEqual(bodyCount, 1, "joined callers must not re-enter present body")
+        XCTAssertTrue(firstResult.completed)
+        XCTAssertTrue(secondResult.completed)
+        XCTAssertEqual(firstResult.freshCfClearance, "joined-clearance")
+        XCTAssertEqual(secondResult.freshCfClearance, "joined-clearance")
+        XCTAssertFalse(FireCloudflareChallengePresentationGate.isPresentationInFlight)
+    }
+
+    func testPresentationGateAllowsSequentialPresentations() async {
+        var bodyCount = 0
+        let first = await FireCloudflareChallengePresentationGate.runExclusive {
+            bodyCount += 1
+            return FireCloudflareChallengeCoordinator.softFailureResult(userCancelled: true)
+        }
+        let second = await FireCloudflareChallengePresentationGate.runExclusive {
+            bodyCount += 1
+            return CloudflareChallengeResultState(
+                completed: true,
+                userCancelled: false,
+                freshCfClearance: "second",
+                cookies: [],
+                browserUserAgent: nil
+            )
+        }
+
+        XCTAssertEqual(bodyCount, 2)
+        XCTAssertTrue(first.userCancelled)
+        XCTAssertTrue(second.completed)
+        XCTAssertEqual(second.freshCfClearance, "second")
+    }
+}


### PR DESCRIPTION
## Summary

- Fix double Cloudflare challenge UI: concurrent requests were stacking full-screen WebViews because `performWithCloudflareRecovery` auto-presented on every CF error (including `in_progress`) while the Rust handler already owned a sheet.
- Introduce a process-wide presentation gate (`FireCloudflareChallengePresentationGate`) so network-owned and manual presents **join** one WebView; body runs on the caller’s MainActor (no extra `Task` hop).
- Read path: wait-then-retry on `in_progress` only (event-driven appear/join waiters). Write path: passthrough so composers fail fast instead of hanging up to minutes.
- Document host ownership contract; add unit tests for recovery policy and gate join.

## Test plan

- [x] `xcodegen generate` + `git diff --exit-code native/ios-app/Fire.xcodeproj` (CI project sync)
- [x] `FireCloudflareChallengeRecoveryTests` (gate join, sequential present, reason policy, in_progress classification)
- [x] `FireWebViewCookieActionSupportTests` (related CF cookie helpers)
- [ ] Manual: trigger CF while loading feed + opening topic detail → only one challenge sheet
- [ ] Manual: cancel challenge → no immediate second sheet
- [ ] Manual: send reply during in-progress challenge → fast error, not long hang
- [ ] Manual: complete challenge → read recovery retries and UI recovers