### PR TITLE
fix(ios): show initial selection on settings appearance control

### DIFF
--- a/native/ios-app/App/Core/UIKit/FireUIKitDesignLanguage.swift
+++ b/native/ios-app/App/Core/UIKit/FireUIKitDesignLanguage.swift
@@ -303,8 +303,12 @@ final class FireUIKitAppearanceCapsuleControl: UIView {
                 selectedPreference = normalized
                 return
             }
-            setNeedsLayout()
             updateButtonStyles()
+            // Defer pill placement to layoutSubviews so user-tap animation can
+            // interpolate from the previous segment. First paint still places the
+            // pill once Auto Layout resolves button frames (see layoutSubviews /
+            // didMoveToWindow).
+            setNeedsLayout()
         }
     }
 
@@ -314,7 +318,11 @@ final class FireUIKitAppearanceCapsuleControl: UIView {
     private let stack = UIStackView()
     private var buttons: [FireAppearancePreference: UIButton] = [:]
     private let selectionPill = UIView()
-    private var didInstallButtons = false
+    /// True after the pill has been placed on a segment with a non-zero frame.
+    /// Prevents first-show animation from CGRect.zero (top-left flash).
+    private var hasPositionedSelectionPill = false
+    /// While true, `layoutSubviews` must not snap the pill (user-tap animation owns it).
+    private var isAnimatingSelectionPill = false
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -328,6 +336,8 @@ final class FireUIKitAppearanceCapsuleControl: UIView {
                 : UIColor(white: 0.93, alpha: 1)
         }
         selectionPill.layer.cornerCurve = .continuous
+        // Stay hidden until the first valid segment layout so we never flash at (0,0).
+        selectionPill.isHidden = true
         addSubview(selectionPill)
 
         stack.axis = .horizontal
@@ -351,7 +361,6 @@ final class FireUIKitAppearanceCapsuleControl: UIView {
             buttons[preference] = button
             stack.addArrangedSubview(button)
         }
-        didInstallButtons = true
         updateButtonStyles()
     }
 
@@ -369,14 +378,43 @@ final class FireUIKitAppearanceCapsuleControl: UIView {
         }
     }
 
+    // MARK: - Testing seams
+
+    /// Current selection-pill frame after layout (unit tests via `@testable import Fire`).
+    var selectionPillFrameForTesting: CGRect { selectionPill.frame }
+
+    var isSelectionPillHiddenForTesting: Bool { selectionPill.isHidden }
+
+    func buttonFrameForTesting(_ preference: FireAppearancePreference) -> CGRect? {
+        let key = Self.normalizedForPicker(preference)
+        guard let button = buttons[key] else { return nil }
+        return button.convert(button.bounds, to: self)
+    }
+
     private func handleTap(_ preference: FireAppearancePreference) {
         let normalized = Self.normalizedForPicker(preference)
         guard selectedPreference != normalized else { return }
+        // Capture before preference mutation so layoutSubviews cannot snap the pill
+        // to the new segment before the animation block runs.
+        let canAnimate = hasPositionedSelectionPill && !selectionPill.isHidden
+        if canAnimate {
+            isAnimatingSelectionPill = true
+        }
         selectedPreference = normalized
         FireMotionHaptics.selection()
         onChange?(normalized)
-        UIView.fireAnimate(kind: .tap) {
-            self.layoutSelectionPill()
+        // Only animate segment-to-segment moves after an initial placement exists.
+        // First placement must snap — otherwise the pill flies in from top-left.
+        if canAnimate {
+            UIView.fireAnimate(kind: .tap) {
+                self.layoutSelectionPill(animated: true)
+            } completion: { [weak self] _ in
+                self?.isAnimatingSelectionPill = false
+                // Settle to Auto Layout geometry after the animation ends.
+                self?.layoutSelectionPill(animated: false)
+            }
+        } else {
+            layoutSelectionPill(animated: false)
         }
     }
 
@@ -438,16 +476,53 @@ final class FireUIKitAppearanceCapsuleControl: UIView {
         }
     }
 
-    private func layoutSelectionPill() {
+    /// Positions the raised selection pill over the active segment.
+    /// - Parameter animated: When true *and* the pill was already placed, the caller
+    ///   may wrap this in an animation. First placement always snaps without motion.
+    private func layoutSelectionPill(animated: Bool) {
+        stack.layoutIfNeeded()
         let selected = Self.normalizedForPicker(selectedPreference)
-        guard let button = buttons[selected], button.bounds.width > 1 else { return }
-        let frame = button.convert(button.bounds, to: self)
-        selectionPill.frame = frame
-        selectionPill.layer.cornerRadius = frame.height / 2
+        guard let button = buttons[selected], button.bounds.width > 1 else {
+            // Invalid geometry: hide and require a snap on the next successful layout
+            // so we never animate out of CGRect.zero.
+            selectionPill.isHidden = true
+            hasPositionedSelectionPill = false
+            return
+        }
+        let target = button.convert(button.bounds, to: self)
+        let apply = {
+            self.selectionPill.frame = target
+            self.selectionPill.layer.cornerRadius = target.height / 2
+            self.selectionPill.isHidden = false
+        }
+        let shouldAnimate = animated && hasPositionedSelectionPill && !selectionPill.isHidden
+        if shouldAnimate {
+            apply()
+        } else {
+            UIView.performWithoutAnimation(apply)
+        }
+        hasPositionedSelectionPill = true
     }
 
     override func layoutSubviews() {
         super.layoutSubviews()
-        layoutSelectionPill()
+        // Layout passes must never animate from a zero frame.
+        // Skip while a segment-change animation is in flight so we do not snap
+        // the pill mid-interpolation. `handleTap` owns animated placement.
+        guard !isAnimatingSelectionPill else { return }
+        layoutSelectionPill(animated: false)
+    }
+
+    override func didMoveToWindow() {
+        super.didMoveToWindow()
+        guard window != nil else {
+            // Detached (e.g. settings rebuildContent): next attach must snap.
+            hasPositionedSelectionPill = false
+            selectionPill.isHidden = true
+            return
+        }
+        setNeedsLayout()
+        layoutIfNeeded()
+        layoutSelectionPill(animated: false)
     }
 }

--- a/native/ios-app/App/Views/Profile/FireSettingsViewController.swift
+++ b/native/ios-app/App/Views/Profile/FireSettingsViewController.swift
@@ -14,7 +14,17 @@ final class FireSettingsViewController: UIViewController {
     private let contentStack = UIStackView()
     private var cancellables: Set<AnyCancellable> = []
 
-    private lazy var appearanceControl = FireUIKitAppearanceCapsuleControl()
+    private lazy var appearanceControl: FireUIKitAppearanceCapsuleControl = {
+        let control = FireUIKitAppearanceCapsuleControl()
+        // Seed from storage before first layout so the pill never paints on the
+        // default `.system` segment when the user has another preference.
+        control.selectedPreference = FireUIKitAppearanceCapsuleControl.normalizedForPicker(
+            FireAppearancePreference(
+                rawValue: UserDefaults.standard.string(forKey: FireTheme.appearancePreferenceStorageKey) ?? ""
+            ) ?? .system
+        )
+        return control
+    }()
     private lazy var diagnosticsCard = FireUIKitSettingsCardView()
     private lazy var signOutCard = FireUIKitSettingsCardView()
     private let versionLabel = UILabel()

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		3CA9AF0BFA58C32834B441F3 /* FirePresentationIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019B4B93D3FDB4C799492775 /* FirePresentationIdentity.swift */; };
 		3E86B05D0E10C74BB865A0F9 /* ConfettiSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 2DFDD7AEF71DAD503CDB00B8 /* ConfettiSwiftUI */; };
 		3F1C13559BEAD77AE0EC1F13 /* FireHeadlessExternalLoginEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E406BC86F476DB0FF2E688F /* FireHeadlessExternalLoginEngine.swift */; };
+		3FDB63119BEBEA0BE1CA2E6A /* FireUIKitAppearanceCapsuleControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8EF10938994EC780C68B9D4 /* FireUIKitAppearanceCapsuleControlTests.swift */; };
 		40B864B25377AE905208F981 /* FireHomeScopeChromeViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48153CE6A692130B4F8D97C5 /* FireHomeScopeChromeViews.swift */; };
 		4291E89FC3D5D35AC9A06898 /* FireOrderedIDList.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00DA04AEF775D5BD01FC23AC /* FireOrderedIDList.swift */; };
 		4397ACCD2A571DB3DA0AC8FC /* FireAppRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CF09F1CBAC6CFAA0E9128A /* FireAppRoute.swift */; };
@@ -448,6 +449,7 @@
 		E6A1ACC49B5E391857645187 /* FireWebViewBrowserProfile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWebViewBrowserProfile.swift; sourceTree = "<group>"; };
 		E7299AEA008EC0AE578A1712 /* FireMidSessionReauthOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireMidSessionReauthOverlayController.swift; sourceTree = "<group>"; };
 		E771E5E48D78AAC476C3A58D /* FireProfileViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileViewController.swift; sourceTree = "<group>"; };
+		E8EF10938994EC780C68B9D4 /* FireUIKitAppearanceCapsuleControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireUIKitAppearanceCapsuleControlTests.swift; sourceTree = "<group>"; };
 		EA23C0E50E7A412A73AF80E6 /* FireMotionReduceMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireMotionReduceMotion.swift; sourceTree = "<group>"; };
 		EA2BF3D92E750EF89E6387BF /* FireMotionTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireMotionTokens.swift; sourceTree = "<group>"; };
 		EAE00F2C2E4EB9A7A99D327A /* FireRouteParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireRouteParser.swift; sourceTree = "<group>"; };
@@ -811,6 +813,7 @@
 				9189433D7C9260885742A5BA /* FireTopicPresentationTests.swift */,
 				41AECD88340113D3FD81D59B /* FireTopicPresentationTestSupport.swift */,
 				EDE93F98F58126B7BEDDB4F7 /* FireTopicTimingTrackerTests.swift */,
+				E8EF10938994EC780C68B9D4 /* FireUIKitAppearanceCapsuleControlTests.swift */,
 				5103D4725A903220359B1C42 /* FireWebViewCookieActionSupportTests.swift */,
 			);
 			name = Unit;
@@ -1280,6 +1283,7 @@
 				56EE60CC67C1D8E444227552 /* FireTopicPresentationTestSupport.swift in Sources */,
 				FFCC342F97F349220632A787 /* FireTopicPresentationTests.swift in Sources */,
 				5CC59FE0F0C9914237A8DE8E /* FireTopicTimingTrackerTests.swift in Sources */,
+				3FDB63119BEBEA0BE1CA2E6A /* FireUIKitAppearanceCapsuleControlTests.swift in Sources */,
 				8146E8382FB40C8617EF19B7 /* FireWebViewCookieActionSupportTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/native/ios-app/Tests/Unit/FireUIKitAppearanceCapsuleControlTests.swift
+++ b/native/ios-app/Tests/Unit/FireUIKitAppearanceCapsuleControlTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import Fire
+
+@MainActor
+final class FireUIKitAppearanceCapsuleControlTests: XCTestCase {
+    func testNormalizedForPickerMapsOLEDToDark() {
+        XCTAssertEqual(
+            FireUIKitAppearanceCapsuleControl.normalizedForPicker(.oled),
+            .dark
+        )
+        XCTAssertEqual(
+            FireUIKitAppearanceCapsuleControl.normalizedForPicker(.dark),
+            .dark
+        )
+        XCTAssertEqual(
+            FireUIKitAppearanceCapsuleControl.normalizedForPicker(.system),
+            .system
+        )
+        XCTAssertEqual(
+            FireUIKitAppearanceCapsuleControl.normalizedForPicker(.light),
+            .light
+        )
+    }
+
+    func testInitialLayoutPlacesSelectionPillOnStoredPreferenceWithoutUserTap() {
+        let control = FireUIKitAppearanceCapsuleControl(frame: CGRect(x: 0, y: 0, width: 320, height: 52))
+        control.selectedPreference = .light
+
+        // Mimic being attached to a windowed hierarchy so Auto Layout resolves.
+        let host = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 80))
+        host.addSubview(control)
+        control.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            control.leadingAnchor.constraint(equalTo: host.leadingAnchor),
+            control.trailingAnchor.constraint(equalTo: host.trailingAnchor),
+            control.topAnchor.constraint(equalTo: host.topAnchor, constant: 8),
+        ])
+        host.layoutIfNeeded()
+        control.layoutIfNeeded()
+
+        XCTAssertFalse(
+            control.isSelectionPillHiddenForTesting,
+            "Selection pill must be visible on first layout without a tap"
+        )
+        XCTAssertGreaterThan(control.selectionPillFrameForTesting.width, 1)
+        XCTAssertGreaterThan(control.selectionPillFrameForTesting.height, 1)
+
+        guard let lightFrame = control.buttonFrameForTesting(.light) else {
+            return XCTFail("Expected light segment button")
+        }
+        XCTAssertEqual(
+            control.selectionPillFrameForTesting.origin.x,
+            lightFrame.origin.x,
+            accuracy: 1.0,
+            "Pill should sit on the light segment after initial layout"
+        )
+        XCTAssertEqual(
+            control.selectionPillFrameForTesting.width,
+            lightFrame.width,
+            accuracy: 1.0
+        )
+    }
+
+    func testSelectionPillFollowsEachPickerOptionOnLayout() {
+        let control = FireUIKitAppearanceCapsuleControl(frame: CGRect(x: 0, y: 0, width: 360, height: 52))
+        let host = UIView(frame: CGRect(x: 0, y: 0, width: 360, height: 80))
+        host.addSubview(control)
+        control.frame = CGRect(x: 0, y: 8, width: 360, height: 52)
+        host.layoutIfNeeded()
+        control.layoutIfNeeded()
+
+        for preference in FireUIKitAppearanceCapsuleControl.pickerOptions {
+            control.selectedPreference = preference
+            control.layoutIfNeeded()
+
+            XCTAssertFalse(control.isSelectionPillHiddenForTesting)
+            guard let buttonFrame = control.buttonFrameForTesting(preference) else {
+                return XCTFail("Missing button for \(preference)")
+            }
+            XCTAssertEqual(
+                control.selectionPillFrameForTesting.midX,
+                buttonFrame.midX,
+                accuracy: 1.5,
+                "Pill midX should match \(preference) segment"
+            )
+        }
+    }
+
+    func testOLEDPreferenceSelectsDarkSegmentPill() {
+        let control = FireUIKitAppearanceCapsuleControl(frame: CGRect(x: 0, y: 0, width: 320, height: 52))
+        let host = UIView(frame: CGRect(x: 0, y: 0, width: 320, height: 80))
+        host.addSubview(control)
+        control.frame = CGRect(x: 0, y: 8, width: 320, height: 52)
+
+        control.selectedPreference = .oled
+        host.layoutIfNeeded()
+        control.layoutIfNeeded()
+
+        XCTAssertEqual(control.selectedPreference, .dark)
+        XCTAssertFalse(control.isSelectionPillHiddenForTesting)
+        guard let darkFrame = control.buttonFrameForTesting(.dark) else {
+            return XCTFail("Expected dark segment button")
+        }
+        XCTAssertEqual(
+            control.selectionPillFrameForTesting.midX,
+            darkFrame.midX,
+            accuracy: 1.5
+        )
+    }
+}

--- a/native/ios-app/project.yml
+++ b/native/ios-app/project.yml
@@ -147,6 +147,23 @@ targets:
           - $(SRCROOT)/Generated/fire_uniffiFFI/fire_uniffiFFI.h
           - $(SRCROOT)/Generated/fire_uniffiFFI/module.modulemap
           - $(SRCROOT)/Generated/lib/$(PLATFORM_NAME)/libfire_uniffi.a
+  # Keep FireTests before FireWidgetExtension so XcodeGen 2.45.x (name-ordered)
+  # and 2.46+ (spec-ordered) emit the same PBXProject target list for CI drift checks.
+  FireTests:
+    type: bundle.unit-test
+    platform: iOS
+    deploymentTarget: "16.0"
+    sources:
+      - path: Tests/Unit
+    dependencies:
+      - target: Fire
+    settings:
+      base:
+        GENERATE_INFOPLIST_FILE: YES
+        SWIFT_INCLUDE_PATHS:
+          - "$(inherited)"
+          - "$(SRCROOT)/Generated"
+
   # Optional local-only target. Not part of the Fire app archive / TestFlight
   # product while disabled above. Re-enable embed + App Group on the main app
   # entitlements together when widget provisioning is ready.
@@ -176,17 +193,3 @@ targets:
         INFOPLIST_FILE: Configs/FireWidget-Info.plist
         SKIP_INSTALL: YES
         TARGETED_DEVICE_FAMILY: "1,2"
-  FireTests:
-    type: bundle.unit-test
-    platform: iOS
-    deploymentTarget: "16.0"
-    sources:
-      - path: Tests/Unit
-    dependencies:
-      - target: Fire
-    settings:
-      base:
-        GENERATE_INFOPLIST_FILE: YES
-        SWIFT_INCLUDE_PATHS:
-          - "$(inherited)"
-          - "$(SRCROOT)/Generated"


### PR DESCRIPTION
## Summary
- Fix settings **外观** capsule missing the active segment on first entry ([#102](https://github.com/peterich-rs/fire/issues/102)).
- Root cause: `selectionPill` stayed at `CGRect.zero` until the first tap, so the selected state was invisible and then animated in from the top-left.
- Place the pill on first valid layout without animation; seed the control from stored preference; animate only subsequent segment-to-segment moves.

## Changes
- `FireUIKitAppearanceCapsuleControl`: hide pill until positioned; snap on first layout / window attach; never animate from zero; keep tap animation for real segment changes.
- `FireSettingsViewController`: seed capsule from `UserDefaults` before first paint.
- Unit tests covering initial placement, all three segments, and OLED→dark normalization.

## Test plan
- [x] `FireUIKitAppearanceCapsuleControlTests` on iPhone 17 (iOS 26.2) — all 4 cases passed
- [ ] Open **设置** with stored 深色 / 系统 / 浅色 — correct segment selected immediately, no top-left flash
- [ ] Switch segments — pill animates between options only
- [ ] Leave and re-enter 设置 — selection still correct without tap

Closes #102