### PR TITLE
feat: in-app feedback foundation (redacted bundles + dual-platform UI + ingress)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ fire/
     knowledge/
     architecture/
       fire-native-workspace.md
+      feedback-and-crash-reporting.md
   native/
     ios-app/
     android-app/
@@ -21,6 +22,8 @@ fire/
       fire-models/
       fire-core/
       fire-uniffi/
+  services/
+    feedback-ingress/
   third_party/
     openwire/
     xlog-rs/

--- a/docs/architecture/feedback-and-crash-reporting.md
+++ b/docs/architecture/feedback-and-crash-reporting.md
@@ -1,0 +1,142 @@
+# Feedback and Crash Reporting
+
+Status: design + foundation in progress (TF public beta).
+
+## Product goals
+
+1. Testers and users can submit **反馈与建议** from the app without a GitHub account.
+2. Submissions become **GitHub Issues** for maintainer triage.
+3. Optional diagnostics (xlog / redacted session / network traces) can be attached with explicit consent.
+4. Automatic crash telemetry (Crashlytics / similar) is a **separate** track from narrative feedback.
+
+## Non-goals
+
+- Shipping a GitHub PAT or App private key inside the mobile binary.
+- Using Discourse `uploads.json` for feedback media.
+- Replacing TestFlight / Play Console feedback channels (those remain secondary).
+- Treating email as the primary support channel.
+
+## Architecture
+
+```text
+Native feedback UI
+  → UniFFI FireDiagnosticsHandle.export_feedback_bundle(...)
+  → Rust redacted package on disk
+  → (future) openwire POST multipart to feedback ingress
+  → Cloudflare Worker holds GitHub secret
+  → GitHub Issues API (bot-created issue)
+```
+
+### Ownership
+
+| Concern | Owner |
+| --- | --- |
+| Form UI, media pickers, consent | Native iOS / Android |
+| Redacted package assembly, flush logs | Rust `fire-core` diagnostics |
+| GitHub issue creation token | Cloudflare Worker secrets only |
+| Crash symbol upload / free-rate | Platform crash SDK (optional Phase B) |
+
+### Client API surface (Rust)
+
+| API | Leaves device? | Session cookies | Sensitive headers |
+| --- | --- | --- | --- |
+| `export_support_bundle` | Local share / developer tools only | Full (intentional for local debug) | Present |
+| `export_feedback_bundle` | Yes (feedback upload / share) | Redacted only | Redacted to `[redacted]` |
+
+Feedback package path:
+
+- `diagnostics/feedback-bundles/fire-feedback-{ts}.json`
+- Payload fields: `kind: "feedback"`, `session_redacted: true`, host meta, capped log windows, capped network traces
+
+UniFFI:
+
+- `FireDiagnosticsHandle.export_feedback_bundle(host_context)`
+
+### Ingress
+
+Scaffold: `services/feedback-ingress/`
+
+- `POST /v1/feedback` multipart
+- Rate limit, size caps, create GitHub issue with labels `feedback`, `beta`, platform, category
+- Optional R2 for attachment blobs
+- Secrets: `GITHUB_TOKEN` or GitHub App installation credentials
+
+**Never** call `api.github.com` with a write credential from the app.
+
+## UI placement
+
+Preferred product entry (iOS):
+
+1. **我的（Profile 一级）→ 反馈与建议** — first row in the account card for early-beta discoverability
+2. **摇一摇** / login-screen icon for pre-login and stuck flows
+3. Presentation is a **full-screen secondary page** (same stack as bookmarks/settings), not a sheet panel
+
+Developer Tools remain under Settings for full-fidelity local export only.
+
+## Users without GitHub
+
+Users do not need GitHub. The Worker bot creates the issue. Fallback “在浏览器打开 Issues” remains for power users who already have GitHub.
+
+Email is not the primary path: no shared triage board, weak attachment policy, spam, and no labels/PR linkage. Optional maintainer notify email can mirror the issue, not replace it.
+
+## Crash reporting (Firebase / etc.)
+
+| Signal | Mechanism |
+| --- | --- |
+| User story + repro + screenshots | In-app feedback |
+| Unhandled crash stacks / ANR | Crashlytics (or Sentry) — optional |
+| Local iOS APM ZIP | Already exists (PLCrashReporter + MetricKit); opt-in attach only |
+
+Android already depends on Firebase for FCM; Crashlytics can reuse the same Firebase project. iOS would add the Crashlytics SDK + dSYM upload.
+
+Enabling automatic crash upload is a **privacy / store questionnaire change**. Current privacy copy states Fire does not automatically upload crash/diagnostics. Update privacy policy and data-safety forms before shipping Crashlytics.
+
+Recommended sequencing:
+
+1. Ship feedback form + redacted bundle + Worker issues (this design).
+2. Add Crashlytics if TF crash volume justifies it.
+3. Link Crashlytics ids into feedback when both exist.
+
+## Privacy constraints
+
+Must never leave the device toward GitHub / public issues:
+
+- `_t`, `_forum_session`, `cf_clearance`, CSRF tokens
+- Full non-redacted `export_session_json`
+- Raw Cookie / Set-Cookie / Authorization headers in network traces
+
+Safe with consent:
+
+- LinuxDo username / user id (optional)
+- App version, build, platform, diagnostic session id
+- Redacted session + capped log tails + redacted traces
+- User-selected screenshots / short video
+
+Public vs private issues:
+
+- Public repo issue bodies are world-readable.
+- Prefer private triage repo **or** private R2 attachment URLs for logs/media; keep public issue text non-sensitive.
+
+## Implementation checklist
+
+- [x] `export_feedback_bundle` (Rust) with redaction tests
+- [x] UniFFI `export_feedback_bundle`
+- [x] Worker scaffold under `services/feedback-ingress/`
+- [x] iOS Settings → 反馈与建议 form (+ 摇一摇 + 登录页入口)
+- [x] Android Profile → 反馈 form
+- [x] Submit via system share sheet (report text + redacted JSON)
+- [ ] Deploy Worker + GitHub secret + labels
+- [ ] Rust submit path (openwire to ingress, no Discourse cookies)
+- [ ] Wire share → Worker auto GitHub issue
+- [ ] Privacy / store doc updates when upload is enabled
+- [ ] Optional Crashlytics
+- [ ] Android shake-to-feedback (optional parity)
+
+## Related paths
+
+- `rust/crates/fire-core/src/diagnostics.rs`
+- `rust/crates/fire-uniffi-diagnostics/`
+- `services/feedback-ingress/`
+- `docs/release/test-feedback-template.md`
+- `docs/release/privacy-policy.md`
+- `docs/release/public-urls.md`

--- a/docs/architecture/fire-native-architecture.md
+++ b/docs/architecture/fire-native-architecture.md
@@ -132,7 +132,7 @@ Core orchestration engine. Owns session state, networking, API orchestration, an
 - **Image request orchestration**: delegates to `fire-image`
 - **Rich text request orchestration**: delegates to `fire-rich-text`
 - **Logging**: mars-xlog integration
-- **Diagnostics**: network trace, support bundle export
+- **Diagnostics**: network trace, local support bundle export, redacted feedback bundle export for off-device submission
 
 #### fire-uniffi-\*
 

--- a/native/android-app/src/main/AndroidManifest.xml
+++ b/native/android-app/src/main/AndroidManifest.xml
@@ -57,6 +57,19 @@
         <activity
             android:name=".ui.webview.FireInAppWebViewActivity"
             android:exported="false" />
+        <activity
+            android:name=".ui.feedback.FeedbackActivity"
+            android:exported="false"
+            android:parentActivityName=".MainActivity" />
+        <provider
+            android:name="androidx.core.content.FileProvider"
+            android:authorities="${applicationId}.fileprovider"
+            android:exported="false"
+            android:grantUriPermissions="true">
+            <meta-data
+                android:name="android.support.FILE_PROVIDER_PATHS"
+                android:resource="@xml/file_paths" />
+        </provider>
         <receiver
             android:name=".ui.topicdetail.BookmarkReminderReceiver"
             android:exported="false" />

--- a/native/android-app/src/main/java/com/fire/app/session/FireSessionStore.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireSessionStore.kt
@@ -337,6 +337,23 @@ class FireSessionStore(
             core.diagnostics().networkTraceDetail(traceId)
         }
 
+    suspend fun exportFeedbackBundle(
+        platform: String,
+        appVersion: String?,
+        buildNumber: String?,
+        scenePhase: String?,
+    ): uniffi.fire_uniffi_diagnostics.SupportBundleExportState =
+        withContext(Dispatchers.IO) {
+            core.diagnostics().exportFeedbackBundle(
+                uniffi.fire_uniffi_diagnostics.SupportBundleHostContextState(
+                    platform = platform,
+                    appVersion = appVersion,
+                    buildNumber = buildNumber,
+                    scenePhase = scenePhase,
+                ),
+            )
+        }
+
     suspend fun exportSessionJson(): String = withContext(Dispatchers.Default) {
         core.session().exportSessionJson()
     }

--- a/native/android-app/src/main/java/com/fire/app/ui/feedback/FeedbackActivity.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/feedback/FeedbackActivity.kt
@@ -1,0 +1,217 @@
+package com.fire.app.ui.feedback
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.widget.ArrayAdapter
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.EditText
+import android.widget.Spinner
+import android.widget.TextView
+import android.widget.Toast
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.FileProvider
+import androidx.lifecycle.lifecycleScope
+import com.fire.app.R
+import com.fire.app.session.FireSessionStoreRepository
+import java.io.File
+import java.time.Instant
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+/**
+ * In-app feedback form. Works without login.
+ * Submit uses the system share sheet (text + optional redacted diagnostics JSON).
+ */
+class FeedbackActivity : AppCompatActivity() {
+
+    private lateinit var titleInput: EditText
+    private lateinit var bodyInput: EditText
+    private lateinit var categorySpinner: Spinner
+    private lateinit var attachLogs: CheckBox
+    private lateinit var metaLabel: TextView
+    private lateinit var statusLabel: TextView
+    private lateinit var submitButton: Button
+    private lateinit var githubButton: Button
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_feedback)
+        supportActionBar?.setDisplayHomeAsUpEnabled(true)
+        title = getString(R.string.feedback_title)
+
+        titleInput = findViewById(R.id.feedback_title)
+        bodyInput = findViewById(R.id.feedback_body)
+        categorySpinner = findViewById(R.id.feedback_category)
+        attachLogs = findViewById(R.id.feedback_attach_logs)
+        metaLabel = findViewById(R.id.feedback_meta)
+        statusLabel = findViewById(R.id.feedback_status)
+        submitButton = findViewById(R.id.feedback_submit)
+        githubButton = findViewById(R.id.feedback_github)
+
+        categorySpinner.adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_dropdown_item,
+            resources.getStringArray(R.array.feedback_categories),
+        )
+        attachLogs.isChecked = true
+
+        lifecycleScope.launch {
+            metaLabel.text = buildMeta()
+        }
+
+        submitButton.setOnClickListener { submit() }
+        githubButton.setOnClickListener {
+            startActivity(
+                Intent(
+                    Intent.ACTION_VIEW,
+                    Uri.parse("https://github.com/peterich-rs/fire/issues"),
+                ),
+            )
+        }
+    }
+
+    override fun onSupportNavigateUp(): Boolean {
+        finish()
+        return true
+    }
+
+    private suspend fun buildMeta(): String {
+        val store = runCatching { FireSessionStoreRepository.get(this) }.getOrNull()
+        val username = store?.let {
+            runCatching { it.snapshot().bootstrap.currentUsername }.getOrNull()
+        } ?: getString(R.string.feedback_not_logged_in)
+        val pm = packageManager.getPackageInfo(packageName, 0)
+        val version = pm.versionName ?: "?"
+        val build = if (android.os.Build.VERSION.SDK_INT >= 28) {
+            pm.longVersionCode.toString()
+        } else {
+            @Suppress("DEPRECATION")
+            pm.versionCode.toString()
+        }
+        return getString(
+            R.string.feedback_meta_format,
+            username,
+            version,
+            build,
+            android.os.Build.VERSION.RELEASE,
+            android.os.Build.MODEL,
+        )
+    }
+
+    private fun submit() {
+        val title = titleInput.text?.toString()?.trim().orEmpty()
+        val body = bodyInput.text?.toString()?.trim().orEmpty()
+        if (title.isEmpty() && body.isEmpty()) {
+            Toast.makeText(this, R.string.feedback_empty, Toast.LENGTH_SHORT).show()
+            return
+        }
+
+        submitButton.isEnabled = false
+        statusLabel.text = getString(R.string.feedback_preparing)
+        lifecycleScope.launch {
+            try {
+                val uris = ArrayList<Uri>()
+                val report = buildReportText(title, body)
+                val reportFile = withContext(Dispatchers.IO) {
+                    File(cacheDir, "fire-feedback-report.txt").also {
+                        it.writeText(report)
+                    }
+                }
+                uris.add(fileUri(reportFile))
+
+                if (attachLogs.isChecked) {
+                    val shareBundle = withContext(Dispatchers.IO) {
+                        runCatching {
+                            val store = FireSessionStoreRepository.get(this@FeedbackActivity)
+                            val pm = packageManager.getPackageInfo(packageName, 0)
+                            val export = store.exportFeedbackBundle(
+                                platform = "android",
+                                appVersion = pm.versionName,
+                                buildNumber = null,
+                                scenePhase = "active",
+                            )
+                            val source = File(export.absolutePath)
+                            // Copy into cache so FileProvider can share it.
+                            val dest = File(cacheDir, export.fileName)
+                            source.copyTo(dest, overwrite = true)
+                            dest
+                        }.getOrNull()
+                    }
+                    if (shareBundle != null && shareBundle.exists()) {
+                        uris.add(fileUri(shareBundle))
+                        statusLabel.text = getString(R.string.feedback_bundle_ok, shareBundle.name)
+                    } else {
+                        statusLabel.text = getString(R.string.feedback_bundle_failed)
+                    }
+                }
+
+                val share = Intent(Intent.ACTION_SEND_MULTIPLE).apply {
+                    type = "*/*"
+                    putParcelableArrayListExtra(Intent.EXTRA_STREAM, uris)
+                    putExtra(Intent.EXTRA_SUBJECT, title.ifBlank { getString(R.string.feedback_title) })
+                    putExtra(Intent.EXTRA_TEXT, report)
+                    addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+                startActivity(Intent.createChooser(share, getString(R.string.feedback_share)))
+            } catch (error: Exception) {
+                statusLabel.text = error.message
+                Toast.makeText(this@FeedbackActivity, error.message, Toast.LENGTH_LONG).show()
+            } finally {
+                submitButton.isEnabled = true
+            }
+        }
+    }
+
+    private suspend fun buildReportText(title: String, body: String): String {
+        val categories = resources.getStringArray(R.array.feedback_category_keys)
+        val category = categories.getOrElse(categorySpinner.selectedItemPosition) { "other" }
+        val store = runCatching { FireSessionStoreRepository.get(this) }.getOrNull()
+        val username = store?.let {
+            runCatching { it.snapshot().bootstrap.currentUsername }.getOrNull()
+        } ?: "anonymous"
+        val pm = packageManager.getPackageInfo(packageName, 0)
+        val version = pm.versionName ?: "?"
+        return """
+            ## ${title.ifBlank { "(no title)" }}
+
+            ### Type
+            $category
+
+            ### Description
+            ${body.ifBlank { "(empty)" }}
+
+            ### Environment
+            - Platform: android
+            - App: $version
+            - Android: ${android.os.Build.VERSION.RELEASE}
+            - Device: ${android.os.Build.MODEL}
+            - LinuxDo: $username
+            - Source: ${intent.getStringExtra(EXTRA_SOURCE) ?: "profile"}
+            - Submitted: ${Instant.now()}
+
+            _Generated by Fire in-app feedback._
+        """.trimIndent()
+    }
+
+    private fun fileUri(file: File): Uri {
+        return FileProvider.getUriForFile(
+            this,
+            "$packageName.fileprovider",
+            file,
+        )
+    }
+
+    companion object {
+        private const val EXTRA_SOURCE = "source"
+
+        fun start(context: Context, source: String = "profile") {
+            context.startActivity(
+                Intent(context, FeedbackActivity::class.java).putExtra(EXTRA_SOURCE, source),
+            )
+        }
+    }
+}

--- a/native/android-app/src/main/java/com/fire/app/ui/profile/ProfileFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/profile/ProfileFragment.kt
@@ -17,6 +17,7 @@ import com.fire.app.R
 import com.fire.app.session.FireSessionStore
 import com.fire.app.session.FireSessionStoreRepository
 import com.fire.app.ui.composer.PrivateMessageComposerSheet
+import com.fire.app.ui.feedback.FeedbackActivity
 import com.fire.app.ui.topicdetail.TopicDetailActivity
 import kotlinx.coroutines.launch
 import uniffi.fire_uniffi_user.UserProfileState
@@ -34,6 +35,7 @@ class ProfileFragment : Fragment() {
     private lateinit var privateMessagesButton: View
     private lateinit var ldcButton: View
     private lateinit var cdkButton: View
+    private lateinit var feedbackButton: View
 
     private var viewModel: ProfileViewModel? = null
     private var requestedUsername: String? = null
@@ -60,6 +62,7 @@ class ProfileFragment : Fragment() {
         privateMessagesButton = view.findViewById(R.id.private_messages_button)
         ldcButton = view.findViewById(R.id.ldc_button)
         cdkButton = view.findViewById(R.id.cdk_button)
+        feedbackButton = view.findViewById(R.id.feedback_button)
 
         viewLifecycleOwner.lifecycleScope.launch {
             val sessionStore = FireSessionStoreRepository.get(requireContext())
@@ -172,6 +175,9 @@ class ProfileFragment : Fragment() {
         }
         cdkButton.setOnClickListener {
             findNavController().navigate(ProfileFragmentDirections.actionProfileToCdk())
+        }
+        feedbackButton.setOnClickListener {
+            FeedbackActivity.start(requireContext(), source = "profile")
         }
     }
 

--- a/native/android-app/src/main/res/layout/activity_feedback.xml
+++ b/native/android-app/src/main/res/layout/activity_feedback.xml
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="utf-8"?>
+<ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:fillViewport="true">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="@string/feedback_intro"
+            android:textAppearance="?attr/textAppearanceBody2" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/feedback_category_label"
+            android:textStyle="bold" />
+
+        <Spinner
+            android:id="@+id/feedback_category"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/feedback_title_label"
+            android:textStyle="bold" />
+
+        <EditText
+            android:id="@+id/feedback_title"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:hint="@string/feedback_title_hint"
+            android:inputType="textCapSentences"
+            android:maxLines="2" />
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/feedback_body_label"
+            android:textStyle="bold" />
+
+        <EditText
+            android:id="@+id/feedback_body"
+            android:layout_width="match_parent"
+            android:layout_height="160dp"
+            android:layout_marginTop="8dp"
+            android:gravity="top"
+            android:hint="@string/feedback_body_hint"
+            android:inputType="textMultiLine|textCapSentences" />
+
+        <CheckBox
+            android:id="@+id/feedback_attach_logs"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:text="@string/feedback_attach_logs" />
+
+        <TextView
+            android:id="@+id/feedback_meta"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="12dp"
+            android:textAppearance="?attr/textAppearanceCaption" />
+
+        <TextView
+            android:id="@+id/feedback_status"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:textAppearance="?attr/textAppearanceCaption" />
+
+        <Button
+            android:id="@+id/feedback_submit"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="16dp"
+            android:text="@string/feedback_submit" />
+
+        <Button
+            android:id="@+id/feedback_github"
+            style="?attr/materialButtonOutlinedStyle"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/feedback_open_github" />
+    </LinearLayout>
+</ScrollView>

--- a/native/android-app/src/main/res/layout/fragment_profile.xml
+++ b/native/android-app/src/main/res/layout/fragment_profile.xml
@@ -96,6 +96,19 @@
                 android:textAppearance="@style/TextAppearance.AppCompat.Button"
                 android:textColor="@color/fire_accent" />
 
+            <TextView
+                android:id="@+id/feedback_button"
+                android:layout_width="96dp"
+                android:layout_height="40dp"
+                android:layout_marginStart="8dp"
+                android:background="?attr/selectableItemBackground"
+                android:ellipsize="end"
+                android:gravity="center"
+                android:singleLine="true"
+                android:text="@string/feedback_action"
+                android:textAppearance="@style/TextAppearance.AppCompat.Button"
+                android:textColor="@color/fire_accent" />
+
         </LinearLayout>
 
     </HorizontalScrollView>

--- a/native/android-app/src/main/res/values/strings.xml
+++ b/native/android-app/src/main/res/values/strings.xml
@@ -552,4 +552,39 @@
     <string name="onboarding_login">登录 LinuxDo</string>
     <string name="onboarding_checking_login_state">正在校验登录态…</string>
     <string name="onboarding_login_check_failed">网络异常，请重新登录</string>
+    <string name="feedback_title">反馈与建议</string>
+    <string name="feedback_intro">无需登录即可提交。当前通过系统分享发送报告；自动创建 GitHub Issue 即将接入。</string>
+    <string name="feedback_category_label">类型</string>
+    <string name="feedback_title_label">标题</string>
+    <string name="feedback_title_hint">简要描述问题</string>
+    <string name="feedback_body_label">详细说明 / 复现步骤</string>
+    <string name="feedback_body_hint">请描述发生了什么、如何复现</string>
+    <string name="feedback_attach_logs">附带脱敏诊断日志（不含登录 cookie）</string>
+    <string name="feedback_submit">分享反馈报告</string>
+    <string name="feedback_open_github">在浏览器打开 GitHub Issues</string>
+    <string name="feedback_share">分享反馈</string>
+    <string name="feedback_empty">请填写标题或详细说明</string>
+    <string name="feedback_preparing">正在准备反馈包…</string>
+    <string name="feedback_bundle_ok">已附带脱敏诊断包：%1$s</string>
+    <string name="feedback_bundle_failed">诊断包导出失败，将仅分享文字报告</string>
+    <string name="feedback_not_logged_in">未登录</string>
+    <string name="feedback_meta_format">LinuxDo: %1$s\nApp: %2$s (%3$s) · Android %4$s\n设备: %5$s</string>
+    <string name="feedback_action">反馈</string>
+    <string-array name="feedback_categories">
+        <item>缺陷</item>
+        <item>崩溃</item>
+        <item>性能</item>
+        <item>界面</item>
+        <item>建议</item>
+        <item>其他</item>
+    </string-array>
+    <string-array name="feedback_category_keys">
+        <item>bug</item>
+        <item>crash</item>
+        <item>performance</item>
+        <item>ui</item>
+        <item>suggestion</item>
+        <item>other</item>
+    </string-array>
 </resources>
+

--- a/native/android-app/src/main/res/xml/file_paths.xml
+++ b/native/android-app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+    <cache-path name="cache" path="." />
+    <files-path name="files" path="." />
+    <external-cache-path name="external_cache" path="." />
+</paths>

--- a/native/ios-app/App/Core/FireRootCoordinator.swift
+++ b/native/ios-app/App/Core/FireRootCoordinator.swift
@@ -41,6 +41,15 @@ final class FireRootCoordinator {
         activeCoordinator.openSecondaryPage(viewController, animated: animated)
     }
 
+    /// Whether the main tab shell is available for full-screen secondary pages.
+    static var canPresentSecondary: Bool {
+        activeCoordinator?.hasMainTabShell == true
+    }
+
+    private var hasMainTabShell: Bool {
+        mainTabBarController != nil
+    }
+
     /// Present or push a typed secondary route (topic / profile / badge) above the tab shell.
     static func presentSecondaryRoute(_ route: FireAppRoute, animated: Bool = true) {
         guard let activeCoordinator else {
@@ -53,6 +62,11 @@ final class FireRootCoordinator {
     /// Secondary stack host when one is covering the tab shell; used by nested route presenters.
     static var activeSecondaryNavigationController: UINavigationController? {
         activeCoordinator?.secondaryNavigationController
+    }
+
+    /// Present feedback from any scene (settings, shake). Does not require login.
+    static func presentFeedback(source: String = "system") {
+        activeCoordinator?.presentFeedback(source: source)
     }
 
     private weak var window: UIWindow?
@@ -120,6 +134,18 @@ final class FireRootCoordinator {
             return
         }
         handleIncomingURL(url)
+    }
+
+    func handleShakeForFeedback() {
+        FireFeedbackPresenter.presentFromShake(appViewModel: viewModel)
+    }
+
+    func presentFeedback(source: String) {
+        FireFeedbackPresenter.present(
+            from: nil,
+            appViewModel: viewModel,
+            source: source
+        )
     }
 
     func handleScenePhaseChange(_ phase: ScenePhaseLabel) {

--- a/native/ios-app/App/Core/FireSceneDelegate.swift
+++ b/native/ios-app/App/Core/FireSceneDelegate.swift
@@ -14,8 +14,11 @@ final class FireSceneDelegate: UIResponder, UIWindowSceneDelegate {
             return
         }
 
-        let window = UIWindow(windowScene: windowScene)
+        let window = FireShakeWindow(windowScene: windowScene)
         let coordinator = FireRootCoordinator(window: window)
+        window.onShake = { [weak coordinator] in
+            coordinator?.handleShakeForFeedback()
+        }
         self.window = window
         self.rootCoordinator = coordinator
         coordinator.start()

--- a/native/ios-app/App/ViewModels/FireAppViewModel+Diagnostics.swift
+++ b/native/ios-app/App/ViewModels/FireAppViewModel+Diagnostics.swift
@@ -70,6 +70,16 @@ extension FireAppViewModel {
         )
     }
 
+    func exportFeedbackBundle(scenePhase: String?) async throws -> SupportBundleExportState {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.exportFeedbackBundle(
+            platform: "ios",
+            appVersion: Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            buildNumber: Bundle.main.object(forInfoDictionaryKey: kCFBundleVersionKey as String) as? String,
+            scenePhase: scenePhase
+        )
+    }
+
     func apmDiagnosticsSummary() async throws -> FireAPMDiagnosticsSummary {
         try await FireAPMManager.shared.diagnosticsSummary()
     }

--- a/native/ios-app/App/Views/Feedback/FireFeedbackPresenter.swift
+++ b/native/ios-app/App/Views/Feedback/FireFeedbackPresenter.swift
@@ -1,0 +1,119 @@
+import UIKit
+
+/// Central entry for in-app feedback (profile, shake, onboarding).
+/// Does not require login. Auto-submit to GitHub is not wired yet — share / open issues.
+///
+/// Presentation is always a **full-screen independent page** (same secondary stack as
+/// bookmarks / settings), never a half-height sheet panel.
+@MainActor
+enum FireFeedbackPresenter {
+    static let issuesURL = URL(string: "https://github.com/peterich-rs/fire/issues")!
+    static let newIssueBaseURL = URL(string: "https://github.com/peterich-rs/fire/issues/new")!
+    static let shakeEnabledStorageKey = "fire.feedback.shakeEnabled"
+
+    private static var lastPresentationAt: Date?
+    private static let presentationCooldown: TimeInterval = 1.2
+    private static weak var activeFeedback: FireFeedbackViewController?
+
+    static var isShakeEnabled: Bool {
+        get {
+            if UserDefaults.standard.object(forKey: shakeEnabledStorageKey) == nil {
+                return true
+            }
+            return UserDefaults.standard.bool(forKey: shakeEnabledStorageKey)
+        }
+        set {
+            UserDefaults.standard.set(newValue, forKey: shakeEnabledStorageKey)
+        }
+    }
+
+    static var isFeedbackVisible: Bool {
+        activeFeedback != nil
+    }
+
+    /// Present feedback as a full-screen page (profile / explicit buttons, no cooldown).
+    static func present(
+        from presenter: UIViewController? = nil,
+        appViewModel: FireAppViewModel,
+        source: String
+    ) {
+        presentInternal(
+            from: presenter,
+            appViewModel: appViewModel,
+            source: source,
+            respectCooldown: false
+        )
+    }
+
+    /// Shake / accidental gestures: cooldown + ignore if already open.
+    static func presentFromShake(appViewModel: FireAppViewModel) {
+        guard isShakeEnabled else { return }
+        presentInternal(
+            from: nil,
+            appViewModel: appViewModel,
+            source: "shake",
+            respectCooldown: true
+        )
+    }
+
+    private static func presentInternal(
+        from presenter: UIViewController?,
+        appViewModel: FireAppViewModel,
+        source: String,
+        respectCooldown: Bool
+    ) {
+        if isFeedbackVisible {
+            return
+        }
+        if respectCooldown, let last = lastPresentationAt,
+           Date().timeIntervalSince(last) < presentationCooldown {
+            return
+        }
+        lastPresentationAt = Date()
+
+        let feedback = FireFeedbackViewController(viewModel: appViewModel, source: source)
+        activeFeedback = feedback
+
+        // Prefer the app-root secondary stack (full screen, covers tab bar) — same
+        // path as bookmarks / settings / other profile drill-downs.
+        if FireRootCoordinator.canPresentSecondary {
+            FireRootCoordinator.presentSecondary(feedback)
+            return
+        }
+
+        // Pre-tab shell (onboarding / early launch): full-screen modal page.
+        let nav = UINavigationController(rootViewController: feedback)
+        nav.modalPresentationStyle = .fullScreen
+        guard let host = presenter ?? topViewController() else {
+            activeFeedback = nil
+            return
+        }
+        host.present(nav, animated: true)
+    }
+
+    static func feedbackDidDismiss() {
+        activeFeedback = nil
+    }
+
+    private static func topViewController(
+        base: UIViewController? = nil
+    ) -> UIViewController? {
+        let base = base ?? {
+            UIApplication.shared.connectedScenes
+                .compactMap { $0 as? UIWindowScene }
+                .flatMap(\.windows)
+                .first(where: \.isKeyWindow)?
+                .rootViewController
+        }()
+        if let nav = base as? UINavigationController {
+            return topViewController(base: nav.visibleViewController)
+        }
+        if let tab = base as? UITabBarController {
+            return topViewController(base: tab.selectedViewController)
+        }
+        if let presented = base?.presentedViewController {
+            return topViewController(base: presented)
+        }
+        return base
+    }
+}

--- a/native/ios-app/App/Views/Feedback/FireFeedbackViewController.swift
+++ b/native/ios-app/App/Views/Feedback/FireFeedbackViewController.swift
@@ -1,0 +1,442 @@
+import PhotosUI
+import SnapKit
+import UIKit
+
+/// In-app feedback form. Works without login.
+/// Current submit path: system share sheet with report text + optional redacted diagnostics JSON.
+@MainActor
+final class FireFeedbackViewController: UIViewController {
+    enum Category: String, CaseIterable {
+        case bug = "bug"
+        case crash = "crash"
+        case performance = "performance"
+        case ui = "ui"
+        case suggestion = "suggestion"
+        case other = "other"
+
+        var title: String {
+            switch self {
+            case .bug: return "缺陷"
+            case .crash: return "崩溃"
+            case .performance: return "性能"
+            case .ui: return "界面"
+            case .suggestion: return "建议"
+            case .other: return "其他"
+            }
+        }
+    }
+
+    private let appViewModel: FireAppViewModel
+    private let source: String
+
+    private let scrollView = UIScrollView()
+    private let contentStack = UIStackView()
+    private let categoryButton = UIButton(type: .system)
+    private let titleField = UITextField()
+    private let bodyView = UITextView()
+    private let attachDiagnosticsSwitch = UISwitch()
+    private let shakeSwitch = UISwitch()
+    private let metaLabel = UILabel()
+    private let submitButton = UIButton(type: .system)
+    private let githubButton = UIButton(type: .system)
+    private let statusLabel = UILabel()
+    private let activity = UIActivityIndicatorView(style: .medium)
+
+    private var selectedCategory: Category = .bug
+    private var selectedImages: [UIImage] = []
+    private let mediaStack = UIStackView()
+
+    init(viewModel: FireAppViewModel, source: String) {
+        self.appViewModel = viewModel
+        self.source = source
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "反馈与建议"
+        view.backgroundColor = FireTheme.uiCanvas
+        navigationItem.largeTitleDisplayMode = .never
+        // Full-screen page: use system back when pushed; close only when we are
+        // the root of a standalone modal stack (onboarding / pre-tab shell).
+        configureNavigationChrome()
+
+        configureLayout()
+        populateMeta()
+        refreshCategoryButton()
+        attachDiagnosticsSwitch.isOn = true
+        shakeSwitch.isOn = FireFeedbackPresenter.isShakeEnabled
+        shakeSwitch.addTarget(self, action: #selector(shakeToggled), for: .valueChanged)
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        configureNavigationChrome()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        let leaving =
+            isMovingFromParent
+            || isBeingDismissed
+            || navigationController?.isBeingDismissed == true
+        if leaving {
+            FireFeedbackPresenter.feedbackDidDismiss()
+        }
+    }
+
+    private func configureNavigationChrome() {
+        let nav = navigationController
+        let isStackRoot = nav?.viewControllers.first === self
+        let isPushed = (nav?.viewControllers.count ?? 0) > 1
+        if isPushed {
+            navigationItem.leftBarButtonItem = nil
+            return
+        }
+        // Root of secondary full-screen stack or onboarding modal: offer close.
+        if isStackRoot {
+            navigationItem.leftBarButtonItem = UIBarButtonItem(
+                barButtonSystemItem: .close,
+                target: self,
+                action: #selector(closeTapped)
+            )
+        }
+    }
+
+    private func configureLayout() {
+        scrollView.alwaysBounceVertical = true
+        scrollView.keyboardDismissMode = .interactive
+        view.addSubview(scrollView)
+        scrollView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        contentStack.axis = .vertical
+        contentStack.spacing = 12
+        contentStack.alignment = .fill
+        scrollView.addSubview(contentStack)
+        contentStack.snp.makeConstraints { make in
+            make.top.equalTo(scrollView.contentLayoutGuide).offset(16)
+            make.bottom.equalTo(scrollView.contentLayoutGuide).offset(-32)
+            make.leading.equalTo(scrollView.frameLayoutGuide).offset(FireTheme.pageHorizontalInset)
+            make.trailing.equalTo(scrollView.frameLayoutGuide).offset(-FireTheme.pageHorizontalInset)
+            make.width.equalTo(scrollView.frameLayoutGuide).offset(-FireTheme.pageHorizontalInset * 2)
+        }
+
+        contentStack.addArrangedSubview(makeCaption("无需登录即可提交。当前会通过系统分享发送报告；自动建 GitHub Issue 即将接入。"))
+        contentStack.addArrangedSubview(makeFieldLabel("类型"))
+        categoryButton.contentHorizontalAlignment = .leading
+        categoryButton.addTarget(self, action: #selector(categoryTapped), for: .touchUpInside)
+        contentStack.addArrangedSubview(categoryButton)
+
+        contentStack.addArrangedSubview(makeFieldLabel("标题"))
+        titleField.placeholder = "简要描述问题"
+        titleField.borderStyle = .roundedRect
+        titleField.font = .systemFont(ofSize: 16)
+        titleField.returnKeyType = .next
+        contentStack.addArrangedSubview(titleField)
+
+        contentStack.addArrangedSubview(makeFieldLabel("详细说明 / 复现步骤"))
+        bodyView.font = .systemFont(ofSize: 16)
+        bodyView.layer.cornerRadius = 8
+        bodyView.layer.borderWidth = 1 / UIScreen.main.scale
+        bodyView.layer.borderColor = FireTheme.uiTertiaryInk.withAlphaComponent(0.35).cgColor
+        bodyView.backgroundColor = FireTheme.uiSurface
+        bodyView.textContainerInset = UIEdgeInsets(top: 10, left: 8, bottom: 10, right: 8)
+        bodyView.isScrollEnabled = false
+        bodyView.snp.makeConstraints { make in
+            make.height.greaterThanOrEqualTo(140)
+        }
+        contentStack.addArrangedSubview(bodyView)
+
+        contentStack.addArrangedSubview(makeFieldLabel("截图（可选）"))
+        let addMedia = UIButton(type: .system)
+        addMedia.setTitle("添加截图", for: .normal)
+        addMedia.addTarget(self, action: #selector(addMediaTapped), for: .touchUpInside)
+        contentStack.addArrangedSubview(addMedia)
+
+        mediaStack.axis = .horizontal
+        mediaStack.spacing = 8
+        mediaStack.alignment = .center
+        contentStack.addArrangedSubview(mediaStack)
+
+        contentStack.addArrangedSubview(makeToggleRow(
+            title: "附带脱敏诊断日志",
+            subtitle: "不含登录 cookie / CSRF",
+            control: attachDiagnosticsSwitch
+        ))
+        contentStack.addArrangedSubview(makeToggleRow(
+            title: "摇一摇打开反馈",
+            subtitle: "未登录界面也可使用",
+            control: shakeSwitch
+        ))
+
+        metaLabel.font = .systemFont(ofSize: 12)
+        metaLabel.textColor = FireTheme.uiTertiaryInk
+        metaLabel.numberOfLines = 0
+        contentStack.addArrangedSubview(metaLabel)
+
+        statusLabel.font = .systemFont(ofSize: 13)
+        statusLabel.textColor = FireTheme.uiTertiaryInk
+        statusLabel.numberOfLines = 0
+        statusLabel.isHidden = true
+        contentStack.addArrangedSubview(statusLabel)
+
+        activity.hidesWhenStopped = true
+        contentStack.addArrangedSubview(activity)
+
+        var submitConfig = UIButton.Configuration.filled()
+        submitConfig.title = "分享反馈报告"
+        submitConfig.baseBackgroundColor = FireTheme.uiAccent
+        submitButton.configuration = submitConfig
+        submitButton.addTarget(self, action: #selector(submitTapped), for: .touchUpInside)
+        contentStack.addArrangedSubview(submitButton)
+
+        var ghConfig = UIButton.Configuration.plain()
+        ghConfig.title = "在浏览器打开 GitHub Issues"
+        githubButton.configuration = ghConfig
+        githubButton.addTarget(self, action: #selector(openGitHubTapped), for: .touchUpInside)
+        contentStack.addArrangedSubview(githubButton)
+    }
+
+    private func makeCaption(_ text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = .systemFont(ofSize: 13)
+        label.textColor = FireTheme.uiSubtleInk
+        label.numberOfLines = 0
+        return label
+    }
+
+    private func makeFieldLabel(_ text: String) -> UILabel {
+        let label = UILabel()
+        label.text = text
+        label.font = .systemFont(ofSize: 13, weight: .semibold)
+        label.textColor = FireTheme.uiSubtleInk
+        return label
+    }
+
+    private func makeToggleRow(title: String, subtitle: String, control: UISwitch) -> UIView {
+        let row = UIView()
+        row.fireApplyCardStyle()
+        let titleLabel = UILabel()
+        titleLabel.text = title
+        titleLabel.font = .systemFont(ofSize: 16, weight: .medium)
+        titleLabel.textColor = FireTheme.uiInk
+        let subtitleLabel = UILabel()
+        subtitleLabel.text = subtitle
+        subtitleLabel.font = .systemFont(ofSize: 12)
+        subtitleLabel.textColor = FireTheme.uiTertiaryInk
+        subtitleLabel.numberOfLines = 0
+        let textStack = UIStackView(arrangedSubviews: [titleLabel, subtitleLabel])
+        textStack.axis = .vertical
+        textStack.spacing = 2
+        row.addSubview(textStack)
+        row.addSubview(control)
+        textStack.snp.makeConstraints { make in
+            make.leading.equalToSuperview().offset(14)
+            make.top.equalToSuperview().offset(12)
+            make.bottom.equalToSuperview().offset(-12)
+            make.trailing.lessThanOrEqualTo(control.snp.leading).offset(-12)
+        }
+        control.snp.makeConstraints { make in
+            make.trailing.equalToSuperview().offset(-14)
+            make.centerY.equalToSuperview()
+        }
+        return row
+    }
+
+    private func populateMeta() {
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = info?["CFBundleVersion"] as? String ?? "?"
+        let username = appViewModel.session.bootstrap.currentUsername
+        let userLine = username.map { "LinuxDo: \($0)" } ?? "LinuxDo: 未登录"
+        let device = UIDevice.current
+        metaLabel.text = """
+        \(userLine)
+        App: \(version) (\(build)) · iOS \(device.systemVersion)
+        设备: \(device.model) · 入口: \(source)
+        """
+    }
+
+    @objc private func closeTapped() {
+        dismiss(animated: true) {
+            FireFeedbackPresenter.feedbackDidDismiss()
+        }
+    }
+
+    @objc private func categoryTapped() {
+        let sheet = UIAlertController(title: "反馈类型", message: nil, preferredStyle: .actionSheet)
+        for category in Category.allCases {
+            sheet.addAction(UIAlertAction(title: category.title, style: .default) { [weak self] _ in
+                self?.selectedCategory = category
+                self?.refreshCategoryButton()
+            })
+        }
+        sheet.addAction(UIAlertAction(title: "取消", style: .cancel))
+        sheet.popoverPresentationController?.sourceView = categoryButton
+        present(sheet, animated: true)
+    }
+
+    private func refreshCategoryButton() {
+        var config = UIButton.Configuration.gray()
+        config.title = selectedCategory.title
+        config.image = UIImage(systemName: "chevron.up.chevron.down")
+        config.imagePlacement = .trailing
+        config.imagePadding = 8
+        config.baseForegroundColor = FireTheme.uiInk
+        categoryButton.configuration = config
+    }
+
+    @objc private func shakeToggled() {
+        FireFeedbackPresenter.isShakeEnabled = shakeSwitch.isOn
+    }
+
+    @objc private func addMediaTapped() {
+        var config = PHPickerConfiguration(photoLibrary: .shared())
+        config.filter = .images
+        config.selectionLimit = max(0, 3 - selectedImages.count)
+        guard config.selectionLimit > 0 else {
+            showStatus("最多 3 张截图")
+            return
+        }
+        let picker = PHPickerViewController(configuration: config)
+        picker.delegate = self
+        present(picker, animated: true)
+    }
+
+    @objc private func openGitHubTapped() {
+        UIApplication.shared.open(FireFeedbackPresenter.issuesURL)
+    }
+
+    @objc private func submitTapped() {
+        let title = titleField.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        let body = bodyView.text?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !title.isEmpty || !body.isEmpty else {
+            showStatus("请填写标题或详细说明")
+            return
+        }
+
+        submitButton.isEnabled = false
+        activity.startAnimating()
+        showStatus("正在准备反馈包…")
+
+        Task { @MainActor in
+            defer {
+                submitButton.isEnabled = true
+                activity.stopAnimating()
+            }
+
+            var items: [Any] = []
+            let report = buildReportText(title: title, body: body)
+            let reportURL = writeTempText(report, name: "fire-feedback-report.txt")
+            items.append(reportURL)
+
+            if attachDiagnosticsSwitch.isOn {
+                do {
+                    let export = try await appViewModel.exportFeedbackBundle(scenePhase: "active")
+                    items.append(URL(fileURLWithPath: export.absolutePath))
+                    showStatus("已附带脱敏诊断包 (\(export.fileName))")
+                } catch {
+                    showStatus("诊断包导出失败，将仅分享文字：\(error.localizedDescription)")
+                }
+            }
+
+            for (index, image) in selectedImages.enumerated() {
+                if let data = image.jpegData(compressionQuality: 0.85) {
+                    let url = FileManager.default.temporaryDirectory
+                        .appendingPathComponent("fire-feedback-\(index).jpg")
+                    try? data.write(to: url, options: .atomic)
+                    items.append(url)
+                }
+            }
+
+            let activity = UIActivityViewController(activityItems: items, applicationActivities: nil)
+            activity.popoverPresentationController?.sourceView = submitButton
+            present(activity, animated: true)
+        }
+    }
+
+    private func buildReportText(title: String, body: String) -> String {
+        let category = selectedCategory
+        let username = appViewModel.session.bootstrap.currentUsername ?? "anonymous"
+        let info = Bundle.main.infoDictionary
+        let version = info?["CFBundleShortVersionString"] as? String ?? "?"
+        let build = info?["CFBundleVersion"] as? String ?? "?"
+        return """
+        ## \(title.isEmpty ? "(no title)" : title)
+
+        ### Type
+        \(category.rawValue)
+
+        ### Description
+        \(body.isEmpty ? "(empty)" : body)
+
+        ### Environment
+        - Platform: ios
+        - App: \(version) (\(build))
+        - iOS: \(UIDevice.current.systemVersion)
+        - Device: \(UIDevice.current.model)
+        - LinuxDo: \(username)
+        - Source: \(source)
+        - Submitted: \(ISO8601DateFormatter().string(from: Date()))
+
+        _Generated by Fire in-app feedback. Prefer attaching the redacted diagnostics JSON when available._
+        """
+    }
+
+    private func writeTempText(_ text: String, name: String) -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(name)
+        try? text.data(using: .utf8)?.write(to: url, options: .atomic)
+        return url
+    }
+
+    private func showStatus(_ text: String) {
+        statusLabel.isHidden = false
+        statusLabel.text = text
+    }
+
+    private func refreshMediaStrip() {
+        mediaStack.arrangedSubviews.forEach {
+            mediaStack.removeArrangedSubview($0)
+            $0.removeFromSuperview()
+        }
+        for image in selectedImages {
+            let imageView = UIImageView(image: image)
+            imageView.contentMode = .scaleAspectFill
+            imageView.clipsToBounds = true
+            imageView.layer.cornerRadius = 8
+            imageView.snp.makeConstraints { make in
+                make.width.height.equalTo(64)
+            }
+            mediaStack.addArrangedSubview(imageView)
+        }
+    }
+}
+
+extension FireFeedbackViewController: PHPickerViewControllerDelegate {
+    func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
+        picker.dismiss(animated: true)
+        guard !results.isEmpty else { return }
+        for result in results {
+            let provider = result.itemProvider
+            guard provider.canLoadObject(ofClass: UIImage.self) else { continue }
+            provider.loadObject(ofClass: UIImage.self) { [weak self] object, _ in
+                guard let image = object as? UIImage else { return }
+                Task { @MainActor in
+                    guard let self else { return }
+                    if self.selectedImages.count < 3 {
+                        self.selectedImages.append(image)
+                        self.refreshMediaStrip()
+                    }
+                }
+            }
+        }
+    }
+}

--- a/native/ios-app/App/Views/Feedback/FireShakeWindow.swift
+++ b/native/ios-app/App/Views/Feedback/FireShakeWindow.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+/// Key window that forwards device shake to the feedback presenter.
+final class FireShakeWindow: UIWindow {
+    var onShake: (() -> Void)?
+
+    override func motionEnded(_ motion: UIEvent.EventSubtype, with event: UIEvent?) {
+        if motion == .motionShake {
+            onShake?()
+        }
+        super.motionEnded(motion, with: event)
+    }
+}

--- a/native/ios-app/App/Views/Other/FireOnboardingView.swift
+++ b/native/ios-app/App/Views/Other/FireOnboardingView.swift
@@ -18,6 +18,7 @@ final class FireOnboardingViewController: UIViewController {
     private let errorBanner = FireOnboardingErrorBannerView()
     private let phaseContainerView = UIView()
     private let developerToolsButton = UIButton(type: .system)
+    private let feedbackButton = UIButton(type: .system)
     private var contentCenterYConstraint: NSLayoutConstraint?
     private var contentTopConstraint: NSLayoutConstraint?
     private var contentBottomConstraint: NSLayoutConstraint?
@@ -66,6 +67,7 @@ final class FireOnboardingViewController: UIViewController {
 
         configureBrand()
         configureDeveloperToolsButton()
+        configureFeedbackButton()
         configureBottomControls()
         configureRootLayout()
         installKeyboardDismissGesture()
@@ -159,6 +161,23 @@ final class FireOnboardingViewController: UIViewController {
         ])
     }
 
+    private func configureFeedbackButton() {
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: "bubble.left.and.exclamationmark.bubble.right")
+        configuration.baseForegroundColor = FireTheme.uiTertiaryInk
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 10, leading: 10, bottom: 10, trailing: 10)
+        feedbackButton.configuration = configuration
+        feedbackButton.accessibilityLabel = "反馈与建议"
+        feedbackButton.translatesAutoresizingMaskIntoConstraints = false
+        feedbackButton.addTarget(self, action: #selector(feedbackButtonTapped), for: .touchUpInside)
+        feedbackButton.fireBindPressBounce(.compact)
+        view.addSubview(feedbackButton)
+        NSLayoutConstraint.activate([
+            feedbackButton.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 4),
+            feedbackButton.trailingAnchor.constraint(equalTo: developerToolsButton.leadingAnchor, constant: -2),
+        ])
+    }
+
     private func configureBottomControls() {
         errorBanner.onDismiss = { [weak self] in
             self?.viewModel.dismissError()
@@ -221,6 +240,7 @@ final class FireOnboardingViewController: UIViewController {
         ])
 
         view.bringSubviewToFront(developerToolsButton)
+        view.bringSubviewToFront(feedbackButton)
     }
 
     private func installKeyboardDismissGesture() {
@@ -1061,6 +1081,14 @@ final class FireOnboardingViewController: UIViewController {
         // Show nav chrome only for the pushed diagnostics page; login itself stays bar-less.
         navigationController?.setNavigationBarHidden(false, animated: true)
         navigationController?.pushViewController(controller, animated: true)
+    }
+
+    @objc private func feedbackButtonTapped() {
+        FireFeedbackPresenter.present(
+            from: self,
+            appViewModel: viewModel,
+            source: "onboarding"
+        )
     }
 
     @objc private func backgroundTapped() {

--- a/native/ios-app/App/Views/Profile/FireProfileViewController.swift
+++ b/native/ios-app/App/Views/Profile/FireProfileViewController.swift
@@ -84,6 +84,8 @@ final class FireProfileViewController: UIViewController {
     }
 
     private enum AccountRow: Int, CaseIterable {
+        /// Early-beta primary entry: keep first for discoverability.
+        case feedback
         case invites
         case ldc
         case cdk
@@ -91,6 +93,7 @@ final class FireProfileViewController: UIViewController {
 
         var title: String {
             switch self {
+            case .feedback: return "反馈与建议"
             case .invites: return "邀请链接"
             case .ldc: return "LDC 信用"
             case .cdk: return "CDK 连接"
@@ -100,6 +103,7 @@ final class FireProfileViewController: UIViewController {
 
         var systemImage: String {
             switch self {
+            case .feedback: return "bubble.left.and.exclamationmark.bubble.right.fill"
             case .invites: return "ticket.fill"
             case .ldc: return "creditcard.fill"
             case .cdk: return "key.fill"
@@ -109,6 +113,7 @@ final class FireProfileViewController: UIViewController {
 
         var iconWellColor: UIColor {
             switch self {
+            case .feedback: return UIColor.systemOrange
             case .invites: return UIColor.systemGreen
             case .ldc: return UIColor.systemCyan
             case .cdk: return FireTheme.uiAccent
@@ -333,6 +338,12 @@ final class FireProfileViewController: UIViewController {
     private func openAccount(_ row: AccountRow) {
         FireMotionHaptics.selection()
         switch row {
+        case .feedback:
+            FireFeedbackPresenter.present(
+                from: self,
+                appViewModel: appViewModel,
+                source: "profile"
+            )
         case .invites:
             pushHosting(FireInviteLinksView(viewModel: appViewModel, username: displayUsername), title: "邀请链接")
         case .ldc:

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		0006B08A873FC6192E616F01 /* FireApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 996D95DE48DA65385BD587F7 /* FireApp.swift */; };
 		02880D7A3651EFC8EF3AA607 /* FireTopicDetailSnapshotAssembler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE3D99CBA147535E68FB7E6 /* FireTopicDetailSnapshotAssembler.swift */; };
+		028F38D6EAB5FAC769AF93EC /* FireShakeWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61901919CC904557BB48E7B9 /* FireShakeWindow.swift */; };
 		03270A2669E87643C2507254 /* FireHomeScopePanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4F09B0F010E9C41B77F4B40 /* FireHomeScopePanelController.swift */; };
 		0344231CB80C3CAD4A0DCBEC /* FireMidSessionReauthOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7299AEA008EC0AE578A1712 /* FireMidSessionReauthOverlayController.swift */; };
 		039707A4CADBA6A80DDB0F70 /* FireLoginScriptsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 140FAA0B35B71300049C7E14 /* FireLoginScriptsTests.swift */; };
@@ -145,6 +146,7 @@
 		9912E13751119248F5626F77 /* FireMainTabBarController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CABC863F0E7DDEACF5B980D /* FireMainTabBarController.swift */; };
 		997549C307522F353C2C4354 /* FireWebViewBrowserProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6A1ACC49B5E391857645187 /* FireWebViewBrowserProfile.swift */; };
 		9B0DABDC5BA87A4CAFF3232D /* FireEntityStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BADC2ED47CF65AD5BE795908 /* FireEntityStateTests.swift */; };
+		9B3FEA7A81A1EA5482AEE24B /* FireFeedbackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 338CF9CFAF93A14A5775E2C7 /* FireFeedbackViewController.swift */; };
 		9E7B9F6741C79AF8E6C3D0DA /* FirePostLayoutManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A1B0239607F0ABAEA1ABCE0 /* FirePostLayoutManager.swift */; };
 		9F734046F02B45409AD5F1C6 /* FireTopicListMessageBusRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 859219285EC36B189AF68256 /* FireTopicListMessageBusRefreshTests.swift */; };
 		A04B275253CDF8FAAC9D8C6C /* FireSearchStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25FD219C2BFB0727FD0D3DD2 /* FireSearchStore.swift */; };
@@ -164,6 +166,7 @@
 		B89B6092EE3AF8B9374CD027 /* FireLargeWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B88E94BDB7F6C957A8239E /* FireLargeWidget.swift */; };
 		B9E25AF09D46C9889B98E8A2 /* FireComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24186C615A12A722B2ABEE06 /* FireComponents.swift */; };
 		BB4439D1D0537CEC232DF789 /* FireWidgetViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06CDD24C8A021152FA0A67AE /* FireWidgetViews.swift */; };
+		BB6794B89B439C61B8A5620C /* FireFeedbackPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F2E6EEDE9F6AACB5DBE9B79 /* FireFeedbackPresenter.swift */; };
 		BD0F6BE28D1D0143383BAF2A /* FireProfileStatsRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8C1BF19AD44A73E451313B6 /* FireProfileStatsRow.swift */; };
 		BD294B1545CC5167CAB3620E /* fire_uniffi_search.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37B06D0B580C355652E1934 /* fire_uniffi_search.swift */; };
 		BDBF0CEBD8F5F7C1C19769B7 /* FireMessageBusCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C11839708BD8C370EB52334 /* FireMessageBusCoordinator.swift */; };
@@ -304,6 +307,7 @@
 		2FCFF26F4042B80F6B91305E /* FireTopicDetailPaginationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailPaginationCoordinator.swift; sourceTree = "<group>"; };
 		301D9A74A8ACFE5A61280A86 /* FireTopicDetailPageState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailPageState.swift; sourceTree = "<group>"; };
 		30F75C7877A380748026CE06 /* FireWidget.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = FireWidget.entitlements; sourceTree = "<group>"; };
+		338CF9CFAF93A14A5775E2C7 /* FireFeedbackViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireFeedbackViewController.swift; sourceTree = "<group>"; };
 		33FDDDCB91B973C1115A8F6B /* FireEntityIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireEntityIndex.swift; sourceTree = "<group>"; };
 		3623960CD988F423E24CCE8C /* FireFilteredTopicListViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireFilteredTopicListViewController.swift; sourceTree = "<group>"; };
 		373861687BBCD8EB8E350DA4 /* FireAPMEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAPMEventStore.swift; sourceTree = "<group>"; };
@@ -335,6 +339,7 @@
 		4E41FA85B0FAA4DAF83AA747 /* FireSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSceneDelegate.swift; sourceTree = "<group>"; };
 		4E86F61501D5E51FA1584156 /* FireWidgetSnapshotWriter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWidgetSnapshotWriter.swift; sourceTree = "<group>"; };
 		4EBE1819A4C585EBED2C8F1C /* FireSearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSearchService.swift; sourceTree = "<group>"; };
+		4F2E6EEDE9F6AACB5DBE9B79 /* FireFeedbackPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireFeedbackPresenter.swift; sourceTree = "<group>"; };
 		502CE714A74D91C33212BF57 /* FireNotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNotificationStore.swift; sourceTree = "<group>"; };
 		5103D4725A903220359B1C42 /* FireWebViewCookieActionSupportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireWebViewCookieActionSupportTests.swift; sourceTree = "<group>"; };
 		5267F5B3B48F8FCBF2B891BD /* FireTopicDetailFeedController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicDetailFeedController.swift; sourceTree = "<group>"; };
@@ -347,6 +352,7 @@
 		5D74211CDB2098D655F1604A /* FireCloudflareChallengeRecoveryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireCloudflareChallengeRecoveryTests.swift; sourceTree = "<group>"; };
 		5DF67696B342C706CB3FAAFB /* FireProfileViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileViewModel.swift; sourceTree = "<group>"; };
 		6073E076839999F32D889101 /* FireSearchTopicsIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireSearchTopicsIntent.swift; sourceTree = "<group>"; };
+		61901919CC904557BB48E7B9 /* FireShakeWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireShakeWindow.swift; sourceTree = "<group>"; };
 		627535804DAD392D5972B8FF /* FireNavigationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireNavigationState.swift; sourceTree = "<group>"; };
 		631A4F82AE7302B3D139F94C /* FireProfileHeaderComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireProfileHeaderComponents.swift; sourceTree = "<group>"; };
 		6566A1D9FDFFFF7BE5EC2229 /* FireTopicTimingTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicTimingTracker.swift; sourceTree = "<group>"; };
@@ -689,6 +695,16 @@
 			path = State;
 			sourceTree = "<group>";
 		};
+		5F7AA7499A2F1D712BD81C5A /* Feedback */ = {
+			isa = PBXGroup;
+			children = (
+				4F2E6EEDE9F6AACB5DBE9B79 /* FireFeedbackPresenter.swift */,
+				338CF9CFAF93A14A5775E2C7 /* FireFeedbackViewController.swift */,
+				61901919CC904557BB48E7B9 /* FireShakeWindow.swift */,
+			);
+			path = Feedback;
+			sourceTree = "<group>";
+		};
 		6D661DB7176AB667F4953BDC /* Startup */ = {
 			isa = PBXGroup;
 			children = (
@@ -895,6 +911,7 @@
 			children = (
 				063FCF8E59D22033447930DF /* Bookmarks */,
 				E6FFE443DA18651279314100 /* Composer */,
+				5F7AA7499A2F1D712BD81C5A /* Feedback */,
 				AED52A2EE8D19079BA80A52A /* Home */,
 				753FEA4F98C4A9F22FDE5C49 /* Messages */,
 				D442C00F2FE450A52723EAB4 /* Notifications */,
@@ -1355,6 +1372,8 @@
 				6CD842F82A4371F3BCCCF4C5 /* FireEntityIndex.swift in Sources */,
 				355451477523656402E506B8 /* FireExportDiagnosticsView.swift in Sources */,
 				E93FB84668880A48421D81BE /* FireExternalLoginMethod.swift in Sources */,
+				BB6794B89B439C61B8A5620C /* FireFeedbackPresenter.swift in Sources */,
+				9B3FEA7A81A1EA5482AEE24B /* FireFeedbackViewController.swift in Sources */,
 				FD8277139166DCD8F96715A9 /* FireFilteredTopicListView.swift in Sources */,
 				2BB1CFDFB44C42712F173627 /* FireFilteredTopicListViewController.swift in Sources */,
 				D2D1EA7C7D1208AEE0932A86 /* FireFollowListViewController.swift in Sources */,
@@ -1427,6 +1446,7 @@
 				75A1614BEE58E22036098E46 /* FireSearchView.swift in Sources */,
 				A29E21413FA011161D518004 /* FireSessionStore.swift in Sources */,
 				660EE0478082FB4E3B85C3B2 /* FireSettingsViewController.swift in Sources */,
+				028F38D6EAB5FAC769AF93EC /* FireShakeWindow.swift in Sources */,
 				5EF8B30E931B020C7512ACE1 /* FireShimmerModifier.swift in Sources */,
 				D89E51A2B4024E06147DAEE7 /* FireShortcuts.swift in Sources */,
 				C55AB47E8AAB3E7A47EE95FF /* FireTabRoot.swift in Sources */,

--- a/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
+++ b/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
@@ -604,6 +604,33 @@ public actor FireSessionStore {
         }
     }
 
+    /// Redacted diagnostics package safe to leave the device (feedback share / upload).
+    public func exportFeedbackBundle(
+        platform: String,
+        appVersion: String?,
+        buildNumber: String?,
+        scenePhase: String?
+    ) async throws -> SupportBundleExportState {
+        let core = self.core
+        let diagnosticsQueue = self.diagnosticsQueue
+        return try await withCheckedThrowingContinuation { continuation in
+            diagnosticsQueue.async {
+                continuation.resume(
+                    with: Result {
+                        try core.diagnostics().exportFeedbackBundle(
+                            hostContext: SupportBundleHostContextState(
+                                platform: platform,
+                                appVersion: appVersion,
+                                buildNumber: buildNumber,
+                                scenePhase: scenePhase
+                            )
+                        )
+                    }
+                )
+            }
+        }
+    }
+
     public func flushLogs(sync: Bool = true) async throws {
         let core = self.core
         let diagnosticsQueue = self.diagnosticsQueue

--- a/rust/crates/fire-core/src/core/mod.rs
+++ b/rust/crates/fire-core/src/core/mod.rs
@@ -39,9 +39,9 @@ use crate::{
     config::FireCoreConfig,
     cookies::FireSessionCookieJar,
     diagnostics::{
-        export_support_bundle, list_log_files, read_log_file, read_log_file_page,
-        DiagnosticsPageDirection, FireDiagnosticsStore, FireLogFileDetail, FireLogFilePage,
-        FireLogFileSummary, FireSupportBundleExport, FireSupportBundleHostContext,
+        export_feedback_bundle, export_support_bundle, list_log_files, read_log_file,
+        read_log_file_page, DiagnosticsPageDirection, FireDiagnosticsStore, FireLogFileDetail,
+        FireLogFilePage, FireLogFileSummary, FireSupportBundleExport, FireSupportBundleHostContext,
         NetworkTraceBodyPage, NetworkTraceDetail, NetworkTraceSummary,
     },
     error::FireCoreError,
@@ -508,6 +508,28 @@ impl FireCore {
             .ok_or(FireCoreError::MissingWorkspacePath)?;
         let session_json = self.export_session_json()?;
         export_support_bundle(
+            workspace_path,
+            &self.diagnostics,
+            &session_json,
+            &host_context,
+        )
+    }
+
+    /// Build a redacted diagnostics package suitable for user feedback upload.
+    ///
+    /// Always uses the redacted session export and strips sensitive network
+    /// headers. Prefer this over [`Self::export_support_bundle`] whenever the
+    /// package may leave the device.
+    pub fn export_feedback_bundle(
+        &self,
+        host_context: FireSupportBundleHostContext,
+    ) -> Result<FireSupportBundleExport, FireCoreError> {
+        self.flush_logs(true);
+        let workspace_path = self
+            .workspace_path()
+            .ok_or(FireCoreError::MissingWorkspacePath)?;
+        let session_json = self.export_redacted_session_json()?;
+        export_feedback_bundle(
             workspace_path,
             &self.diagnostics,
             &session_json,

--- a/rust/crates/fire-core/src/diagnostics.rs
+++ b/rust/crates/fire-core/src/diagnostics.rs
@@ -40,6 +40,11 @@ const SUPPORT_BUNDLE_TRACE_LIMIT: usize = 20;
 const SUPPORT_BUNDLE_LOG_PAGE_BYTES: usize = 96 * 1024;
 const SUPPORT_BUNDLE_TRACE_BODY_BYTES: usize = 32 * 1024;
 const SUPPORT_BUNDLE_DIR_NAME: &str = "support-bundles";
+const FEEDBACK_BUNDLE_DIR_NAME: &str = "feedback-bundles";
+const FEEDBACK_BUNDLE_LOG_FILE_LIMIT: usize = 4;
+const FEEDBACK_BUNDLE_TRACE_LIMIT: usize = 12;
+const FEEDBACK_BUNDLE_LOG_PAGE_BYTES: usize = 64 * 1024;
+const FEEDBACK_BUNDLE_TRACE_BODY_BYTES: usize = 16 * 1024;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NetworkTraceOutcome {
@@ -1276,15 +1281,116 @@ pub(crate) fn export_support_bundle(
     session_json: &str,
     host_context: &FireSupportBundleHostContext,
 ) -> Result<FireSupportBundleExport, FireCoreError> {
+    export_diagnostics_bundle(
+        workspace_path,
+        diagnostics,
+        session_json,
+        host_context,
+        DiagnosticsBundleKind::Support,
+    )
+}
+
+/// Export a diagnostics package safe for off-device feedback submission.
+///
+/// Unlike [`export_support_bundle`], this path always expects a **redacted**
+/// session JSON and strips cookie / auth / CSRF headers from network traces.
+/// Local developer support bundles remain intentionally full-fidelity.
+pub(crate) fn export_feedback_bundle(
+    workspace_path: &Path,
+    diagnostics: &FireDiagnosticsStore,
+    redacted_session_json: &str,
+    host_context: &FireSupportBundleHostContext,
+) -> Result<FireSupportBundleExport, FireCoreError> {
+    export_diagnostics_bundle(
+        workspace_path,
+        diagnostics,
+        redacted_session_json,
+        host_context,
+        DiagnosticsBundleKind::Feedback,
+    )
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum DiagnosticsBundleKind {
+    Support,
+    Feedback,
+}
+
+impl DiagnosticsBundleKind {
+    fn file_prefix(self) -> &'static str {
+        match self {
+            Self::Support => "fire-support",
+            Self::Feedback => "fire-feedback",
+        }
+    }
+
+    fn dir_name(self) -> &'static str {
+        match self {
+            Self::Support => SUPPORT_BUNDLE_DIR_NAME,
+            Self::Feedback => FEEDBACK_BUNDLE_DIR_NAME,
+        }
+    }
+
+    fn kind_label(self) -> &'static str {
+        match self {
+            Self::Support => "support",
+            Self::Feedback => "feedback",
+        }
+    }
+
+    fn log_file_limit(self) -> usize {
+        match self {
+            Self::Support => SUPPORT_BUNDLE_LOG_FILE_LIMIT,
+            Self::Feedback => FEEDBACK_BUNDLE_LOG_FILE_LIMIT,
+        }
+    }
+
+    fn trace_limit(self) -> usize {
+        match self {
+            Self::Support => SUPPORT_BUNDLE_TRACE_LIMIT,
+            Self::Feedback => FEEDBACK_BUNDLE_TRACE_LIMIT,
+        }
+    }
+
+    fn log_page_bytes(self) -> usize {
+        match self {
+            Self::Support => SUPPORT_BUNDLE_LOG_PAGE_BYTES,
+            Self::Feedback => FEEDBACK_BUNDLE_LOG_PAGE_BYTES,
+        }
+    }
+
+    fn trace_body_bytes(self) -> usize {
+        match self {
+            Self::Support => SUPPORT_BUNDLE_TRACE_BODY_BYTES,
+            Self::Feedback => FEEDBACK_BUNDLE_TRACE_BODY_BYTES,
+        }
+    }
+
+    fn redact_sensitive_headers(self) -> bool {
+        matches!(self, Self::Feedback)
+    }
+
+    fn session_redacted(self) -> bool {
+        matches!(self, Self::Feedback)
+    }
+}
+
+fn export_diagnostics_bundle(
+    workspace_path: &Path,
+    diagnostics: &FireDiagnosticsStore,
+    session_json: &str,
+    host_context: &FireSupportBundleHostContext,
+    kind: DiagnosticsBundleKind,
+) -> Result<FireSupportBundleExport, FireCoreError> {
     let generated_at_unix_ms = now_unix_ms();
-    let file_name = format!("fire-support-{generated_at_unix_ms}.json");
+    let file_name = format!("{}-{generated_at_unix_ms}.json", kind.file_prefix());
     let relative_path = Path::new("diagnostics")
-        .join("support-bundles")
+        .join(kind.dir_name())
         .join(&file_name);
     let absolute_path = workspace_path.join(&relative_path);
     let parent = absolute_path
         .parent()
-        .expect("support bundle path should have a parent");
+        .expect("diagnostics bundle path should have a parent");
     fs::create_dir_all(parent).map_err(|source| FireCoreError::DiagnosticsIo {
         path: parent.to_path_buf(),
         source,
@@ -1295,18 +1401,19 @@ pub(crate) fn export_support_bundle(
     let log_files = list_log_files(workspace_path)?;
     let log_pages = log_files
         .iter()
-        .take(SUPPORT_BUNDLE_LOG_FILE_LIMIT)
+        .take(kind.log_file_limit())
         .map(|file| {
             read_log_file_page(
                 workspace_path,
                 &file.relative_path,
                 None,
-                SUPPORT_BUNDLE_LOG_PAGE_BYTES,
+                kind.log_page_bytes(),
                 DiagnosticsPageDirection::Older,
             )
         })
         .collect::<Result<Vec<_>, _>>()?;
-    let trace_summaries = diagnostics.summaries(SUPPORT_BUNDLE_TRACE_LIMIT);
+    let trace_summaries = diagnostics.summaries(kind.trace_limit());
+    let redact_headers = kind.redact_sensitive_headers();
     let trace_payloads = trace_summaries
         .iter()
         .map(|summary| {
@@ -1318,15 +1425,21 @@ pub(crate) fn export_support_bundle(
             let body_page = diagnostics.network_trace_body_page(
                 summary.id,
                 None,
-                SUPPORT_BUNDLE_TRACE_BODY_BYTES,
+                kind.trace_body_bytes(),
                 DiagnosticsPageDirection::Newer,
             );
-            Ok(support_bundle_trace_json(&detail, body_page.as_ref()))
+            Ok(support_bundle_trace_json(
+                &detail,
+                body_page.as_ref(),
+                redact_headers,
+            ))
         })
         .collect::<Result<Vec<_>, FireCoreError>>()?;
 
     let payload = json!({
         "version": 1,
+        "kind": kind.kind_label(),
+        "session_redacted": kind.session_redacted(),
         "generated_at_unix_ms": generated_at_unix_ms,
         "diagnostic_session_id": diagnostics.diagnostic_session_id(),
         "host": {
@@ -1674,9 +1787,13 @@ fn normalized_page_bytes(requested: usize, fallback: usize) -> usize {
 
 fn is_support_bundle_path(workspace_path: &Path, path: &Path) -> bool {
     let support_bundle_root = Path::new("diagnostics").join(SUPPORT_BUNDLE_DIR_NAME);
+    let feedback_bundle_root = Path::new("diagnostics").join(FEEDBACK_BUNDLE_DIR_NAME);
     path.strip_prefix(workspace_path)
         .ok()
-        .is_some_and(|relative_path| relative_path.starts_with(&support_bundle_root))
+        .is_some_and(|relative_path| {
+            relative_path.starts_with(&support_bundle_root)
+                || relative_path.starts_with(&feedback_bundle_root)
+        })
 }
 
 fn workspace_relative_path_string(path: &Path) -> String {
@@ -1702,6 +1819,7 @@ fn support_bundle_log_json(page: &FireLogFilePage) -> Value {
 fn support_bundle_trace_json(
     detail: &NetworkTraceDetail,
     body_page: Option<&NetworkTraceBodyPage>,
+    redact_sensitive_headers: bool,
 ) -> Value {
     json!({
         "summary": {
@@ -1726,12 +1844,12 @@ fn support_bundle_trace_json(
         "request_headers": detail
             .request_headers
             .iter()
-            .map(support_bundle_header_json)
+            .map(|header| support_bundle_header_json(header, redact_sensitive_headers))
             .collect::<Vec<_>>(),
         "response_headers": detail
             .response_headers
             .iter()
-            .map(support_bundle_header_json)
+            .map(|header| support_bundle_header_json(header, redact_sensitive_headers))
             .collect::<Vec<_>>(),
         "events": detail.events.iter().map(support_bundle_event_json).collect::<Vec<_>>(),
         "body_page": body_page.map(|page| {
@@ -1759,11 +1877,33 @@ fn diagnostics_text_page_json(page: &DiagnosticsTextPage) -> Value {
     })
 }
 
-fn support_bundle_header_json(header: &NetworkTraceHeader) -> Value {
+fn support_bundle_header_json(
+    header: &NetworkTraceHeader,
+    redact_sensitive_headers: bool,
+) -> Value {
+    let value = if redact_sensitive_headers && is_sensitive_header_name(&header.name) {
+        "[redacted]"
+    } else {
+        header.value.as_str()
+    };
     json!({
         "name": header.name,
-        "value": header.value,
+        "value": value,
     })
+}
+
+fn is_sensitive_header_name(name: &str) -> bool {
+    matches!(
+        name.to_ascii_lowercase().as_str(),
+        "cookie"
+            | "set-cookie"
+            | "authorization"
+            | "proxy-authorization"
+            | "x-csrf-token"
+            | "x-api-key"
+            | "x-auth-token"
+            | "x-access-token"
+    )
 }
 
 fn support_bundle_event_json(event: &NetworkTraceEvent) -> Value {
@@ -1834,9 +1974,9 @@ mod tests {
     use serde_json::Value;
 
     use super::{
-        export_support_bundle, read_log_file_page, DiagnosticsPageDirection, FireDiagnosticsStore,
-        FireSupportBundleHostContext, NetworkTraceOutcome, Request, RequestBody, Response,
-        ResponseBody,
+        export_feedback_bundle, export_support_bundle, read_log_file_page,
+        DiagnosticsPageDirection, FireDiagnosticsStore, FireSupportBundleHostContext,
+        NetworkTraceOutcome, Request, RequestBody, Response, ResponseBody,
     };
 
     #[test]
@@ -2195,6 +2335,109 @@ mod tests {
             !file
                 .relative_path
                 .starts_with("diagnostics/support-bundles/")
+        }));
+    }
+
+    #[test]
+    fn feedback_bundle_export_redacts_session_and_sensitive_headers() {
+        let workspace_dir = temp_workspace_dir("diagnostics-feedback-bundle");
+        let diagnostics_dir = workspace_dir.join("diagnostics");
+        fs::create_dir_all(&diagnostics_dir).expect("diagnostics dir");
+        fs::write(
+            diagnostics_dir.join("fire-readable.log"),
+            "feedback-line-01\nfeedback-line-02\n",
+        )
+        .expect("readable log");
+
+        let store = FireDiagnosticsStore::new();
+        let mut request = Request::builder()
+            .method("GET")
+            .uri("https://linux.do/latest.json")
+            .header("cookie", "session=secret")
+            .header("x-csrf-token", "csrf-secret")
+            .header("accept", "application/json")
+            .body(RequestBody::empty())
+            .expect("request");
+        let trace_id = store.prepare_request_trace("fetch latest", &mut request);
+        store.record_request_headers_snapshot(trace_id, &request, 1);
+
+        let response = Response::builder()
+            .status(200)
+            .header("content-type", "application/json")
+            .header("set-cookie", "session=secret")
+            .body(ResponseBody::empty())
+            .expect("response");
+        store.record_response_headers(trace_id, &response);
+        store.record_response_body_text(trace_id, "{\"ok\":true}", Some("application/json"));
+
+        let export = export_feedback_bundle(
+            &workspace_dir,
+            &store,
+            r#"{"auth_cookies_redacted":true,"snapshot":{"username":"alice"}}"#,
+            &FireSupportBundleHostContext {
+                platform: "ios".to_string(),
+                app_version: Some("1.0".to_string()),
+                build_number: Some("100".to_string()),
+                scene_phase: Some("active".to_string()),
+            },
+        )
+        .expect("export feedback bundle");
+
+        assert!(export
+            .relative_path
+            .starts_with("diagnostics/feedback-bundles/"));
+        assert!(export.file_name.starts_with("fire-feedback-"));
+
+        let payload: Value =
+            serde_json::from_slice(&fs::read(&export.absolute_path).expect("feedback bundle file"))
+                .expect("feedback bundle json");
+
+        assert_eq!(payload["kind"], "feedback");
+        assert_eq!(payload["session_redacted"], true);
+        assert_eq!(payload["session"]["auth_cookies_redacted"], true);
+        assert_eq!(payload["session"]["snapshot"]["username"], "alice");
+
+        let request_headers = payload["network_traces"][0]["request_headers"]
+            .as_array()
+            .expect("request headers");
+        let response_headers = payload["network_traces"][0]["response_headers"]
+            .as_array()
+            .expect("response headers");
+
+        assert_eq!(
+            request_headers
+                .iter()
+                .find(|header| header["name"] == "cookie")
+                .expect("cookie header")["value"],
+            "[redacted]"
+        );
+        assert_eq!(
+            request_headers
+                .iter()
+                .find(|header| header["name"] == "x-csrf-token")
+                .expect("csrf header")["value"],
+            "[redacted]"
+        );
+        assert_eq!(
+            request_headers
+                .iter()
+                .find(|header| header["name"] == "accept")
+                .expect("accept header")["value"],
+            "application/json"
+        );
+        assert_eq!(
+            response_headers
+                .iter()
+                .find(|header| header["name"] == "set-cookie")
+                .expect("set-cookie header")["value"],
+            "[redacted]"
+        );
+
+        let listed_logs = super::list_log_files(&workspace_dir).expect("list logs");
+        assert!(listed_logs.iter().all(|file| {
+            !file
+                .relative_path
+                .starts_with("diagnostics/feedback-bundles/")
         }));
     }
 

--- a/rust/crates/fire-uniffi-diagnostics/src/lib.rs
+++ b/rust/crates/fire-uniffi-diagnostics/src/lib.rs
@@ -51,6 +51,25 @@ impl FireDiagnosticsHandle {
         )
     }
 
+    /// Export a redacted diagnostics package for in-app feedback submission.
+    ///
+    /// Safe to leave the device: session cookies and sensitive headers are stripped.
+    pub fn export_feedback_bundle(
+        &self,
+        host_context: SupportBundleHostContextState,
+    ) -> Result<SupportBundleExportState, FireUniFfiError> {
+        run_fallible(
+            &self.shared.panic_state,
+            &self.shared.core,
+            "export_feedback_bundle",
+            move |inner| {
+                inner
+                    .export_feedback_bundle(host_context.into())
+                    .map(Into::into)
+            },
+        )
+    }
+
     pub fn flush_logs(&self, sync: bool) -> Result<(), FireUniFfiError> {
         run_infallible(
             &self.shared.panic_state,

--- a/services/feedback-ingress/README.md
+++ b/services/feedback-ingress/README.md
@@ -1,0 +1,83 @@
+# Fire Feedback Ingress
+
+Cloudflare Worker that accepts in-app feedback submissions and opens a GitHub
+issue on behalf of the user. **GitHub credentials never ship in the mobile app.**
+
+## Why this exists
+
+Fire clients cannot safely hold a GitHub write token. Anyone who extracts the
+binary would get unlimited issue spam and write access. This Worker is the only
+component that holds a GitHub App installation token or fine-grained PAT.
+
+## Flow
+
+```text
+App (native UI)
+  → Rust export_feedback_bundle (redacted session + logs)
+  → POST multipart to this Worker
+  → Worker rate-limits, stores attachments, creates GitHub Issue
+```
+
+## Setup
+
+1. Create a GitHub App (preferred) or fine-grained PAT scoped to issues write on
+   the target repo (public `peterich-rs/fire` and/or a private triage repo).
+2. Optional: create an R2 bucket for attachment storage.
+3. Configure secrets:
+
+```bash
+cd services/feedback-ingress
+npx wrangler secret put GITHUB_TOKEN          # or use GitHub App secrets below
+npx wrangler secret put GITHUB_APP_ID         # optional GitHub App path
+npx wrangler secret put GITHUB_APP_PRIVATE_KEY
+npx wrangler secret put GITHUB_INSTALLATION_ID
+```
+
+4. Edit `wrangler.toml` for account, route, and `GITHUB_OWNER` / `GITHUB_REPO`.
+5. Deploy:
+
+```bash
+npx wrangler deploy
+```
+
+## API
+
+### `POST /v1/feedback`
+
+`multipart/form-data` fields:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `title` | yes | Issue title (max 120 chars) |
+| `body` | yes | Description / repro steps |
+| `category` | no | `bug` / `crash` / `performance` / `ui` / `suggestion` / `other` |
+| `severity` | no | `critical` / `high` / `medium` / `low` |
+| `platform` | no | `ios` / `android` |
+| `app_version` | no | Marketing version |
+| `build_number` | no | Build number |
+| `username` | no | LinuxDo username if logged in |
+| `diagnostic_session_id` | no | From Rust diagnostics |
+| `bundle` | no | Redacted feedback JSON from `export_feedback_bundle` |
+| `media` | no | One or more image/video parts (size-capped) |
+
+Response `201`:
+
+```json
+{
+  "ok": true,
+  "issue_number": 123,
+  "issue_url": "https://github.com/peterich-rs/fire/issues/123"
+}
+```
+
+## Security notes
+
+- Never put `GITHUB_TOKEN` in the app binary or client config files.
+- Rate-limit by IP (and later install id).
+- Reject oversized payloads.
+- Feedback bundles must be the **redacted** export only.
+- Prefer a private triage repo or private R2 URLs if logs may contain usernames/URLs you do not want public.
+
+## Status
+
+Scaffold for TF feedback pipeline. Wire app submit path after deploy + secrets.

--- a/services/feedback-ingress/package.json
+++ b/services/feedback-ingress/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "fire-feedback-ingress",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "typecheck": "tsc --noEmit"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20250416.0",
+    "typescript": "^5.8.3",
+    "wrangler": "^4.14.0"
+  }
+}

--- a/services/feedback-ingress/src/index.ts
+++ b/services/feedback-ingress/src/index.ts
@@ -1,0 +1,346 @@
+/**
+ * Fire feedback ingress Worker.
+ *
+ * Accepts multipart feedback from the mobile apps and creates a GitHub Issue
+ * using a server-side secret. Clients never hold GitHub credentials.
+ */
+
+export interface Env {
+  GITHUB_TOKEN?: string;
+  GITHUB_APP_ID?: string;
+  GITHUB_APP_PRIVATE_KEY?: string;
+  GITHUB_INSTALLATION_ID?: string;
+  GITHUB_OWNER: string;
+  GITHUB_REPO: string;
+  MAX_TITLE_CHARS: string;
+  MAX_BODY_CHARS: string;
+  MAX_BUNDLE_BYTES: string;
+  MAX_MEDIA_BYTES: string;
+  MAX_MEDIA_FILES: string;
+  RATE_LIMIT_PER_IP_PER_HOUR: string;
+  /** Optional R2 bucket for attachment blobs. */
+  ATTACHMENTS?: R2Bucket;
+}
+
+interface FeedbackFields {
+  title: string;
+  body: string;
+  category?: string;
+  severity?: string;
+  platform?: string;
+  app_version?: string;
+  build_number?: string;
+  username?: string;
+  diagnostic_session_id?: string;
+  bundle?: File;
+  media: File[];
+}
+
+const ALLOWED_CATEGORIES = new Set([
+  "bug",
+  "crash",
+  "performance",
+  "ui",
+  "suggestion",
+  "other",
+]);
+
+const ALLOWED_SEVERITIES = new Set([
+  "critical",
+  "high",
+  "medium",
+  "low",
+]);
+
+/** In-memory rate limit (best-effort per isolate; use Durable Object / KV for production). */
+const rateBuckets = new Map<string, { count: number; resetAt: number }>();
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (request.method === "GET" && url.pathname === "/health") {
+      return json({ ok: true, service: "fire-feedback-ingress" });
+    }
+
+    if (request.method === "POST" && url.pathname === "/v1/feedback") {
+      return handleFeedback(request, env);
+    }
+
+    return json({ ok: false, error: "not_found" }, 404);
+  },
+};
+
+async function handleFeedback(request: Request, env: Env): Promise<Response> {
+  const ip =
+    request.headers.get("cf-connecting-ip") ??
+    request.headers.get("x-forwarded-for") ??
+    "unknown";
+
+  const limit = parsePositiveInt(env.RATE_LIMIT_PER_IP_PER_HOUR, 10);
+  if (!allowRate(ip, limit)) {
+    return json({ ok: false, error: "rate_limited" }, 429);
+  }
+
+  let fields: FeedbackFields;
+  try {
+    fields = await parseMultipart(request, env);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : "invalid_payload";
+    return json({ ok: false, error: message }, 400);
+  }
+
+  const token = await resolveGitHubToken(env);
+  if (!token) {
+    return json(
+      {
+        ok: false,
+        error: "server_misconfigured",
+        detail: "Missing GITHUB_TOKEN or GitHub App secrets",
+      },
+      500,
+    );
+  }
+
+  const labels = buildLabels(fields);
+  const issueBody = await buildIssueBody(fields, env);
+
+  const createResponse = await fetch(
+    `https://api.github.com/repos/${env.GITHUB_OWNER}/${env.GITHUB_REPO}/issues`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: "application/vnd.github+json",
+        "User-Agent": "fire-feedback-ingress",
+        "X-GitHub-Api-Version": "2022-11-28",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        title: fields.title,
+        body: issueBody,
+        labels,
+      }),
+    },
+  );
+
+  if (!createResponse.ok) {
+    const detail = await createResponse.text();
+    return json(
+      {
+        ok: false,
+        error: "github_create_failed",
+        status: createResponse.status,
+        detail: detail.slice(0, 500),
+      },
+      502,
+    );
+  }
+
+  const issue = (await createResponse.json()) as {
+    number: number;
+    html_url: string;
+  };
+
+  return json(
+    {
+      ok: true,
+      issue_number: issue.number,
+      issue_url: issue.html_url,
+    },
+    201,
+  );
+}
+
+async function parseMultipart(request: Request, env: Env): Promise<FeedbackFields> {
+  const contentType = request.headers.get("content-type") ?? "";
+  if (!contentType.includes("multipart/form-data")) {
+    throw new Error("expected_multipart");
+  }
+
+  const form = await request.formData();
+  const title = String(form.get("title") ?? "").trim();
+  const body = String(form.get("body") ?? "").trim();
+  const maxTitle = parsePositiveInt(env.MAX_TITLE_CHARS, 120);
+  const maxBody = parsePositiveInt(env.MAX_BODY_CHARS, 8000);
+
+  if (!title) throw new Error("title_required");
+  if (!body) throw new Error("body_required");
+  if (title.length > maxTitle) throw new Error("title_too_long");
+  if (body.length > maxBody) throw new Error("body_too_long");
+
+  const category = optionalString(form.get("category"));
+  if (category && !ALLOWED_CATEGORIES.has(category)) {
+    throw new Error("invalid_category");
+  }
+  const severity = optionalString(form.get("severity"));
+  if (severity && !ALLOWED_SEVERITIES.has(severity)) {
+    throw new Error("invalid_severity");
+  }
+
+  const bundleEntry = form.get("bundle");
+  let bundle: File | undefined;
+  if (bundleEntry instanceof File && bundleEntry.size > 0) {
+    const maxBundle = parsePositiveInt(env.MAX_BUNDLE_BYTES, 2 * 1024 * 1024);
+    if (bundleEntry.size > maxBundle) throw new Error("bundle_too_large");
+    bundle = bundleEntry;
+  }
+
+  const maxMedia = parsePositiveInt(env.MAX_MEDIA_BYTES, 5 * 1024 * 1024);
+  const maxMediaFiles = parsePositiveInt(env.MAX_MEDIA_FILES, 3);
+  const media: File[] = [];
+  for (const [key, value] of form.entries()) {
+    if (key !== "media" && !key.startsWith("media[")) continue;
+    if (!(value instanceof File) || value.size === 0) continue;
+    if (value.size > maxMedia) throw new Error("media_too_large");
+    media.push(value);
+    if (media.length > maxMediaFiles) throw new Error("too_many_media");
+  }
+
+  return {
+    title,
+    body,
+    category,
+    severity,
+    platform: optionalString(form.get("platform")),
+    app_version: optionalString(form.get("app_version")),
+    build_number: optionalString(form.get("build_number")),
+    username: optionalString(form.get("username")),
+    diagnostic_session_id: optionalString(form.get("diagnostic_session_id")),
+    bundle,
+    media,
+  };
+}
+
+function buildLabels(fields: FeedbackFields): string[] {
+  const labels = ["feedback", "beta"];
+  if (fields.category) labels.push(`feedback:${fields.category}`);
+  if (fields.severity) labels.push(`severity:${fields.severity}`);
+  if (fields.platform === "ios" || fields.platform === "android") {
+    labels.push(fields.platform);
+  }
+  return labels;
+}
+
+async function buildIssueBody(fields: FeedbackFields, env: Env): Promise<string> {
+  const lines: string[] = [];
+  lines.push("## User report");
+  lines.push("");
+  lines.push(fields.body);
+  lines.push("");
+  lines.push("## Environment");
+  lines.push("");
+  lines.push(`- Platform: ${fields.platform ?? "unknown"}`);
+  lines.push(`- App version: ${fields.app_version ?? "unknown"}`);
+  lines.push(`- Build: ${fields.build_number ?? "unknown"}`);
+  lines.push(`- Category: ${fields.category ?? "unspecified"}`);
+  lines.push(`- Severity: ${fields.severity ?? "unspecified"}`);
+  lines.push(`- LinuxDo user: ${fields.username ?? "anonymous / not logged in"}`);
+  lines.push(
+    `- Diagnostic session: ${fields.diagnostic_session_id ?? "none"}`,
+  );
+  lines.push("");
+  lines.push("_Submitted via Fire in-app feedback (bot account)._");
+
+  const attachmentNotes: string[] = [];
+
+  if (fields.bundle) {
+    const note = await storeAttachment(env, fields.bundle, "bundle");
+    attachmentNotes.push(note);
+  }
+  for (const [index, file] of fields.media.entries()) {
+    const note = await storeAttachment(env, file, `media-${index + 1}`);
+    attachmentNotes.push(note);
+  }
+
+  if (attachmentNotes.length > 0) {
+    lines.push("");
+    lines.push("## Attachments");
+    lines.push("");
+    for (const note of attachmentNotes) {
+      lines.push(`- ${note}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+async function storeAttachment(
+  env: Env,
+  file: File,
+  kind: string,
+): Promise<string> {
+  const safeName = sanitizeFileName(file.name || kind);
+  if (!env.ATTACHMENTS) {
+    // Without R2, record metadata only. Wire R2 for real blob retention.
+    return `${kind}: \`${safeName}\` (${file.size} bytes) — storage not configured`;
+  }
+
+  const key = `feedback/${Date.now()}-${crypto.randomUUID()}-${safeName}`;
+  await env.ATTACHMENTS.put(key, await file.arrayBuffer(), {
+    httpMetadata: {
+      contentType: file.type || "application/octet-stream",
+    },
+  });
+  return `${kind}: \`${key}\` (${file.size} bytes)`;
+}
+
+async function resolveGitHubToken(env: Env): Promise<string | null> {
+  if (env.GITHUB_TOKEN) {
+    return env.GITHUB_TOKEN;
+  }
+
+  // GitHub App installation token path can be added later.
+  // For TF bootstrap, a fine-grained PAT in GITHUB_TOKEN is enough.
+  if (
+    env.GITHUB_APP_ID &&
+    env.GITHUB_APP_PRIVATE_KEY &&
+    env.GITHUB_INSTALLATION_ID
+  ) {
+    return null; // TODO: mint installation token via JWT
+  }
+
+  return null;
+}
+
+function allowRate(ip: string, limitPerHour: number): boolean {
+  const now = Date.now();
+  const hourMs = 60 * 60 * 1000;
+  const bucket = rateBuckets.get(ip);
+  if (!bucket || now >= bucket.resetAt) {
+    rateBuckets.set(ip, { count: 1, resetAt: now + hourMs });
+    return true;
+  }
+  if (bucket.count >= limitPerHour) {
+    return false;
+  }
+  bucket.count += 1;
+  return true;
+}
+
+function optionalString(value: FormDataEntryValue | null): string | undefined {
+  if (value == null) return undefined;
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function parsePositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sanitizeFileName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]+/g, "_").slice(0, 120);
+}
+
+function json(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "content-type": "application/json; charset=utf-8",
+      "cache-control": "no-store",
+    },
+  });
+}

--- a/services/feedback-ingress/tsconfig.json
+++ b/services/feedback-ingress/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ES2022",
+    "moduleResolution": "Bundler",
+    "lib": ["ES2022"],
+    "types": ["@cloudflare/workers-types"],
+    "strict": true,
+    "skipLibCheck": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/services/feedback-ingress/wrangler.toml
+++ b/services/feedback-ingress/wrangler.toml
@@ -1,0 +1,23 @@
+name = "fire-feedback-ingress"
+main = "src/index.ts"
+compatibility_date = "2026-04-01"
+
+# Configure after Cloudflare account is ready:
+# routes = [{ pattern = "feedback.example.com/*", zone_name = "example.com" }]
+
+[vars]
+GITHUB_OWNER = "peterich-rs"
+GITHUB_REPO = "fire"
+# Optional private triage repo:
+# GITHUB_REPO = "fire-triage"
+MAX_TITLE_CHARS = "120"
+MAX_BODY_CHARS = "8000"
+MAX_BUNDLE_BYTES = "2097152"
+MAX_MEDIA_BYTES = "5242880"
+MAX_MEDIA_FILES = "3"
+RATE_LIMIT_PER_IP_PER_HOUR = "10"
+
+# Uncomment when using R2 for attachments:
+# [[r2_buckets]]
+# binding = "ATTACHMENTS"
+# bucket_name = "fire-feedback-attachments"


### PR DESCRIPTION
## Summary

- Add a **redacted** `export_feedback_bundle` path in Rust/UniFFI for off-device feedback (cookies and sensitive headers stripped; smaller log/trace caps than local support bundles).
- Ship **iOS** and **Android** in-app “反馈与建议” UI with share-sheet submit (works without login); iOS also supports shake / onboarding entry points.
- Scaffold `services/feedback-ingress` Cloudflare Worker so GitHub credentials never ship in the mobile binary.
- Document architecture and ownership in `docs/architecture/feedback-and-crash-reporting.md`.

## Commits

1. `docs(architecture): document feedback and crash reporting design`
2. `feat(rust): export redacted feedback diagnostics bundles`
3. `feat(services): scaffold feedback-ingress Cloudflare Worker`
4. `feat(ios): add in-app feedback form and shake entry`
5. `feat(android): add in-app feedback form from profile`

## Out of scope / intentionally excluded

- `references/dexo/` local reference tree (not part of this feature)
- Dirty `references/fluxdo` submodule working tree (unrelated)
- End-to-end multipart upload to the Worker (clients currently use system share; upload path is designed next)
- Crashlytics / automatic crash telemetry (separate Phase B track)

## Local verification

| Check | Result |
| --- | --- |
| `cargo fmt --all --check` | pass |
| `cargo clippy -p fire-models -p fire-core -p fire-uniffi --all-targets --no-deps -- -D warnings` | pass |
| `cargo test -p fire-models -p fire-store -p fire-core -p fire-uniffi --all-targets` | pass |
| `cargo test -p fire-core --lib -- export_` (support + feedback bundle tests) | pass |
| `xcodegen generate` + `git diff --exit-code native/ios-app/Fire.xcodeproj` | in sync |
| iOS simulator `xcodebuild … build` (Fire scheme) | **BUILD SUCCEEDED** |
| Android `./gradlew testDebugUnitTest assembleDebug` | **BUILD SUCCESSFUL** |

## Test plan

- [ ] CI green: Rust lint / host tests / UniFFI / iOS tests / Android tests
- [ ] iOS: open 反馈与建议 from profile, onboarding, and shake; submit with diagnostics attached; confirm shared JSON is under `diagnostics/feedback-bundles/` and has `session_redacted: true`
- [ ] Android: open 反馈 from profile; submit with logs attached via share sheet; confirm FileProvider URI works
- [ ] Confirm support-bundle (developer tools) path remains full-fidelity and separate from feedback
- [ ] Optional: deploy `services/feedback-ingress` to a staging Worker and validate `POST /v1/feedback` → GitHub issue (secrets only on Worker)