### PR TITLE
feat: configurable DoH and fullscreen chat conversations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,6 +691,7 @@ name = "fire-core"
 version = "0.1.0"
 dependencies = [
  "base64",
+ "bytes",
  "ego-tree",
  "fire-models",
  "fire-rich-text",

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Fire 是一个全新的原生客户端工作区，目标栈为 `Swift + Kotlin +
 
 ### 聊天
 
-聊天 tab 对接 Discourse Chat：频道列表（私信 / 公共频道）、会话消息收发、已读回执与新建 DM。协议面见 `docs/knowledge/api/15-chat.md`。
+聊天 tab 对接 Discourse Chat：频道列表（私信 / 公共频道）、会话消息收发、已读回执与新建 DM。iOS 进入会话后是盖住底栏的全屏二级页（与贴文详情相同）；Android 会话是独立 Activity。协议面见 `docs/knowledge/api/15-chat.md`。
+
+设置里可开关 DNS over HTTPS，并选择内置源或填写自定义 DoH URL，用于改善 API 在 DNS 污染网络下的连通性。详见 `docs/architecture/doh-dns-over-https.md`。
 
 ### 网络请求查看
 

--- a/docs/architecture/2026-08-09-chat-tab-design.md
+++ b/docs/architecture/2026-08-09-chat-tab-design.md
@@ -20,7 +20,7 @@
 
 1. 频道列表：私信 / 公共频道分段
 2. 未读徽章：DM = unread+mention；公共 = 仅 mention；muted 不计
-3. 进入会话：拉消息（`fetch_from_last_read`）、发送、上报已读
+3. 进入会话：拉消息（`fetch_from_last_read`）、发送、上报已读。iOS 会话页通过 `FireRootCoordinator.presentSecondary` 盖住 tab shell（与贴文详情同一套全屏二级栈，根页可右滑关掉）；Android 会话本来就是独立 `ChatChannelActivity`
 4. 新建 DM：`POST /chat/api/direct-message-channels`（1:1 默认 upsert）
 5. 滑动操作：标记已读、退出会话（iOS）
 

--- a/docs/architecture/doh-dns-over-https.md
+++ b/docs/architecture/doh-dns-over-https.md
@@ -1,0 +1,47 @@
+# DNS over HTTPS
+
+日期：2026-08-22  
+状态：已实现
+
+## 范围
+
+Fire 在 **openwire 建连 DNS** 这一条权威路径上支持 RFC 8484 DoH。用户可在设置里开关，并选择内置源或填写自定义 `https://` URL。
+
+| 层 | 路径 |
+|----|------|
+| 模型 | `fire-models::doh` |
+| Core | `fire-core::doh` → `Client::builder().dns_resolver(FireDohResolver)` |
+| UniFFI | `FireSessionHandle::{list_doh_presets,get_doh_settings,set_doh_settings,probe_doh_settings}` |
+| iOS | 设置 → DNS over HTTPS（`FireDohSourceViewController`） |
+| Android | 个人页 → 设置（`SettingsActivity`） |
+
+## 权威路径
+
+每次 API / MessageBus 请求建立 TCP 前，openwire 调用 `DnsResolver`。`FireDohResolver`：
+
+1. 关闭 → `tokio::net::lookup_host`（系统 DNS）
+2. 主机已是 IP → 直接使用
+3. 主机等于当前 DoH 服务器主机 → 预设 bootstrap IP 或系统 DNS（禁止递归 DoH）
+4. 否则 POST `application/dns-message` 查 A + AAAA，按 TTL 缓存
+
+失败语义仍是 `WireErrorKind::Dns`。**不会**在 DoH 失败后回退系统 DNS 去解析业务域名——污染环境下回退会假装成功。
+
+设置热更新：resolver 持有 `Arc<RwLock<DohSettings>>`，不重建 HTTP Client。持久化在 `workspace/cache/doh-settings.json`。
+
+## 预设
+
+默认关闭，默认 URL 为阿里 DNS。内置源：阿里 DNS、DNSPod、腾讯 DNS、Cloudflare、Google、Quad9、Canadian Shield。预设主机带 bootstrap IP，避免解析 DoH 主机时再走被污染的系统 DNS。
+
+## 非范围
+
+- 不引入 FluxDO 本地 MITM 代理、不安装用户 CA、不做 ECH。
+- WebView 登录 / Cloudflare challenge 仍走系统 DNS（platform-owned）。
+- Nuke / Coil 图片请求仍走系统 DNS。linux.do 图床若也被污染，会出现 API 通、图片不通；后续工作流再考虑平台 DNS 挂钩。
+
+## 验证
+
+```bash
+cargo fmt --all --check
+cargo clippy --keep-going -p fire-models -p fire-core -p fire-uniffi --all-targets --no-deps -- -D warnings
+cargo test -p fire-models -p fire-core -p fire-uniffi --all-targets
+```

--- a/docs/architecture/fire-native-architecture.md
+++ b/docs/architecture/fire-native-architecture.md
@@ -124,7 +124,7 @@ Rich text render instruction generation.
 
 Core orchestration engine. Owns session state, networking, API orchestration, and delegates to subsystems.
 
-- **Networking**: openwire client + transparent gzip/zlib/brotli/zstd response compression + request epoch guard + CSRF retry + auth signal/probe policy + Cloudflare challenge handler retry + logging
+- **Networking**: openwire client + optional DoH `DnsResolver` (user-configurable endpoint, default off) + transparent gzip/zlib/brotli/zstd response compression + request epoch guard + CSRF retry + auth signal/probe policy + Cloudflare challenge handler retry + logging
 - **Session management**: Cookie sync, Bootstrap parsing, login state machine
 - **API orchestration**: topic list, topic detail, post CRUD, user, search, notifications
 - **MessageBus**: long-polling, subscription management, channel routing

--- a/native/android-app/src/main/AndroidManifest.xml
+++ b/native/android-app/src/main/AndroidManifest.xml
@@ -65,6 +65,10 @@
             android:name=".ui.feedback.FeedbackActivity"
             android:exported="false"
             android:parentActivityName=".MainActivity" />
+        <activity
+            android:name=".ui.settings.SettingsActivity"
+            android:exported="false"
+            android:parentActivityName=".MainActivity" />
         <provider
             android:name="androidx.core.content.FileProvider"
             android:authorities="${applicationId}.fileprovider"

--- a/native/android-app/src/main/java/com/fire/app/session/FireSessionStore.kt
+++ b/native/android-app/src/main/java/com/fire/app/session/FireSessionStore.kt
@@ -47,6 +47,9 @@ import uniffi.fire_uniffi_session.CookieSelfHealingHandler
 import uniffi.fire_uniffi_session.CookieReplayEntryState
 import uniffi.fire_uniffi_session.CookieSweepPlanState
 import uniffi.fire_uniffi_session.CurrentUserSnapshotState
+import uniffi.fire_uniffi_session.DohPresetState
+import uniffi.fire_uniffi_session.DohProbeResultState
+import uniffi.fire_uniffi_session.DohSettingsState
 import uniffi.fire_uniffi_session.HomeTopicListScopeState
 import uniffi.fire_uniffi_session.LoginFinalizationResultState
 import uniffi.fire_uniffi_session.LoginStateDeterminationState
@@ -1058,6 +1061,26 @@ class FireSessionStore(
 
     fun setCurrentHomeTopicListScope(scope: HomeTopicListScopeState): HomeTopicListScopeState {
         return core.session().setCurrentHomeTopicListScope(scope)
+    }
+
+    suspend fun listDohPresets(): List<DohPresetState> = withContext(Dispatchers.IO) {
+        core.session().listDohPresets()
+    }
+
+    suspend fun getDohSettings(): DohSettingsState = withContext(Dispatchers.IO) {
+        core.session().getDohSettings()
+    }
+
+    suspend fun setDohSettings(settings: DohSettingsState): DohSettingsState =
+        withContext(Dispatchers.IO) {
+            core.session().setDohSettings(settings)
+        }
+
+    suspend fun probeDohSettings(
+        settings: DohSettingsState,
+        host: String? = null,
+    ): DohProbeResultState = withContext(Dispatchers.IO) {
+        core.session().probeDohSettings(settings, host)
     }
 
     suspend fun determineLoginStateWithProbe(): LoginStateDeterminationState {

--- a/native/android-app/src/main/java/com/fire/app/ui/profile/ProfileFragment.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/profile/ProfileFragment.kt
@@ -18,6 +18,7 @@ import com.fire.app.session.FireSessionStore
 import com.fire.app.session.FireSessionStoreRepository
 import com.fire.app.ui.composer.PrivateMessageComposerSheet
 import com.fire.app.ui.feedback.FeedbackActivity
+import com.fire.app.ui.settings.SettingsActivity
 import com.fire.app.ui.topicdetail.TopicDetailActivity
 import kotlinx.coroutines.launch
 import uniffi.fire_uniffi_user.UserProfileState
@@ -35,6 +36,7 @@ class ProfileFragment : Fragment() {
     private lateinit var privateMessagesButton: View
     private lateinit var ldcButton: View
     private lateinit var cdkButton: View
+    private lateinit var settingsButton: View
     private lateinit var feedbackButton: View
 
     private var viewModel: ProfileViewModel? = null
@@ -62,6 +64,7 @@ class ProfileFragment : Fragment() {
         privateMessagesButton = view.findViewById(R.id.private_messages_button)
         ldcButton = view.findViewById(R.id.ldc_button)
         cdkButton = view.findViewById(R.id.cdk_button)
+        settingsButton = view.findViewById(R.id.settings_button)
         feedbackButton = view.findViewById(R.id.feedback_button)
 
         viewLifecycleOwner.lifecycleScope.launch {
@@ -175,6 +178,9 @@ class ProfileFragment : Fragment() {
         }
         cdkButton.setOnClickListener {
             findNavController().navigate(ProfileFragmentDirections.actionProfileToCdk())
+        }
+        settingsButton.setOnClickListener {
+            SettingsActivity.start(requireContext())
         }
         feedbackButton.setOnClickListener {
             FeedbackActivity.start(requireContext(), source = "profile")

--- a/native/android-app/src/main/java/com/fire/app/ui/settings/SettingsActivity.kt
+++ b/native/android-app/src/main/java/com/fire/app/ui/settings/SettingsActivity.kt
@@ -1,0 +1,195 @@
+package com.fire.app.ui.settings
+
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
+import android.widget.ArrayAdapter
+import android.widget.EditText
+import android.widget.Spinner
+import android.widget.TextView
+import androidx.activity.enableEdgeToEdge
+import androidx.appcompat.app.AppCompatActivity
+import androidx.appcompat.app.AppCompatDelegate
+import androidx.appcompat.widget.SwitchCompat
+import androidx.lifecycle.lifecycleScope
+import com.fire.app.R
+import com.fire.app.core.theme.compose.FireAppearancePreference
+import com.fire.app.session.FireSessionStoreRepository
+import com.google.android.material.appbar.MaterialToolbar
+import com.google.android.material.button.MaterialButton
+import kotlinx.coroutines.launch
+import uniffi.fire_uniffi_session.DohPresetState
+import uniffi.fire_uniffi_session.DohSettingsState
+
+class SettingsActivity : AppCompatActivity() {
+
+    private lateinit var appearanceSpinner: Spinner
+    private lateinit var dohEnabled: SwitchCompat
+    private lateinit var presetSpinner: Spinner
+    private lateinit var customUrl: EditText
+    private lateinit var testButton: MaterialButton
+    private lateinit var statusLabel: TextView
+
+    private var presets: List<DohPresetState> = emptyList()
+    private var settings = DohSettingsState(enabled = false, endpointUrl = "")
+    private var suppressPersistence = false
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        enableEdgeToEdge()
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_settings)
+
+        val toolbar = findViewById<MaterialToolbar>(R.id.settings_toolbar)
+        toolbar.setNavigationOnClickListener { finish() }
+        toolbar.title = getString(R.string.settings_title)
+
+        appearanceSpinner = findViewById(R.id.settings_appearance)
+        dohEnabled = findViewById(R.id.settings_doh_enabled)
+        presetSpinner = findViewById(R.id.settings_doh_preset)
+        customUrl = findViewById(R.id.settings_doh_custom)
+        testButton = findViewById(R.id.settings_doh_test)
+        statusLabel = findViewById(R.id.settings_doh_status)
+
+        val appearanceOptions = listOf(
+            FireAppearancePreference.System,
+            FireAppearancePreference.Dark,
+            FireAppearancePreference.Light,
+        )
+        appearanceSpinner.adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_dropdown_item,
+            appearanceOptions.map { option ->
+                when (option) {
+                    FireAppearancePreference.System -> getString(R.string.settings_appearance_system)
+                    FireAppearancePreference.Dark -> getString(R.string.settings_appearance_dark)
+                    FireAppearancePreference.Light -> getString(R.string.settings_appearance_light)
+                }
+            },
+        )
+        val currentAppearance = FireAppearancePreference.load(this)
+        appearanceSpinner.setSelection(appearanceOptions.indexOf(currentAppearance).coerceAtLeast(0))
+        appearanceSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                val preference = appearanceOptions[position]
+                FireAppearancePreference.save(this@SettingsActivity, preference)
+                AppCompatDelegate.setDefaultNightMode(
+                    when (preference) {
+                        FireAppearancePreference.System -> AppCompatDelegate.MODE_NIGHT_FOLLOW_SYSTEM
+                        FireAppearancePreference.Dark -> AppCompatDelegate.MODE_NIGHT_YES
+                        FireAppearancePreference.Light -> AppCompatDelegate.MODE_NIGHT_NO
+                    },
+                )
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>?) = Unit
+        }
+
+        dohEnabled.setOnCheckedChangeListener { _, enabled ->
+            if (suppressPersistence) return@setOnCheckedChangeListener
+            persist(settings.copy(enabled = enabled))
+        }
+        presetSpinner.onItemSelectedListener = object : AdapterView.OnItemSelectedListener {
+            override fun onItemSelected(parent: AdapterView<*>?, view: View?, position: Int, id: Long) {
+                if (suppressPersistence) return
+                val customIndex = presets.size
+                if (position == customIndex) {
+                    customUrl.visibility = View.VISIBLE
+                    if (customUrl.text.isBlank()) {
+                        customUrl.setText(settings.endpointUrl)
+                    }
+                    val url = customUrl.text.toString().ifBlank { settings.endpointUrl }
+                    persist(settings.copy(endpointUrl = url))
+                } else {
+                    customUrl.visibility = View.GONE
+                    persist(settings.copy(endpointUrl = presets[position].endpointUrl))
+                }
+            }
+
+            override fun onNothingSelected(parent: AdapterView<*>?) = Unit
+        }
+        testButton.setOnClickListener { probe() }
+
+        lifecycleScope.launch { loadDoh() }
+    }
+
+    private suspend fun loadDoh() {
+        val store = FireSessionStoreRepository.get(this)
+        presets = store.listDohPresets()
+        settings = store.getDohSettings()
+        bindDoh()
+    }
+
+    private fun bindDoh() {
+        suppressPersistence = true
+        dohEnabled.isChecked = settings.enabled
+        val labels = presets.map { it.displayName } + getString(R.string.settings_doh_custom)
+        presetSpinner.adapter = ArrayAdapter(
+            this,
+            android.R.layout.simple_spinner_dropdown_item,
+            labels,
+        )
+        val presetIndex = presets.indexOfFirst { it.endpointUrl == settings.endpointUrl }
+        if (presetIndex >= 0) {
+            presetSpinner.setSelection(presetIndex)
+            customUrl.visibility = View.GONE
+        } else {
+            presetSpinner.setSelection(presets.size)
+            customUrl.visibility = View.VISIBLE
+            customUrl.setText(settings.endpointUrl)
+        }
+        suppressPersistence = false
+    }
+
+    private fun persist(next: DohSettingsState) {
+        val resolved = if (presetSpinner.selectedItemPosition == presets.size) {
+            next.copy(endpointUrl = customUrl.text.toString().ifBlank { next.endpointUrl })
+        } else {
+            next
+        }
+        lifecycleScope.launch {
+            runCatching {
+                val store = FireSessionStoreRepository.get(this@SettingsActivity)
+                settings = store.setDohSettings(resolved)
+                bindDoh()
+            }.onFailure { error ->
+                statusLabel.text = error.message
+            }
+        }
+    }
+
+    private fun probe() {
+        val candidate = if (presetSpinner.selectedItemPosition == presets.size) {
+            settings.copy(endpointUrl = customUrl.text.toString())
+        } else {
+            settings
+        }
+        statusLabel.text = getString(R.string.settings_doh_testing)
+        lifecycleScope.launch {
+            runCatching {
+                val store = FireSessionStoreRepository.get(this@SettingsActivity)
+                store.probeDohSettings(candidate)
+            }.onSuccess { result ->
+                statusLabel.text = if (result.ok) {
+                    getString(
+                        R.string.settings_doh_ok,
+                        result.host,
+                        result.resolvedAddresses.joinToString(),
+                        result.elapsedMs.toString(),
+                    )
+                } else {
+                    result.errorMessage ?: getString(R.string.settings_doh_failed)
+                }
+            }.onFailure { error ->
+                statusLabel.text = error.message ?: getString(R.string.settings_doh_failed)
+            }
+        }
+    }
+
+    companion object {
+        fun start(context: Context) {
+            context.startActivity(Intent(context, SettingsActivity::class.java))
+        }
+    }
+}

--- a/native/android-app/src/main/res/layout/activity_settings.xml
+++ b/native/android-app/src/main/res/layout/activity_settings.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:orientation="vertical">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/settings_toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        app:title="@string/settings_title"
+        app:navigationIcon="@drawable/ic_arrow_back" />
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:fillViewport="true">
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="16dp">
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/settings_appearance"
+                android:textAppearance="?attr/textAppearanceSubtitle2" />
+
+            <Spinner
+                android:id="@+id/settings_appearance"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="24dp"
+                android:text="@string/settings_doh"
+                android:textAppearance="?attr/textAppearanceSubtitle2" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:text="@string/settings_doh_hint"
+                android:textAppearance="?attr/textAppearanceBody2" />
+
+            <androidx.appcompat.widget.SwitchCompat
+                android:id="@+id/settings_doh_enabled"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:text="@string/settings_doh_enable" />
+
+            <TextView
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/settings_doh_source"
+                android:textAppearance="?attr/textAppearanceBody2" />
+
+            <Spinner
+                android:id="@+id/settings_doh_preset"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp" />
+
+            <EditText
+                android:id="@+id/settings_doh_custom"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="8dp"
+                android:hint="@string/settings_doh_custom_hint"
+                android:inputType="textUri"
+                android:visibility="gone" />
+
+            <com.google.android.material.button.MaterialButton
+                android:id="@+id/settings_doh_test"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="16dp"
+                android:text="@string/settings_doh_test" />
+
+            <TextView
+                android:id="@+id/settings_doh_status"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="12dp"
+                android:textAppearance="?attr/textAppearanceBody2" />
+        </LinearLayout>
+    </ScrollView>
+</LinearLayout>

--- a/native/android-app/src/main/res/layout/fragment_profile.xml
+++ b/native/android-app/src/main/res/layout/fragment_profile.xml
@@ -97,6 +97,19 @@
                 android:textColor="@color/fire_accent" />
 
             <TextView
+                android:id="@+id/settings_button"
+                android:layout_width="96dp"
+                android:layout_height="40dp"
+                android:layout_marginStart="8dp"
+                android:background="?attr/selectableItemBackground"
+                android:ellipsize="end"
+                android:gravity="center"
+                android:singleLine="true"
+                android:text="@string/settings_action"
+                android:textAppearance="@style/TextAppearance.AppCompat.Button"
+                android:textColor="@color/fire_accent" />
+
+            <TextView
                 android:id="@+id/feedback_button"
                 android:layout_width="96dp"
                 android:layout_height="40dp"

--- a/native/android-app/src/main/res/values/strings.xml
+++ b/native/android-app/src/main/res/values/strings.xml
@@ -596,6 +596,22 @@
     <string name="feedback_not_logged_in">未登录</string>
     <string name="feedback_meta_format">LinuxDo: %1$s\nApp: %2$s (%3$s) · Android %4$s\n设备: %5$s</string>
     <string name="feedback_action">反馈</string>
+    <string name="settings_action">设置</string>
+    <string name="settings_title">设置</string>
+    <string name="settings_appearance">外观</string>
+    <string name="settings_appearance_system">跟随系统</string>
+    <string name="settings_appearance_dark">深色</string>
+    <string name="settings_appearance_light">浅色</string>
+    <string name="settings_doh">DNS over HTTPS</string>
+    <string name="settings_doh_hint">加密 DNS 查询，改善 API 连接稳定性。关闭后使用系统 DNS。</string>
+    <string name="settings_doh_enable">使用 DoH</string>
+    <string name="settings_doh_source">解析源</string>
+    <string name="settings_doh_custom">自定义</string>
+    <string name="settings_doh_custom_hint">https://example/dns-query</string>
+    <string name="settings_doh_test">测试连接</string>
+    <string name="settings_doh_testing">正在测试…</string>
+    <string name="settings_doh_ok">成功：%1$s → %2$s（%3$sms）</string>
+    <string name="settings_doh_failed">测试失败</string>
     <string-array name="feedback_categories">
         <item>缺陷</item>
         <item>崩溃</item>

--- a/native/ios-app/App/ViewModels/FireAppViewModel+Network.swift
+++ b/native/ios-app/App/ViewModels/FireAppViewModel+Network.swift
@@ -3,18 +3,18 @@ import Foundation
 extension FireAppViewModel {
     func listDohPresets() async throws -> [DohPresetState] {
         let sessionStore = try await sessionStoreValue()
-        return try sessionStore.listDohPresets()
+        return try await sessionStore.listDohPresets()
     }
 
     func getDohSettings() async throws -> DohSettingsState {
         let sessionStore = try await sessionStoreValue()
-        return try sessionStore.getDohSettings()
+        return try await sessionStore.getDohSettings()
     }
 
     @discardableResult
     func setDohSettings(_ settings: DohSettingsState) async throws -> DohSettingsState {
         let sessionStore = try await sessionStoreValue()
-        return try sessionStore.setDohSettings(settings)
+        return try await sessionStore.setDohSettings(settings)
     }
 
     func probeDohSettings(

--- a/native/ios-app/App/ViewModels/FireAppViewModel+Network.swift
+++ b/native/ios-app/App/ViewModels/FireAppViewModel+Network.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension FireAppViewModel {
+    func listDohPresets() async throws -> [DohPresetState] {
+        let sessionStore = try await sessionStoreValue()
+        return try sessionStore.listDohPresets()
+    }
+
+    func getDohSettings() async throws -> DohSettingsState {
+        let sessionStore = try await sessionStoreValue()
+        return try sessionStore.getDohSettings()
+    }
+
+    @discardableResult
+    func setDohSettings(_ settings: DohSettingsState) async throws -> DohSettingsState {
+        let sessionStore = try await sessionStoreValue()
+        return try sessionStore.setDohSettings(settings)
+    }
+
+    func probeDohSettings(
+        _ settings: DohSettingsState,
+        host: String? = nil
+    ) async throws -> DohProbeResultState {
+        let sessionStore = try await sessionStoreValue()
+        return try await sessionStore.probeDohSettings(settings, host: host)
+    }
+}

--- a/native/ios-app/App/Views/Chat/FireChatChannelViewController.swift
+++ b/native/ios-app/App/Views/Chat/FireChatChannelViewController.swift
@@ -162,6 +162,31 @@ final class FireChatChannelViewController: UIViewController, UITableViewDataSour
         Task { await loadInitial() }
     }
 
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        updateDismissButtonIfNeeded()
+    }
+
+    private func updateDismissButtonIfNeeded() {
+        let isRootPresentedChat =
+            navigationController?.presentingViewController != nil
+            && navigationController?.viewControllers.count == 1
+        if isRootPresentedChat {
+            let dismissAction = UIAction { [weak self] _ in
+                self?.navigationController?.dismiss(animated: true)
+            }
+            let dismissItem = UIBarButtonItem(
+                title: "返回",
+                image: UIImage(systemName: "chevron.backward"),
+                primaryAction: dismissAction
+            )
+            dismissItem.accessibilityLabel = "返回"
+            navigationItem.leftBarButtonItem = dismissItem
+        } else {
+            navigationItem.leftBarButtonItem = nil
+        }
+    }
+
     deinit {
         NotificationCenter.default.removeObserver(self)
         if let busObserver {

--- a/native/ios-app/App/Views/Chat/FireChatViewController.swift
+++ b/native/ios-app/App/Views/Chat/FireChatViewController.swift
@@ -217,7 +217,7 @@ final class FireChatViewController: UIViewController {
                 self?.channelsStore.clearTracking(for: channelID)
             }
         )
-        navigationController?.pushViewController(controller, animated: true)
+        FireRootCoordinator.presentSecondary(controller)
     }
 }
 

--- a/native/ios-app/App/Views/Profile/FireDohSourceViewController.swift
+++ b/native/ios-app/App/Views/Profile/FireDohSourceViewController.swift
@@ -1,0 +1,226 @@
+import UIKit
+
+@MainActor
+final class FireDohSourceViewController: UIViewController, UITableViewDataSource, UITableViewDelegate {
+    var onChange: ((DohSettingsState, [DohPresetState]) -> Void)?
+
+    private let appViewModel: FireAppViewModel
+    private let tableView = UITableView(frame: .zero, style: .insetGrouped)
+    private let enableSwitch = UISwitch()
+    private let testButton = UIButton(type: .system)
+    private let statusLabel = UILabel()
+
+    private var settings = DohSettingsState(enabled: false, endpointUrl: "")
+    private var presets: [DohPresetState] = []
+    private var isSaving = false
+    private var isProbing = false
+
+    init(viewModel: FireAppViewModel) {
+        self.appViewModel = viewModel
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        title = "DNS over HTTPS"
+        navigationItem.largeTitleDisplayMode = .never
+        view.backgroundColor = FireTheme.uiCanvas
+        navigationController?.navigationBar.tintColor = FireTheme.uiAccent
+
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.backgroundColor = FireTheme.uiCanvas
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "cell")
+        view.addSubview(tableView)
+        NSLayoutConstraint.activate([
+            tableView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            tableView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            tableView.topAnchor.constraint(equalTo: view.topAnchor),
+            tableView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        enableSwitch.addTarget(self, action: #selector(enableChanged), for: .valueChanged)
+
+        var buttonConfig = UIButton.Configuration.filled()
+        buttonConfig.title = "测试连接"
+        buttonConfig.cornerStyle = .capsule
+        testButton.configuration = buttonConfig
+        testButton.addTarget(self, action: #selector(testTapped), for: .touchUpInside)
+
+        statusLabel.font = .preferredFont(forTextStyle: .footnote)
+        statusLabel.textColor = FireTheme.uiTertiaryInk
+        statusLabel.numberOfLines = 0
+        statusLabel.text = "仅对 API 请求生效。关闭后使用系统 DNS。"
+
+        tableView.tableFooterView = makeFooter()
+        Task { await reload() }
+    }
+
+    override func viewDidLayoutSubviews() {
+        super.viewDidLayoutSubviews()
+        guard let footer = tableView.tableFooterView else { return }
+        let target = footer.systemLayoutSizeFitting(
+            CGSize(width: tableView.bounds.width, height: 0),
+            withHorizontalFittingPriority: .required,
+            verticalFittingPriority: .fittingSizeLevel
+        )
+        if footer.frame.size != target {
+            footer.frame.size = target
+            tableView.tableFooterView = footer
+        }
+    }
+
+    private func makeFooter() -> UIView {
+        let stack = UIStackView(arrangedSubviews: [testButton, statusLabel])
+        stack.axis = .vertical
+        stack.spacing = 12
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        let host = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: 120))
+        host.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.topAnchor.constraint(equalTo: host.topAnchor, constant: 16),
+            stack.leadingAnchor.constraint(equalTo: host.leadingAnchor, constant: 20),
+            stack.trailingAnchor.constraint(equalTo: host.trailingAnchor, constant: -20),
+            stack.bottomAnchor.constraint(equalTo: host.bottomAnchor, constant: -16),
+        ])
+        return host
+    }
+
+    private func reload() async {
+        do {
+            presets = try await appViewModel.listDohPresets()
+            settings = try await appViewModel.getDohSettings()
+            enableSwitch.isOn = settings.enabled
+            tableView.reloadData()
+            onChange?(settings, presets)
+        } catch {
+            statusLabel.text = error.localizedDescription
+        }
+    }
+
+    @objc private func enableChanged() {
+        settings = DohSettingsState(enabled: enableSwitch.isOn, endpointUrl: settings.endpointUrl)
+        persist()
+    }
+
+    @objc private func testTapped() {
+        guard !isProbing else { return }
+        isProbing = true
+        statusLabel.text = "正在测试…"
+        Task {
+            defer { isProbing = false }
+            do {
+                let result = try await appViewModel.probeDohSettings(settings)
+                if result.ok {
+                    let addresses = result.resolvedAddresses.joined(separator: ", ")
+                    statusLabel.text = "成功：\(result.host) → \(addresses)（\(result.elapsedMs)ms）"
+                } else {
+                    statusLabel.text = result.errorMessage ?? "测试失败"
+                }
+            } catch {
+                statusLabel.text = error.localizedDescription
+            }
+        }
+    }
+
+    private func persist() {
+        guard !isSaving else { return }
+        isSaving = true
+        Task {
+            defer { isSaving = false }
+            do {
+                settings = try await appViewModel.setDohSettings(settings)
+                enableSwitch.isOn = settings.enabled
+                tableView.reloadData()
+                onChange?(settings, presets)
+            } catch {
+                statusLabel.text = error.localizedDescription
+                enableSwitch.isOn = settings.enabled
+            }
+        }
+    }
+
+    func numberOfSections(in tableView: UITableView) -> Int { 2 }
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        section == 0 ? 1 : presets.count + 1
+    }
+
+    func tableView(_ tableView: UITableView, titleForHeaderInSection section: Int) -> String? {
+        section == 0 ? "开关" : "解析源"
+    }
+
+    func tableView(_ tableView: UITableView, titleForFooterInSection section: Int) -> String? {
+        section == 1 ? "自定义源必须是 https:// 开头的 DoH URL。预设源会用内置 IP 启动，避免系统 DNS 污染。" : nil
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath)
+        var content = cell.defaultContentConfiguration()
+        cell.accessoryView = nil
+        cell.accessoryType = .none
+        cell.selectionStyle = .default
+        if indexPath.section == 0 {
+            content.text = "使用 DoH"
+            content.secondaryText = "加密 DNS 查询，改善连接稳定性"
+            cell.accessoryView = enableSwitch
+            cell.selectionStyle = .none
+        } else if indexPath.row < presets.count {
+            let preset = presets[indexPath.row]
+            content.text = preset.displayName
+            content.secondaryText = preset.endpointUrl
+            if settings.endpointUrl == preset.endpointUrl {
+                cell.accessoryType = .checkmark
+            }
+        } else {
+            content.text = "自定义"
+            let isCustom = presets.allSatisfy { $0.endpointUrl != settings.endpointUrl }
+            content.secondaryText = isCustom && !settings.endpointUrl.isEmpty
+                ? settings.endpointUrl
+                : "输入自己的 DoH 地址"
+            cell.accessoryType = isCustom ? .checkmark : .disclosureIndicator
+        }
+        cell.contentConfiguration = content
+        return cell
+    }
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        tableView.deselectRow(at: indexPath, animated: true)
+        guard indexPath.section == 1 else { return }
+        if indexPath.row < presets.count {
+            let preset = presets[indexPath.row]
+            settings = DohSettingsState(enabled: settings.enabled, endpointUrl: preset.endpointUrl)
+            persist()
+            return
+        }
+        presentCustomURLPrompt()
+    }
+
+    private func presentCustomURLPrompt() {
+        let alert = UIAlertController(
+            title: "自定义 DoH",
+            message: "例如 https://dns.alidns.com/dns-query",
+            preferredStyle: .alert
+        )
+        alert.addTextField { field in
+            field.keyboardType = .URL
+            field.autocapitalizationType = .none
+            field.autocorrectionType = .no
+            field.text = self.settings.endpointUrl
+        }
+        alert.addAction(UIAlertAction(title: "取消", style: .cancel))
+        alert.addAction(UIAlertAction(title: "保存", style: .default) { [weak self] _ in
+            guard let self else { return }
+            let raw = alert.textFields?.first?.text ?? ""
+            self.settings = DohSettingsState(enabled: self.settings.enabled, endpointUrl: raw)
+            self.persist()
+        })
+        present(alert, animated: true)
+    }
+}

--- a/native/ios-app/App/Views/Profile/FireSettingsViewController.swift
+++ b/native/ios-app/App/Views/Profile/FireSettingsViewController.swift
@@ -26,8 +26,11 @@ final class FireSettingsViewController: UIViewController {
         return control
     }()
     private lazy var diagnosticsCard = FireUIKitSettingsCardView()
+    private lazy var networkCard = FireUIKitSettingsCardView()
     private lazy var signOutCard = FireUIKitSettingsCardView()
     private let versionLabel = UILabel()
+    private var dohSettings: DohSettingsState?
+    private var dohPresets: [DohPresetState] = []
 
     init(viewModel: FireAppViewModel, canLogout: Bool) {
         self.appViewModel = viewModel
@@ -51,6 +54,7 @@ final class FireSettingsViewController: UIViewController {
         configureScrollLayout()
         rebuildContent()
         bind()
+        Task { await loadDohSettings() }
     }
 
     override func viewWillAppear(_ animated: Bool) {
@@ -116,6 +120,24 @@ final class FireSettingsViewController: UIViewController {
         contentStack.addArrangedSubview(appearanceControl)
         contentStack.setCustomSpacing(FireTheme.sectionSpacing, after: appearanceControl)
         syncAppearanceControl()
+
+        // NETWORK
+        contentStack.addArrangedSubview(makeSectionHeader("网络"))
+        contentStack.setCustomSpacing(10, after: contentStack.arrangedSubviews.last!)
+        networkCard.setRows([
+            (
+                .init(
+                    systemImage: "lock.shield.fill",
+                    title: "DNS over HTTPS",
+                    subtitle: dohSubtitle,
+                    showsChevron: true,
+                    iconWellColor: UIColor.systemTeal
+                ),
+                { [weak self] in self?.openDohSettings() }
+            ),
+        ])
+        contentStack.addArrangedSubview(networkCard)
+        contentStack.setCustomSpacing(FireTheme.sectionSpacing, after: networkCard)
 
         // DIAGNOSTICS
         contentStack.addArrangedSubview(makeSectionHeader("诊断"))
@@ -203,6 +225,40 @@ final class FireSettingsViewController: UIViewController {
             self?.appViewModel.logout()
         })
         present(alert, animated: true)
+    }
+
+    private var dohSubtitle: String {
+        guard let settings = dohSettings else { return "加载中…" }
+        if !settings.enabled {
+            return "关闭"
+        }
+        if let preset = dohPresets.first(where: { $0.endpointUrl == settings.endpointUrl }) {
+            return preset.displayName
+        }
+        return settings.endpointUrl
+    }
+
+    private func loadDohSettings() async {
+        do {
+            async let settings = appViewModel.getDohSettings()
+            async let presets = appViewModel.listDohPresets()
+            dohSettings = try await settings
+            dohPresets = try await presets
+            rebuildContent()
+        } catch {
+            dohSettings = DohSettingsState(enabled: false, endpointUrl: "")
+            rebuildContent()
+        }
+    }
+
+    private func openDohSettings() {
+        let controller = FireDohSourceViewController(viewModel: appViewModel)
+        controller.onChange = { [weak self] settings, presets in
+            self?.dohSettings = settings
+            self?.dohPresets = presets
+            self?.rebuildContent()
+        }
+        navigationController?.pushViewController(controller, animated: true)
     }
 
     private func openDeveloperTools() {

--- a/native/ios-app/Fire.xcodeproj/project.pbxproj
+++ b/native/ios-app/Fire.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		D2D1EA7C7D1208AEE0932A86 /* FireFollowListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5C18328DFF8C1C3145C2DAC /* FireFollowListViewController.swift */; };
 		D89E51A2B4024E06147DAEE7 /* FireShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 949B945E18FF2C7CF0F29CB4 /* FireShortcuts.swift */; };
 		D914CE5CE076533C2C932623 /* FirePushDiagnosticsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C710FF0F248498E25E02037D /* FirePushDiagnosticsView.swift */; };
+		DA3519D17B33A6FF56FAD600 /* FireDohSourceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4AF197F76705D49E465A05B /* FireDohSourceViewController.swift */; };
 		DA6BD635BF623E34D242CB15 /* FireNavigationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627535804DAD392D5972B8FF /* FireNavigationState.swift */; };
 		DC4203187C3CAF0846C2D8BF /* FireRouteParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAE00F2C2E4EB9A7A99D327A /* FireRouteParser.swift */; };
 		DEAA3B204324377FFCAA1F1B /* FireWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEEAB2E2FBB20FA96A15FD11 /* FireWidgetBundle.swift */; };
@@ -225,6 +226,7 @@
 		ED9CD3DE021ED54FED139F8A /* FireTopicDetailRuntimeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7523D63E40FC490B6E3F1ED /* FireTopicDetailRuntimeTests.swift */; };
 		F25C8C5E91D29F5BEDB35E9A /* FireTopicDetailPageState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 301D9A74A8ACFE5A61280A86 /* FireTopicDetailPageState.swift */; };
 		F31A70760B997F5ADFB7C489 /* FireListSectionModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFB6B1F10783D1D78B2D1F63 /* FireListSectionModel.swift */; };
+		F388A1165747AC85DEE53FFD /* FireAppViewModel+Network.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67D675A6BC377D2479E2A90B /* FireAppViewModel+Network.swift */; };
 		F3EE595ECC3F647D419D1833 /* FireSmallWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44E64FAEF7CBC79DBC2491BB /* FireSmallWidget.swift */; };
 		F41EBD87EC59341D3A7DD381 /* FireOnboardingCredentialFormView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F112BF5A6A226C1D21861F90 /* FireOnboardingCredentialFormView.swift */; };
 		F4E23711C352DB67C48DDEDA /* FireUIKitSkeleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = F45FD2D6B300FDC58C2FD04A /* FireUIKitSkeleton.swift */; };
@@ -369,6 +371,7 @@
 		6566A1D9FDFFFF7BE5EC2229 /* FireTopicTimingTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireTopicTimingTracker.swift; sourceTree = "<group>"; };
 		656CE7A291529B78CBAB24D8 /* FireAppViewModelSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppViewModelSupport.swift; sourceTree = "<group>"; };
 		6620F19612B42BD0471BE1CA /* FireUIKitEmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireUIKitEmptyStateView.swift; sourceTree = "<group>"; };
+		67D675A6BC377D2479E2A90B /* FireAppViewModel+Network.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FireAppViewModel+Network.swift"; sourceTree = "<group>"; };
 		6958AA64094FA7BB21B5FC36 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		6975FD77F7DBD0670E237842 /* FireCDKView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireCDKView.swift; sourceTree = "<group>"; };
 		6C063DC3D3814082F9655534 /* FireAppViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireAppViewModel.swift; sourceTree = "<group>"; };
@@ -471,6 +474,7 @@
 		E355FDE3F6E9A5FFB6229374 /* FireHomeScopePresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireHomeScopePresentation.swift; sourceTree = "<group>"; };
 		E379AA9200DC2BD19BEC807F /* FireListPaginationAndUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireListPaginationAndUpdateTests.swift; sourceTree = "<group>"; };
 		E4616E00DD2F43C18973E520 /* FireUIKitErrorBannerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireUIKitErrorBannerView.swift; sourceTree = "<group>"; };
+		E4AF197F76705D49E465A05B /* FireDohSourceViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireDohSourceViewController.swift; sourceTree = "<group>"; };
 		E5B34317DAE5858951DCD928 /* fire_uniffi_messagebus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = fire_uniffi_messagebus.swift; sourceTree = "<group>"; };
 		E5FFB93F34563ABE34B99183 /* FireUIKitDesignLanguage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireUIKitDesignLanguage.swift; sourceTree = "<group>"; };
 		E650ABD9C06621BC41908D59 /* FireContextMenus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FireContextMenus.swift; sourceTree = "<group>"; };
@@ -770,6 +774,7 @@
 			children = (
 				BF5B6841F5556D86C606379F /* FireBadgeDetailView.swift */,
 				6975FD77F7DBD0670E237842 /* FireCDKView.swift */,
+				E4AF197F76705D49E465A05B /* FireDohSourceViewController.swift */,
 				D5C18328DFF8C1C3145C2DAC /* FireFollowListViewController.swift */,
 				73F4567310A9F3A185F64D4D /* FireLDCView.swift */,
 				71D0063A5014FEF51FB2B8E8 /* FireMyBadgesView.swift */,
@@ -1069,6 +1074,7 @@
 				6C063DC3D3814082F9655534 /* FireAppViewModel.swift */,
 				D042B49EA2CBAB217A5011AF /* FireAppViewModel+Chat.swift */,
 				1F1F872C6062881E7513980D /* FireAppViewModel+Diagnostics.swift */,
+				67D675A6BC377D2479E2A90B /* FireAppViewModel+Network.swift */,
 				F74563DD6B9E870850553DDA /* FireAppViewModel+Profile.swift */,
 				2933910F4309CBB2CC5F2BEC /* FireAppViewModel+RecoveryURLs.swift */,
 				656CE7A291529B78CBAB24D8 /* FireAppViewModelSupport.swift */,
@@ -1371,6 +1377,7 @@
 				957DADCF16F936D3BCCDE7F5 /* FireAppServiceHost.swift in Sources */,
 				CD0EDE3D5D4C6F06272F451A /* FireAppViewModel+Chat.swift in Sources */,
 				7B772557813420536690D938 /* FireAppViewModel+Diagnostics.swift in Sources */,
+				F388A1165747AC85DEE53FFD /* FireAppViewModel+Network.swift in Sources */,
 				D100DFBC749CA19A23E11CD3 /* FireAppViewModel+Profile.swift in Sources */,
 				5F12EFC296AA350367A07DB5 /* FireAppViewModel+RecoveryURLs.swift in Sources */,
 				B0AA426C24E27249B4AE2E57 /* FireAppViewModel.swift in Sources */,
@@ -1403,6 +1410,7 @@
 				D0125C21FE7596D530229F97 /* FireDiagnosticsShared.swift in Sources */,
 				ABCB88B6D78156FB353E922B /* FireDiagnosticsViewModel.swift in Sources */,
 				939404BE03A327D4A29B6E33 /* FireDiffableListController.swift in Sources */,
+				DA3519D17B33A6FF56FAD600 /* FireDohSourceViewController.swift in Sources */,
 				DFEA3B2EB2A47B0DE062F7F9 /* FireDraftsView.swift in Sources */,
 				6CD842F82A4371F3BCCCF4C5 /* FireEntityIndex.swift in Sources */,
 				355451477523656402E506B8 /* FireExportDiagnosticsView.swift in Sources */,

--- a/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
+++ b/native/ios-app/Sources/FireAppSession/FireSessionStore.swift
@@ -186,6 +186,26 @@ public actor FireSessionStore {
         try core.session().currentHomeTopicListScope()
     }
 
+    public func listDohPresets() throws -> [DohPresetState] {
+        try core.session().listDohPresets()
+    }
+
+    public func getDohSettings() throws -> DohSettingsState {
+        try core.session().getDohSettings()
+    }
+
+    @discardableResult
+    public func setDohSettings(_ settings: DohSettingsState) throws -> DohSettingsState {
+        try core.session().setDohSettings(settings: settings)
+    }
+
+    public func probeDohSettings(
+        _ settings: DohSettingsState,
+        host: String? = nil
+    ) async throws -> DohProbeResultState {
+        try await core.session().probeDohSettings(settings: settings, host: host)
+    }
+
     @discardableResult
     public func setCurrentHomeTopicListScope(
         _ scope: HomeTopicListScopeState

--- a/rust/crates/fire-core/Cargo.toml
+++ b/rust/crates/fire-core/Cargo.toml
@@ -11,6 +11,7 @@ fire-models = { path = "../fire-models" }
 fire-rich-text = { path = "../fire-rich-text" }
 fire-store = { path = "../fire-store" }
 base64.workspace = true
+bytes.workspace = true
 futures-util.workspace = true
 http.workspace = true
 http-body-util.workspace = true

--- a/rust/crates/fire-core/src/core/mod.rs
+++ b/rust/crates/fire-core/src/core/mod.rs
@@ -10,6 +10,8 @@ mod ldc;
 mod messagebus;
 mod network;
 mod notifications;
+
+pub(crate) use network::apply_platform_tls;
 mod persistence;
 mod presence;
 mod rate_limit;
@@ -26,8 +28,8 @@ use std::{
 };
 
 use fire_models::{
-    AuthRuntimeSignal, BootstrapArtifacts, CookieSnapshot, HomeTopicListScope, SessionSnapshot,
-    TopicListQuery,
+    AuthRuntimeSignal, BootstrapArtifacts, CookieSnapshot, DohPreset, DohProbeResult, DohSettings,
+    HomeTopicListScope, SessionSnapshot, TopicListQuery,
 };
 use fire_store::FireStore;
 use openwire::Client;
@@ -45,6 +47,7 @@ use crate::{
         FireLogFilePage, FireLogFileSummary, FireSupportBundleExport, FireSupportBundleHostContext,
         NetworkTraceBodyPage, NetworkTraceDetail, NetworkTraceSummary,
     },
+    doh::FireDohController,
     error::FireCoreError,
     logging::{log_host_message, logger_runtime_for_workspace, FireHostLogLevel},
     state_observer::FireStateObserverRegistry,
@@ -143,6 +146,7 @@ pub struct FireCore {
     base_url: Url,
     workspace_path: Option<PathBuf>,
     network: network::FireNetworkLayer,
+    doh: FireDohController,
     diagnostics: Arc<FireDiagnosticsStore>,
     session: Arc<RwLock<FireSessionRuntimeState>>,
     message_bus: Arc<Mutex<messagebus::FireMessageBusRuntime>>,
@@ -205,18 +209,21 @@ impl FireCore {
         let cloudflare_challenge_runtime = Arc::new(Mutex::new(
             cf_challenge::FireCloudflareChallengeRuntime::default(),
         ));
+        let doh = FireDohController::load(workspace_path.as_deref())?;
         let network = network::FireNetworkLayer::new(
             &base_url,
             Arc::clone(&session),
             Arc::clone(&diagnostics),
             cookie_jar,
             Arc::clone(&cloudflare_challenge_runtime),
+            doh.resolver(),
         )?;
 
         Ok(Self {
             base_url,
             workspace_path,
             network,
+            doh,
             diagnostics,
             session,
             message_bus: Arc::new(Mutex::new(messagebus::FireMessageBusRuntime::default())),
@@ -331,6 +338,26 @@ impl FireCore {
 
     pub fn shared_client(&self) -> Client {
         self.network.client()
+    }
+
+    pub fn doh_settings(&self) -> DohSettings {
+        self.doh.settings()
+    }
+
+    pub fn list_doh_presets(&self) -> Vec<DohPreset> {
+        DohPreset::all().to_vec()
+    }
+
+    pub fn set_doh_settings(&self, settings: DohSettings) -> Result<DohSettings, FireCoreError> {
+        self.doh.set_settings(settings)
+    }
+
+    pub async fn probe_doh_settings(
+        &self,
+        settings: DohSettings,
+        host: Option<String>,
+    ) -> Result<DohProbeResult, FireCoreError> {
+        self.doh.probe_settings(settings, host.as_deref()).await
     }
 
     pub fn preloaded_data_service(&self) -> &Arc<crate::preloaded_data::PreloadedDataService> {

--- a/rust/crates/fire-core/src/core/network.rs
+++ b/rust/crates/fire-core/src/core/network.rs
@@ -13,8 +13,9 @@ use http::{
 #[cfg(debug_assertions)]
 use openwire::ProxyRules;
 use openwire::{
-    BoxFuture, Call, CallOptions, Client, Exchange, HttpLogger, Interceptor,
-    LogLevel as OpenWireLogLevel, LoggerInterceptor, Next, RequestBody, ResponseBody, WireError,
+    BoxFuture, Call, CallOptions, Client, ClientBuilder, DnsResolver, Exchange, HttpLogger,
+    Interceptor, LogLevel as OpenWireLogLevel, LoggerInterceptor, Next, RequestBody, ResponseBody,
+    WireError,
 };
 use serde::{de::DeserializeOwned, Deserialize};
 use tracing::{debug, info, warn};
@@ -239,6 +240,17 @@ fn fire_openwire_logger_interceptor() -> LoggerInterceptor {
         .redact_header(HeaderName::from_static("x-csrf-token"))
 }
 
+pub(crate) fn apply_platform_tls(builder: ClientBuilder) -> ClientBuilder {
+    #[cfg(target_os = "android")]
+    {
+        builder.tls_connector(android_tls_connector())
+    }
+    #[cfg(not(target_os = "android"))]
+    {
+        builder
+    }
+}
+
 #[cfg(target_os = "android")]
 fn android_tls_connector() -> openwire::RustlsTlsConnector {
     let roots = rustls::RootCertStore::from_iter(webpki_roots::TLS_SERVER_ROOTS.iter().cloned());
@@ -458,9 +470,11 @@ impl FireNetworkLayer {
         cloudflare_challenge_runtime: Arc<
             Mutex<super::cf_challenge::FireCloudflareChallengeRuntime>,
         >,
+        dns_resolver: impl DnsResolver,
     ) -> Result<Self, FireCoreError> {
         let builder = Client::builder()
             .cookie_jar(cookie_jar)
+            .dns_resolver(dns_resolver)
             .application_interceptor(FireCommonHeaderInterceptor::new(
                 base_url.clone(),
                 Arc::clone(&session),
@@ -478,8 +492,7 @@ impl FireNetworkLayer {
             )));
         #[cfg(debug_assertions)]
         let builder = builder.proxy_selector(ProxyRules::new().use_system_proxy(true));
-        #[cfg(target_os = "android")]
-        let builder = builder.tls_connector(android_tls_connector());
+        let builder = apply_platform_tls(builder);
         let client = builder
             .build()
             .map_err(|source| FireCoreError::ClientBuild { source })?;

--- a/rust/crates/fire-core/src/doh/mod.rs
+++ b/rust/crates/fire-core/src/doh/mod.rs
@@ -1,0 +1,5 @@
+mod resolver;
+mod transport;
+mod wire;
+
+pub use resolver::{FireDohController, FireDohResolver};

--- a/rust/crates/fire-core/src/doh/resolver.rs
+++ b/rust/crates/fire-core/src/doh/resolver.rs
@@ -1,0 +1,480 @@
+use std::{
+    collections::HashMap,
+    io,
+    net::{IpAddr, SocketAddr},
+    path::{Path, PathBuf},
+    sync::{Arc, Mutex, RwLock},
+    time::{Duration, Instant},
+};
+
+use fire_models::{DohPreset, DohProbeResult, DohSettings};
+use openwire::{BoxFuture, CallContext, DnsResolver, WireError};
+use tracing::{debug, info, warn};
+
+use crate::{
+    error::FireCoreError,
+    sync_utils::{read_rwlock, write_rwlock},
+};
+
+use super::{
+    transport::{endpoint_host, system_lookup, DohTransport, OpenWireDohTransport},
+    wire::{DnsRecord, QTYPE_A, QTYPE_AAAA},
+};
+
+const CACHE_MIN_TTL: Duration = Duration::from_secs(30);
+const CACHE_MAX_TTL: Duration = Duration::from_secs(300);
+const SETTINGS_FILE_NAME: &str = "doh-settings.json";
+const PROBE_HOST: &str = "linux.do";
+
+#[derive(Clone)]
+pub struct FireDohController {
+    resolver: FireDohResolver,
+    path: Option<PathBuf>,
+}
+
+impl FireDohController {
+    pub fn load(workspace_path: Option<&Path>) -> Result<Self, FireCoreError> {
+        let path = workspace_path.map(|root| root.join("cache").join(SETTINGS_FILE_NAME));
+        let settings = match path.as_deref() {
+            Some(path) if path.exists() => load_settings(path)?,
+            _ => DohSettings::default(),
+        };
+        let settings = settings
+            .normalize()
+            .map_err(|error| FireCoreError::InvalidArgument {
+                operation: "load doh settings",
+                details: error.to_string(),
+            })?;
+        let transport = Arc::new(OpenWireDohTransport::new()?);
+        let resolver = FireDohResolver::new(settings, transport);
+        Ok(Self { resolver, path })
+    }
+
+    pub fn resolver(&self) -> FireDohResolver {
+        self.resolver.clone()
+    }
+
+    pub fn settings(&self) -> DohSettings {
+        self.resolver.settings()
+    }
+
+    pub fn set_settings(&self, settings: DohSettings) -> Result<DohSettings, FireCoreError> {
+        let settings = settings
+            .normalize()
+            .map_err(|error| FireCoreError::InvalidArgument {
+                operation: "set doh settings",
+                details: error.to_string(),
+            })?;
+        self.resolver.replace_settings(settings.clone());
+        if let Some(path) = &self.path {
+            persist_settings(path, &settings)?;
+        }
+        info!(
+            enabled = settings.enabled,
+            endpoint = %settings.endpoint_url,
+            "updated DoH settings"
+        );
+        Ok(settings)
+    }
+
+    pub async fn probe_settings(
+        &self,
+        settings: DohSettings,
+        host: Option<&str>,
+    ) -> Result<DohProbeResult, FireCoreError> {
+        let settings = settings
+            .normalize()
+            .map_err(|error| FireCoreError::InvalidArgument {
+                operation: "probe doh settings",
+                details: error.to_string(),
+            })?;
+        let host = host
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .unwrap_or(PROBE_HOST)
+            .to_string();
+        let started = Instant::now();
+        match self
+            .resolver
+            .resolve_with_settings(&settings, &host, 443)
+            .await
+        {
+            Ok(addrs) => Ok(DohProbeResult {
+                ok: true,
+                host,
+                resolved_addresses: addrs.iter().map(SocketAddr::to_string).collect(),
+                elapsed_ms: elapsed_ms(started),
+                error_message: None,
+            }),
+            Err(error) => Ok(DohProbeResult {
+                ok: false,
+                host,
+                resolved_addresses: Vec::new(),
+                elapsed_ms: elapsed_ms(started),
+                error_message: Some(error.to_string()),
+            }),
+        }
+    }
+}
+
+#[derive(Clone)]
+pub struct FireDohResolver {
+    inner: Arc<FireDohResolverInner>,
+}
+
+struct FireDohResolverInner {
+    settings: RwLock<DohSettings>,
+    cache: Mutex<HashMap<String, CacheEntry>>,
+    transport: Arc<dyn DohTransport>,
+}
+
+#[derive(Clone)]
+struct CacheEntry {
+    addrs: Vec<SocketAddr>,
+    expires_at: Instant,
+}
+
+impl FireDohResolver {
+    fn new(settings: DohSettings, transport: Arc<dyn DohTransport>) -> Self {
+        Self {
+            inner: Arc::new(FireDohResolverInner {
+                settings: RwLock::new(settings),
+                cache: Mutex::new(HashMap::new()),
+                transport,
+            }),
+        }
+    }
+
+    pub fn settings(&self) -> DohSettings {
+        read_rwlock(&self.inner.settings, "doh settings").clone()
+    }
+
+    fn replace_settings(&self, settings: DohSettings) {
+        *write_rwlock(&self.inner.settings, "doh settings") = settings;
+        self.clear_cache();
+    }
+
+    fn clear_cache(&self) {
+        self.inner
+            .cache
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .clear();
+    }
+
+    async fn resolve_with_settings(
+        &self,
+        settings: &DohSettings,
+        host: &str,
+        port: u16,
+    ) -> Result<Vec<SocketAddr>, WireError> {
+        if let Ok(ip) = host.parse::<IpAddr>() {
+            return Ok(vec![SocketAddr::new(ip, port)]);
+        }
+        if !settings.enabled {
+            return system_lookup(host, port).await;
+        }
+        if endpoint_host(&settings.endpoint_url).as_deref() == Some(host) {
+            return resolve_doh_endpoint_host(host, port).await;
+        }
+        self.lookup_doh(settings, host, port).await
+    }
+
+    async fn lookup_doh(
+        &self,
+        settings: &DohSettings,
+        host: &str,
+        port: u16,
+    ) -> Result<Vec<SocketAddr>, WireError> {
+        let cache_key = format!("{host}:{port}");
+        if let Some(cached) = self.cached(&cache_key) {
+            debug!(host, port, "DoH cache hit");
+            return Ok(cached);
+        }
+
+        let (a_result, aaaa_result) = tokio::join!(
+            self.inner
+                .transport
+                .query(&settings.endpoint_url, host, QTYPE_A),
+            self.inner
+                .transport
+                .query(&settings.endpoint_url, host, QTYPE_AAAA),
+        );
+
+        let mut records = Vec::new();
+        let mut last_error: Option<FireCoreError> = None;
+        match a_result {
+            Ok(found) => records.extend(found),
+            Err(error) => last_error = Some(error),
+        }
+        match aaaa_result {
+            Ok(found) => records.extend(found),
+            Err(error) => {
+                if last_error.is_none() {
+                    last_error = Some(error);
+                }
+            }
+        }
+        if records.is_empty() {
+            let details = last_error
+                .map(|error| error.to_string())
+                .unwrap_or_else(|| "DoH returned no addresses".to_string());
+            warn!(host, port, %details, "DoH lookup failed");
+            return Err(WireError::dns(
+                format!("DoH lookup failed for {host}"),
+                io::Error::other(details),
+            ));
+        }
+
+        let ttl = records
+            .iter()
+            .map(|record| Duration::from_secs(u64::from(record.ttl_secs)))
+            .min()
+            .unwrap_or(CACHE_MIN_TTL)
+            .clamp(CACHE_MIN_TTL, CACHE_MAX_TTL);
+        let addrs = records
+            .into_iter()
+            .map(|DnsRecord { address, .. }| SocketAddr::new(address, port))
+            .collect::<Vec<_>>();
+        self.store_cache(cache_key, addrs.clone(), ttl);
+        debug!(
+            host,
+            port,
+            count = addrs.len(),
+            ttl_secs = ttl.as_secs(),
+            "DoH lookup succeeded"
+        );
+        Ok(addrs)
+    }
+
+    fn cached(&self, key: &str) -> Option<Vec<SocketAddr>> {
+        let mut cache = self
+            .inner
+            .cache
+            .lock()
+            .unwrap_or_else(|error| error.into_inner());
+        let now = Instant::now();
+        match cache.get(key) {
+            Some(entry) if entry.expires_at > now => Some(entry.addrs.clone()),
+            Some(_) => {
+                cache.remove(key);
+                None
+            }
+            None => None,
+        }
+    }
+
+    fn store_cache(&self, key: String, addrs: Vec<SocketAddr>, ttl: Duration) {
+        self.inner
+            .cache
+            .lock()
+            .unwrap_or_else(|error| error.into_inner())
+            .insert(
+                key,
+                CacheEntry {
+                    addrs,
+                    expires_at: Instant::now() + ttl,
+                },
+            );
+    }
+}
+
+impl DnsResolver for FireDohResolver {
+    fn resolve(
+        &self,
+        ctx: CallContext,
+        host: String,
+        port: u16,
+    ) -> BoxFuture<Result<Vec<SocketAddr>, WireError>> {
+        let resolver = self.clone();
+        Box::pin(async move {
+            ctx.listener().dns_start(&ctx, &host, port);
+            let settings = resolver.settings();
+            match resolver.resolve_with_settings(&settings, &host, port).await {
+                Ok(addrs) => {
+                    ctx.listener().dns_end(&ctx, &host, &addrs);
+                    Ok(addrs)
+                }
+                Err(error) => {
+                    ctx.listener().dns_failed(&ctx, &host, &error);
+                    Err(error)
+                }
+            }
+        })
+    }
+}
+
+async fn resolve_doh_endpoint_host(host: &str, port: u16) -> Result<Vec<SocketAddr>, WireError> {
+    if let Some(preset) = DohPreset::by_host(host) {
+        let addrs: Vec<SocketAddr> = preset
+            .bootstrap_ips
+            .iter()
+            .filter_map(|ip| ip.parse::<IpAddr>().ok())
+            .map(|ip| SocketAddr::new(ip, port))
+            .collect();
+        if !addrs.is_empty() {
+            return Ok(addrs);
+        }
+    }
+    system_lookup(host, port).await
+}
+
+fn load_settings(path: &Path) -> Result<DohSettings, FireCoreError> {
+    let payload = std::fs::read_to_string(path).map_err(|source| FireCoreError::WorkspaceIo {
+        path: path.to_path_buf(),
+        source,
+    })?;
+    serde_json::from_str(&payload).map_err(FireCoreError::PersistDeserialize)
+}
+
+fn persist_settings(path: &Path, settings: &DohSettings) -> Result<(), FireCoreError> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|source| FireCoreError::WorkspaceIo {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+    let payload =
+        serde_json::to_string_pretty(settings).map_err(FireCoreError::PersistSerialize)?;
+    std::fs::write(path, payload).map_err(|source| FireCoreError::WorkspaceIo {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+fn elapsed_ms(started: Instant) -> u64 {
+    started.elapsed().as_millis().min(u128::from(u64::MAX)) as u64
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::doh::transport::FakeDohTransport;
+    use std::net::Ipv4Addr;
+
+    fn record(octet: u8) -> DnsRecord {
+        DnsRecord {
+            address: IpAddr::V4(Ipv4Addr::new(1, 2, 3, octet)),
+            ttl_secs: 120,
+        }
+    }
+
+    #[tokio::test]
+    async fn disabled_settings_do_not_call_transport() {
+        let transport = FakeDohTransport::new(|_, _, _| {
+            panic!("transport should not be used when DoH is disabled");
+        });
+        let resolver = FireDohResolver::new(
+            DohSettings {
+                enabled: false,
+                endpoint_url: "https://dns.alidns.com/dns-query".into(),
+            },
+            Arc::new(transport),
+        );
+        // 127.0.0.1 is an IP literal, so even enabled mode would skip transport.
+        let addrs = resolver
+            .resolve_with_settings(&resolver.settings(), "127.0.0.1", 443)
+            .await
+            .unwrap();
+        assert_eq!(addrs, vec!["127.0.0.1:443".parse().unwrap()]);
+    }
+
+    #[tokio::test]
+    async fn enabled_lookup_uses_transport_and_cache() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        let calls = Arc::new(AtomicUsize::new(0));
+        let calls_clone = calls.clone();
+        let transport = FakeDohTransport::new(move |endpoint, name, qtype| {
+            calls_clone.fetch_add(1, Ordering::SeqCst);
+            assert_eq!(endpoint, "https://dns.alidns.com/dns-query");
+            assert_eq!(name, "linux.do");
+            if qtype == QTYPE_A {
+                Ok(vec![record(10)])
+            } else {
+                Ok(Vec::new())
+            }
+        });
+        let settings = DohSettings {
+            enabled: true,
+            endpoint_url: "https://dns.alidns.com/dns-query".into(),
+        };
+        let resolver = FireDohResolver::new(settings.clone(), Arc::new(transport));
+        let first = resolver
+            .resolve_with_settings(&settings, "linux.do", 443)
+            .await
+            .unwrap();
+        let second = resolver
+            .resolve_with_settings(&settings, "linux.do", 443)
+            .await
+            .unwrap();
+        assert_eq!(first, vec!["1.2.3.10:443".parse().unwrap()]);
+        assert_eq!(first, second);
+        // A + AAAA once; second resolve is cached.
+        assert_eq!(calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn doh_endpoint_host_uses_bootstrap_not_transport() {
+        let transport = FakeDohTransport::new(|_, _, _| {
+            panic!("must not recurse into DoH for the DoH host");
+        });
+        let settings = DohSettings {
+            enabled: true,
+            endpoint_url: "https://dns.alidns.com/dns-query".into(),
+        };
+        let resolver = FireDohResolver::new(settings.clone(), Arc::new(transport));
+        let addrs = resolver
+            .resolve_with_settings(&settings, "dns.alidns.com", 443)
+            .await
+            .unwrap();
+        let ips: Vec<_> = addrs.into_iter().map(|addr| addr.ip()).collect();
+        assert!(ips.contains(&"223.5.5.5".parse().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn replacing_settings_clears_cache() {
+        let transport = FakeDohTransport::new(|_, name, qtype| {
+            if qtype != QTYPE_A {
+                return Ok(Vec::new());
+            }
+            let octet = if name == "linux.do" { 1 } else { 2 };
+            Ok(vec![record(octet)])
+        });
+        let settings = DohSettings {
+            enabled: true,
+            endpoint_url: "https://dns.alidns.com/dns-query".into(),
+        };
+        let resolver = FireDohResolver::new(settings.clone(), Arc::new(transport));
+        let _ = resolver
+            .resolve_with_settings(&settings, "linux.do", 443)
+            .await
+            .unwrap();
+        resolver.replace_settings(settings.clone());
+        let addrs = resolver
+            .resolve_with_settings(&settings, "example.com", 443)
+            .await
+            .unwrap();
+        assert_eq!(addrs, vec!["1.2.3.2:443".parse().unwrap()]);
+    }
+
+    #[test]
+    fn persist_roundtrip() {
+        let dir = std::env::temp_dir().join(format!(
+            "fire-doh-test-{}",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join(SETTINGS_FILE_NAME);
+        let settings = DohSettings {
+            enabled: true,
+            endpoint_url: "https://dns.google/dns-query".into(),
+        };
+        persist_settings(&path, &settings).unwrap();
+        let loaded = load_settings(&path).unwrap();
+        assert_eq!(loaded, settings);
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/rust/crates/fire-core/src/doh/transport.rs
+++ b/rust/crates/fire-core/src/doh/transport.rs
@@ -1,0 +1,236 @@
+use std::{
+    io,
+    net::{IpAddr, SocketAddr},
+    time::Duration,
+};
+
+use bytes::Bytes;
+use fire_models::{normalize_doh_endpoint_url, DohPreset};
+use http::{header::CONTENT_TYPE, Method, Request};
+use openwire::{BoxFuture, CallContext, Client, DnsResolver, RequestBody, WireError};
+use url::Url;
+
+use crate::error::FireCoreError;
+
+use super::wire::{decode_addresses, encode_query, DnsRecord};
+
+const DOH_CONNECT_TIMEOUT: Duration = Duration::from_secs(10);
+const DOH_CALL_TIMEOUT: Duration = Duration::from_secs(12);
+const DOH_CONTENT_TYPE: &str = "application/dns-message";
+
+pub(crate) trait DohTransport: Send + Sync {
+    fn query(
+        &self,
+        endpoint_url: &str,
+        name: &str,
+        qtype: u16,
+    ) -> BoxFuture<Result<Vec<DnsRecord>, FireCoreError>>;
+}
+
+#[derive(Clone)]
+pub(crate) struct OpenWireDohTransport {
+    client: Client,
+}
+
+impl OpenWireDohTransport {
+    pub(crate) fn new() -> Result<Self, FireCoreError> {
+        let mut builder = Client::builder()
+            .dns_resolver(BootstrapDnsResolver)
+            .connect_timeout(DOH_CONNECT_TIMEOUT)
+            .call_timeout(DOH_CALL_TIMEOUT);
+        builder = crate::core::apply_platform_tls(builder);
+        let client = builder
+            .build()
+            .map_err(|source| FireCoreError::ClientBuild { source })?;
+        Ok(Self { client })
+    }
+}
+
+impl DohTransport for OpenWireDohTransport {
+    fn query(
+        &self,
+        endpoint_url: &str,
+        name: &str,
+        qtype: u16,
+    ) -> BoxFuture<Result<Vec<DnsRecord>, FireCoreError>> {
+        let client = self.client.clone();
+        let endpoint_url = endpoint_url.to_string();
+        let name = name.to_string();
+        Box::pin(async move {
+            let endpoint = normalize_doh_endpoint_url(&endpoint_url).map_err(|error| {
+                FireCoreError::InvalidArgument {
+                    operation: "doh query",
+                    details: error.to_string(),
+                }
+            })?;
+            let query = encode_query(next_query_id(), &name, qtype).map_err(|error| {
+                FireCoreError::InvalidArgument {
+                    operation: "doh query",
+                    details: error.to_string(),
+                }
+            })?;
+            let request = Request::builder()
+                .method(Method::POST)
+                .uri(&endpoint)
+                .header(CONTENT_TYPE, DOH_CONTENT_TYPE)
+                .header(http::header::ACCEPT, DOH_CONTENT_TYPE)
+                .body(RequestBody::from_bytes(Bytes::from(query)))
+                .map_err(FireCoreError::RequestBuild)?;
+            let response = client
+                .execute(request)
+                .await
+                .map_err(|source| FireCoreError::Network { source })?;
+            let status = response.status();
+            let body = response
+                .into_body()
+                .bytes()
+                .await
+                .map_err(|source| FireCoreError::Network { source })?;
+            if !status.is_success() {
+                return Err(FireCoreError::HttpStatus {
+                    operation: "doh query",
+                    status: status.as_u16(),
+                    body: String::from_utf8_lossy(&body).into_owned(),
+                });
+            }
+            decode_addresses(&body, qtype).map_err(|error| FireCoreError::InvalidArgument {
+                operation: "doh query",
+                details: error.to_string(),
+            })
+        })
+    }
+}
+
+#[derive(Clone, Debug, Default)]
+struct BootstrapDnsResolver;
+
+impl DnsResolver for BootstrapDnsResolver {
+    fn resolve(
+        &self,
+        ctx: CallContext,
+        host: String,
+        port: u16,
+    ) -> BoxFuture<Result<Vec<SocketAddr>, WireError>> {
+        Box::pin(async move {
+            ctx.listener().dns_start(&ctx, &host, port);
+            match resolve_bootstrap_host(&host, port).await {
+                Ok(addrs) => {
+                    ctx.listener().dns_end(&ctx, &host, &addrs);
+                    Ok(addrs)
+                }
+                Err(error) => {
+                    ctx.listener().dns_failed(&ctx, &host, &error);
+                    Err(error)
+                }
+            }
+        })
+    }
+}
+
+async fn resolve_bootstrap_host(host: &str, port: u16) -> Result<Vec<SocketAddr>, WireError> {
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return Ok(vec![SocketAddr::new(ip, port)]);
+    }
+    if let Some(preset) = DohPreset::by_host(host) {
+        let addrs: Vec<SocketAddr> = preset
+            .bootstrap_ips
+            .iter()
+            .filter_map(|ip| ip.parse::<IpAddr>().ok())
+            .map(|ip| SocketAddr::new(ip, port))
+            .collect();
+        if !addrs.is_empty() {
+            return Ok(addrs);
+        }
+    }
+    system_lookup(host, port).await
+}
+
+pub(crate) async fn system_lookup(host: &str, port: u16) -> Result<Vec<SocketAddr>, WireError> {
+    match tokio::net::lookup_host((host, port)).await {
+        Ok(addrs) => {
+            let addrs: Vec<_> = addrs.collect();
+            if addrs.is_empty() {
+                Err(WireError::dns(
+                    "DNS resolution returned no socket addresses",
+                    io::Error::new(io::ErrorKind::NotFound, "empty DNS result"),
+                ))
+            } else {
+                Ok(addrs)
+            }
+        }
+        Err(error) => Err(WireError::dns("DNS resolution failed", error)),
+    }
+}
+
+fn next_query_id() -> u16 {
+    use std::sync::atomic::{AtomicU16, Ordering};
+    static NEXT: AtomicU16 = AtomicU16::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+pub(crate) fn endpoint_host(endpoint_url: &str) -> Option<String> {
+    Url::parse(endpoint_url)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_ascii_lowercase))
+}
+
+#[cfg(test)]
+type FakeDohHandler = std::sync::Arc<
+    dyn Fn(String, String, u16) -> Result<Vec<DnsRecord>, FireCoreError> + Send + Sync,
+>;
+
+#[cfg(test)]
+#[derive(Clone)]
+pub(crate) struct FakeDohTransport {
+    handler: FakeDohHandler,
+}
+
+#[cfg(test)]
+impl FakeDohTransport {
+    pub(crate) fn new(
+        handler: impl Fn(String, String, u16) -> Result<Vec<DnsRecord>, FireCoreError>
+            + Send
+            + Sync
+            + 'static,
+    ) -> Self {
+        Self {
+            handler: std::sync::Arc::new(handler),
+        }
+    }
+}
+
+#[cfg(test)]
+impl DohTransport for FakeDohTransport {
+    fn query(
+        &self,
+        endpoint_url: &str,
+        name: &str,
+        qtype: u16,
+    ) -> BoxFuture<Result<Vec<DnsRecord>, FireCoreError>> {
+        let result = (self.handler)(endpoint_url.to_string(), name.to_string(), qtype);
+        Box::pin(async move { result })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn bootstrap_uses_preset_ips() {
+        let addrs = resolve_bootstrap_host("dns.alidns.com", 443)
+            .await
+            .expect("bootstrap");
+        let ips: Vec<_> = addrs.into_iter().map(|addr| addr.ip()).collect();
+        assert!(ips.contains(&"223.5.5.5".parse().unwrap()));
+        assert!(ips.contains(&"223.6.6.6".parse().unwrap()));
+    }
+
+    #[tokio::test]
+    async fn bootstrap_accepts_ip_literal() {
+        let addrs = resolve_bootstrap_host("1.1.1.1", 443)
+            .await
+            .expect("ip literal");
+        assert_eq!(addrs, vec!["1.1.1.1:443".parse().unwrap()]);
+    }
+}

--- a/rust/crates/fire-core/src/doh/wire.rs
+++ b/rust/crates/fire-core/src/doh/wire.rs
@@ -1,0 +1,248 @@
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+
+use thiserror::Error;
+
+pub const QTYPE_A: u16 = 1;
+pub const QTYPE_AAAA: u16 = 28;
+const QCLASS_IN: u16 = 1;
+const DNS_HEADER_LEN: usize = 12;
+const MAX_NAME_HOPS: usize = 10;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+pub enum DnsWireError {
+    #[error("DNS name is empty")]
+    EmptyName,
+    #[error("DNS name label is too long")]
+    LabelTooLong,
+    #[error("DNS message is truncated")]
+    Truncated,
+    #[error("DNS message contains an invalid compression pointer")]
+    BadPointer,
+    #[error("DNS name is too long")]
+    NameTooLong,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DnsRecord {
+    pub address: IpAddr,
+    pub ttl_secs: u32,
+}
+
+pub fn encode_query(id: u16, name: &str, qtype: u16) -> Result<Vec<u8>, DnsWireError> {
+    let mut message = Vec::with_capacity(64);
+    message.extend_from_slice(&id.to_be_bytes());
+    message.extend_from_slice(&0x0100u16.to_be_bytes()); // RD
+    message.extend_from_slice(&1u16.to_be_bytes()); // QDCOUNT
+    message.extend_from_slice(&0u16.to_be_bytes()); // ANCOUNT
+    message.extend_from_slice(&0u16.to_be_bytes()); // NSCOUNT
+    message.extend_from_slice(&0u16.to_be_bytes()); // ARCOUNT
+    encode_name(name, &mut message)?;
+    message.extend_from_slice(&qtype.to_be_bytes());
+    message.extend_from_slice(&QCLASS_IN.to_be_bytes());
+    Ok(message)
+}
+
+pub fn decode_addresses(message: &[u8], qtype: u16) -> Result<Vec<DnsRecord>, DnsWireError> {
+    if message.len() < DNS_HEADER_LEN {
+        return Err(DnsWireError::Truncated);
+    }
+    let qdcount = u16::from_be_bytes([message[4], message[5]]) as usize;
+    let ancount = u16::from_be_bytes([message[6], message[7]]) as usize;
+    let mut offset = DNS_HEADER_LEN;
+    for _ in 0..qdcount {
+        skip_name(message, &mut offset)?;
+        offset = offset
+            .checked_add(4)
+            .filter(|value| *value <= message.len())
+            .ok_or(DnsWireError::Truncated)?;
+    }
+
+    let mut records = Vec::new();
+    for _ in 0..ancount {
+        skip_name(message, &mut offset)?;
+        if offset + 10 > message.len() {
+            return Err(DnsWireError::Truncated);
+        }
+        let rtype = u16::from_be_bytes([message[offset], message[offset + 1]]);
+        let _rclass = u16::from_be_bytes([message[offset + 2], message[offset + 3]]);
+        let ttl = u32::from_be_bytes([
+            message[offset + 4],
+            message[offset + 5],
+            message[offset + 6],
+            message[offset + 7],
+        ]);
+        let rdlength = u16::from_be_bytes([message[offset + 8], message[offset + 9]]) as usize;
+        offset += 10;
+        if offset + rdlength > message.len() {
+            return Err(DnsWireError::Truncated);
+        }
+        let rdata = &message[offset..offset + rdlength];
+        offset += rdlength;
+        if rtype != qtype {
+            continue;
+        }
+        match (qtype, rdlength) {
+            (QTYPE_A, 4) => records.push(DnsRecord {
+                address: IpAddr::V4(Ipv4Addr::new(rdata[0], rdata[1], rdata[2], rdata[3])),
+                ttl_secs: ttl,
+            }),
+            (QTYPE_AAAA, 16) => {
+                let mut octets = [0u8; 16];
+                octets.copy_from_slice(rdata);
+                records.push(DnsRecord {
+                    address: IpAddr::V6(Ipv6Addr::from(octets)),
+                    ttl_secs: ttl,
+                });
+            }
+            _ => {}
+        }
+    }
+    Ok(records)
+}
+
+fn encode_name(name: &str, out: &mut Vec<u8>) -> Result<(), DnsWireError> {
+    let trimmed = name.trim().trim_end_matches('.');
+    if trimmed.is_empty() {
+        return Err(DnsWireError::EmptyName);
+    }
+    let start_len = out.len();
+    for label in trimmed.split('.') {
+        if label.is_empty() {
+            return Err(DnsWireError::EmptyName);
+        }
+        if label.len() > 63 {
+            return Err(DnsWireError::LabelTooLong);
+        }
+        out.push(label.len() as u8);
+        out.extend_from_slice(label.as_bytes());
+        if out.len() - start_len > 253 {
+            return Err(DnsWireError::NameTooLong);
+        }
+    }
+    out.push(0);
+    Ok(())
+}
+
+fn skip_name(message: &[u8], offset: &mut usize) -> Result<(), DnsWireError> {
+    let mut hops = 0;
+    let mut jumped = false;
+    let mut cursor = *offset;
+    loop {
+        if hops > MAX_NAME_HOPS {
+            return Err(DnsWireError::BadPointer);
+        }
+        if cursor >= message.len() {
+            return Err(DnsWireError::Truncated);
+        }
+        let len = message[cursor];
+        if len & 0xC0 == 0xC0 {
+            if cursor + 1 >= message.len() {
+                return Err(DnsWireError::Truncated);
+            }
+            let pointer = (((len as usize) & 0x3F) << 8) | message[cursor + 1] as usize;
+            if pointer >= message.len() {
+                return Err(DnsWireError::BadPointer);
+            }
+            if !jumped {
+                *offset = cursor + 2;
+                jumped = true;
+            }
+            cursor = pointer;
+            hops += 1;
+            continue;
+        }
+        if len & 0xC0 != 0 {
+            return Err(DnsWireError::BadPointer);
+        }
+        cursor += 1 + len as usize;
+        if !jumped {
+            *offset = cursor;
+        }
+        if len == 0 {
+            if !jumped {
+                *offset = cursor;
+            }
+            return Ok(());
+        }
+        hops += 1;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn encode_query_linux_do_a() {
+        let message = encode_query(0x1234, "linux.do", QTYPE_A).unwrap();
+        assert_eq!(&message[0..2], &[0x12, 0x34]);
+        assert_eq!(&message[4..6], &[0x00, 0x01]);
+        assert_eq!(
+            &message[12..],
+            &[5, b'l', b'i', b'n', b'u', b'x', 2, b'd', b'o', 0, 0, 1, 0, 1]
+        );
+    }
+
+    #[test]
+    fn decode_a_record_with_compression() {
+        // Query for example.com + one A answer that compresses the name.
+        let mut message = encode_query(1, "example.com", QTYPE_A).unwrap();
+        // ANCOUNT = 1
+        message[7] = 1;
+        message.extend_from_slice(&[
+            0xC0, 0x0C, // pointer to offset 12 (example.com)
+            0x00, 0x01, // A
+            0x00, 0x01, // IN
+            0x00, 0x00, 0x00, 60, // TTL 60
+            0x00, 0x04, // RDLENGTH
+            93, 184, 216, 34,
+        ]);
+        let records = decode_addresses(&message, QTYPE_A).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(
+            records[0].address,
+            IpAddr::V4(Ipv4Addr::new(93, 184, 216, 34))
+        );
+        assert_eq!(records[0].ttl_secs, 60);
+    }
+
+    #[test]
+    fn decode_aaaa_record() {
+        let mut message = encode_query(7, "ipv6.example", QTYPE_AAAA).unwrap();
+        message[7] = 1;
+        let name_pointer_offset = 12u16;
+        message.extend_from_slice(&[
+            0xC0,
+            name_pointer_offset as u8,
+            0x00,
+            0x1C,
+            0x00,
+            0x01,
+            0x00,
+            0x00,
+            0x01,
+            0x2C,
+            0x00,
+            0x10,
+        ]);
+        message.extend_from_slice(&[0u8; 15]);
+        message.push(1);
+        let records = decode_addresses(&message, QTYPE_AAAA).unwrap();
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].ttl_secs, 300);
+        assert_eq!(
+            records[0].address,
+            IpAddr::V6(Ipv6Addr::from([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1
+            ]))
+        );
+    }
+
+    #[test]
+    fn encode_rejects_empty_name() {
+        assert_eq!(
+            encode_query(1, "", QTYPE_A).unwrap_err(),
+            DnsWireError::EmptyName
+        );
+    }
+}

--- a/rust/crates/fire-core/src/lib.rs
+++ b/rust/crates/fire-core/src/lib.rs
@@ -5,6 +5,7 @@ mod cookies;
 mod core;
 mod creation_payloads;
 mod diagnostics;
+mod doh;
 mod error;
 mod json_helpers;
 mod ldc_payloads;
@@ -32,8 +33,10 @@ pub use diagnostics::{
     NetworkTraceBodyPage, NetworkTraceDetail, NetworkTraceEvent, NetworkTraceHeader,
     NetworkTraceOutcome, NetworkTraceSummary,
 };
+pub use doh::{FireDohController, FireDohResolver};
 pub use error::{CloudflareChallengeFailureReason, FireCoreError};
 pub use fire_models::LoginFinalizationResult;
+pub use fire_models::{DohPreset, DohProbeResult, DohSettings};
 pub use logging::{FireHostLogLevel, FireLogger, FireLoggerConfig};
 pub use presentation::{
     monogram_for_username, plain_text_from_html, preview_text_from_html, topic_status_labels,

--- a/rust/crates/fire-models/src/doh.rs
+++ b/rust/crates/fire-models/src/doh.rs
@@ -1,0 +1,226 @@
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+pub const DEFAULT_DOH_ENDPOINT_URL: &str = "https://dns.alidns.com/dns-query";
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DohSettings {
+    pub enabled: bool,
+    pub endpoint_url: String,
+}
+
+impl Default for DohSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            endpoint_url: DEFAULT_DOH_ENDPOINT_URL.to_string(),
+        }
+    }
+}
+
+impl DohSettings {
+    pub fn normalize(self) -> Result<Self, DohSettingsError> {
+        Ok(Self {
+            enabled: self.enabled,
+            endpoint_url: normalize_doh_endpoint_url(&self.endpoint_url)?,
+        })
+    }
+
+    pub fn matching_preset(&self) -> Option<&'static DohPreset> {
+        DohPreset::all()
+            .iter()
+            .find(|preset| preset.endpoint_url == self.endpoint_url)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DohPreset {
+    pub id: &'static str,
+    pub display_name: &'static str,
+    pub endpoint_url: &'static str,
+    pub bootstrap_ips: &'static [&'static str],
+}
+
+impl DohPreset {
+    pub const fn all() -> &'static [DohPreset] {
+        &DOH_PRESETS
+    }
+
+    pub fn by_id(id: &str) -> Option<&'static DohPreset> {
+        Self::all().iter().find(|preset| preset.id == id)
+    }
+
+    pub fn by_endpoint_url(url: &str) -> Option<&'static DohPreset> {
+        Self::all().iter().find(|preset| preset.endpoint_url == url)
+    }
+
+    pub fn by_host(host: &str) -> Option<&'static DohPreset> {
+        let host = host.trim().trim_end_matches('.').to_ascii_lowercase();
+        Self::all().iter().find(|preset| {
+            Url::parse(preset.endpoint_url)
+                .ok()
+                .and_then(|url| url.host_str().map(str::to_ascii_lowercase))
+                .is_some_and(|preset_host| preset_host == host)
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DohProbeResult {
+    pub ok: bool,
+    pub host: String,
+    pub resolved_addresses: Vec<String>,
+    pub elapsed_ms: u64,
+    pub error_message: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DohSettingsError {
+    EmptyUrl,
+    InvalidUrl(String),
+    UnsupportedScheme(String),
+    MissingHost,
+}
+
+impl std::fmt::Display for DohSettingsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::EmptyUrl => f.write_str("DoH URL is empty"),
+            Self::InvalidUrl(value) => write!(f, "invalid DoH URL: {value}"),
+            Self::UnsupportedScheme(scheme) => {
+                write!(f, "DoH URL must use https, got {scheme}")
+            }
+            Self::MissingHost => f.write_str("DoH URL is missing a host"),
+        }
+    }
+}
+
+impl std::error::Error for DohSettingsError {}
+
+pub fn normalize_doh_endpoint_url(raw: &str) -> Result<String, DohSettingsError> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return Err(DohSettingsError::EmptyUrl);
+    }
+    let mut url = Url::parse(trimmed)
+        .map_err(|error| DohSettingsError::InvalidUrl(format!("{trimmed}: {error}")))?;
+    if url.scheme() != "https" {
+        return Err(DohSettingsError::UnsupportedScheme(
+            url.scheme().to_string(),
+        ));
+    }
+    if url.host_str().is_none() {
+        return Err(DohSettingsError::MissingHost);
+    }
+    if url.username() != "" || url.password().is_some() {
+        return Err(DohSettingsError::InvalidUrl(
+            "DoH URL must not include credentials".to_string(),
+        ));
+    }
+    url.set_fragment(None);
+    if url.path().is_empty() || url.path() == "/" {
+        url.set_path("/dns-query");
+    }
+    Ok(url.to_string())
+}
+
+const DOH_PRESETS: [DohPreset; 7] = [
+    DohPreset {
+        id: "alidns",
+        display_name: "阿里 DNS",
+        endpoint_url: DEFAULT_DOH_ENDPOINT_URL,
+        bootstrap_ips: &["223.5.5.5", "223.6.6.6"],
+    },
+    DohPreset {
+        id: "dnspod",
+        display_name: "DNSPod",
+        endpoint_url: "https://doh.pub/dns-query",
+        bootstrap_ips: &["1.12.12.12", "120.53.53.53"],
+    },
+    DohPreset {
+        id: "tencent",
+        display_name: "腾讯 DNS",
+        endpoint_url: "https://dns.pub/dns-query",
+        bootstrap_ips: &["1.12.12.12"],
+    },
+    DohPreset {
+        id: "cloudflare",
+        display_name: "Cloudflare",
+        endpoint_url: "https://cloudflare-dns.com/dns-query",
+        bootstrap_ips: &["1.1.1.1", "1.0.0.1"],
+    },
+    DohPreset {
+        id: "google",
+        display_name: "Google",
+        endpoint_url: "https://dns.google/dns-query",
+        bootstrap_ips: &["8.8.8.8", "8.8.4.4"],
+    },
+    DohPreset {
+        id: "quad9",
+        display_name: "Quad9",
+        endpoint_url: "https://dns.quad9.net/dns-query",
+        bootstrap_ips: &["9.9.9.9", "149.112.112.112"],
+    },
+    DohPreset {
+        id: "cira",
+        display_name: "Canadian Shield",
+        endpoint_url: "https://private.canadianshield.cira.ca/dns-query",
+        bootstrap_ips: &[],
+    },
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_settings_are_disabled_with_alidns() {
+        let settings = DohSettings::default();
+        assert!(!settings.enabled);
+        assert_eq!(settings.endpoint_url, DEFAULT_DOH_ENDPOINT_URL);
+        assert_eq!(
+            settings.matching_preset().map(|preset| preset.id),
+            Some("alidns")
+        );
+    }
+
+    #[test]
+    fn normalize_fills_default_path() {
+        assert_eq!(
+            normalize_doh_endpoint_url("https://dns.alidns.com").unwrap(),
+            "https://dns.alidns.com/dns-query"
+        );
+        assert_eq!(
+            normalize_doh_endpoint_url("https://dns.google/dns-query").unwrap(),
+            "https://dns.google/dns-query"
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_http_and_empty() {
+        assert!(matches!(
+            normalize_doh_endpoint_url("http://dns.alidns.com/dns-query"),
+            Err(DohSettingsError::UnsupportedScheme(_))
+        ));
+        assert_eq!(
+            normalize_doh_endpoint_url("   ").unwrap_err(),
+            DohSettingsError::EmptyUrl
+        );
+    }
+
+    #[test]
+    fn normalize_rejects_credentials() {
+        assert!(matches!(
+            normalize_doh_endpoint_url("https://user:pass@dns.alidns.com/dns-query"),
+            Err(DohSettingsError::InvalidUrl(_))
+        ));
+    }
+
+    #[test]
+    fn presets_have_unique_ids() {
+        let mut ids: Vec<_> = DohPreset::all().iter().map(|preset| preset.id).collect();
+        ids.sort_unstable();
+        ids.dedup();
+        assert_eq!(ids.len(), DohPreset::all().len());
+    }
+}

--- a/rust/crates/fire-models/src/lib.rs
+++ b/rust/crates/fire-models/src/lib.rs
@@ -1,5 +1,6 @@
 mod chat;
 mod cookie;
+mod doh;
 mod ldc;
 mod messagebus;
 mod notification;
@@ -12,6 +13,7 @@ mod user;
 
 pub use chat::*;
 pub use cookie::*;
+pub use doh::*;
 pub use ldc::*;
 pub use messagebus::*;
 pub use notification::*;

--- a/rust/crates/fire-uniffi-session/src/lib.rs
+++ b/rust/crates/fire-uniffi-session/src/lib.rs
@@ -16,7 +16,8 @@ pub use records::{
     CookieReplayEntryState, CookieSameSiteState, CookieSelfHealingHandler,
     CookieSelfHealingPhaseState, CookieSelfHealingRequestState, CookieSelfHealingResultState,
     CookieSourceState, CookieState, CookieSweepIntentState, CookieSweepPlanState,
-    CurrentUserSnapshotState, HomeTopicListScopeState, LoginFailureKindState, LoginFailureState,
+    CurrentUserSnapshotState, DohPresetState, DohProbeResultState, DohSettingsState,
+    HomeTopicListScopeState, LoginFailureKindState, LoginFailureState,
     LoginFinalizationResultState, LoginPhaseState, LoginStateDeterminationState, LoginSyncState,
     NuclearResetPlanState, PassiveLogoutTriggerState, PlatformCookieState, PreloadedDataStateState,
     RefreshBatchState, RefreshTriggerState, SecondFactorRequirementState, SessionPersistenceState,
@@ -792,5 +793,55 @@ impl FireSessionHandle {
             },
         )
         .await
+    }
+
+    pub fn list_doh_presets(&self) -> Result<Vec<DohPresetState>, FireUniFfiError> {
+        run_infallible(
+            &self.shared.panic_state,
+            &self.shared.core,
+            "list_doh_presets",
+            |inner| {
+                inner
+                    .list_doh_presets()
+                    .iter()
+                    .map(DohPresetState::from)
+                    .collect()
+            },
+        )
+    }
+
+    pub fn get_doh_settings(&self) -> Result<DohSettingsState, FireUniFfiError> {
+        run_infallible(
+            &self.shared.panic_state,
+            &self.shared.core,
+            "get_doh_settings",
+            |inner| inner.doh_settings().into(),
+        )
+    }
+
+    pub fn set_doh_settings(
+        &self,
+        settings: DohSettingsState,
+    ) -> Result<DohSettingsState, FireUniFfiError> {
+        run_fallible(
+            &self.shared.panic_state,
+            &self.shared.core,
+            "set_doh_settings",
+            move |inner| inner.set_doh_settings(settings.into()).map(Into::into),
+        )
+    }
+
+    pub async fn probe_doh_settings(
+        &self,
+        settings: DohSettingsState,
+        host: Option<String>,
+    ) -> Result<DohProbeResultState, FireUniFfiError> {
+        let inner = self.shared.core.clone();
+        let panic_state = self.shared.panic_state.clone();
+        let result = run_on_ffi_runtime("probe_doh_settings", panic_state, async move {
+            inner.probe_doh_settings(settings.into(), host).await
+        })
+        .await?;
+        Ok(result.into())
     }
 }

--- a/rust/crates/fire-uniffi-session/src/records.rs
+++ b/rust/crates/fire-uniffi-session/src/records.rs
@@ -6,11 +6,11 @@ use fire_models::{
     AppStateRefreshEvent, BootstrapArtifacts, CanonicalCookie, CloudflareChallengeRequest,
     CloudflareChallengeResult, CookieSameSite, CookieSelfHealingPhase, CookieSelfHealingRequest,
     CookieSelfHealingResult, CookieSnapshot, CookieSource, CookieSweepIntent, CookieSweepPlan,
-    HomeTopicListScope, LoginFailure, LoginFailureKind, LoginFinalizationResult, LoginPhase,
-    LoginSyncInput, NuclearResetPlan, PassiveLogoutTrigger, PlatformCookie, ProbeResult,
-    RefreshBatch, SecondFactorRequirement, SessionReadiness, SessionSnapshot, SignalStrength,
-    TopicCategory, WebViewCookieAction, WebViewCookieInfo, WebViewLoginDecision,
-    WebViewLoginJsResult, WebViewLoginPhase,
+    DohPreset, DohProbeResult, DohSettings, HomeTopicListScope, LoginFailure, LoginFailureKind,
+    LoginFinalizationResult, LoginPhase, LoginSyncInput, NuclearResetPlan, PassiveLogoutTrigger,
+    PlatformCookie, ProbeResult, RefreshBatch, SecondFactorRequirement, SessionReadiness,
+    SessionSnapshot, SignalStrength, TopicCategory, WebViewCookieAction, WebViewCookieInfo,
+    WebViewLoginDecision, WebViewLoginJsResult, WebViewLoginPhase,
 };
 use fire_store::cookie_replay::CookieReplayEntry;
 
@@ -1192,4 +1192,72 @@ pub trait CloudflareClearanceResolvedHandler: Send + Sync {
 #[uniffi::export(with_foreign)]
 pub trait CookieSelfHealingHandler: Send + Sync {
     fn heal_cookies(&self, request: CookieSelfHealingRequestState) -> CookieSelfHealingResultState;
+}
+
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct DohSettingsState {
+    pub enabled: bool,
+    pub endpoint_url: String,
+}
+
+impl From<DohSettings> for DohSettingsState {
+    fn from(value: DohSettings) -> Self {
+        Self {
+            enabled: value.enabled,
+            endpoint_url: value.endpoint_url,
+        }
+    }
+}
+
+impl From<DohSettingsState> for DohSettings {
+    fn from(value: DohSettingsState) -> Self {
+        Self {
+            enabled: value.enabled,
+            endpoint_url: value.endpoint_url,
+        }
+    }
+}
+
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct DohPresetState {
+    pub id: String,
+    pub display_name: String,
+    pub endpoint_url: String,
+    pub bootstrap_ips: Vec<String>,
+}
+
+impl From<&DohPreset> for DohPresetState {
+    fn from(value: &DohPreset) -> Self {
+        Self {
+            id: value.id.to_string(),
+            display_name: value.display_name.to_string(),
+            endpoint_url: value.endpoint_url.to_string(),
+            bootstrap_ips: value
+                .bootstrap_ips
+                .iter()
+                .map(|ip| (*ip).to_string())
+                .collect(),
+        }
+    }
+}
+
+#[derive(uniffi::Record, Debug, Clone)]
+pub struct DohProbeResultState {
+    pub ok: bool,
+    pub host: String,
+    pub resolved_addresses: Vec<String>,
+    pub elapsed_ms: u64,
+    pub error_message: Option<String>,
+}
+
+impl From<DohProbeResult> for DohProbeResultState {
+    fn from(value: DohProbeResult) -> Self {
+        Self {
+            ok: value.ok,
+            host: value.host,
+            resolved_addresses: value.resolved_addresses,
+            elapsed_ms: value.elapsed_ms,
+            error_message: value.error_message,
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- Add a user-configurable DNS over HTTPS resolver on the openwire path so API and MessageBus lookups can bypass poisoned system DNS. Settings are opt-in (default off), persist in the workspace, and apply without rebuilding the HTTP client. iOS Settings and a new Android Settings screen expose presets, a custom HTTPS URL, and a probe action.
- Present iOS chat conversations on the same fullscreen secondary stack as topic detail (covers the tab bar, root page can swipe away). The chat tab remains the channel list. Android conversations were already a separate activity.

## DoH notes

- Authoritative path is `FireDohResolver` plugged into `Client::builder().dns_resolver(...)`.
- DoH failures stay `WireErrorKind::Dns` and do **not** fall back to system DNS for business hostnames.
- WebView login, Cloudflare challenge, and image loaders still use system DNS.

## Test plan

- [x] `cargo fmt --all --check` equivalent: `cargo fmt --all` then clippy/tests
- [x] `cargo clippy --keep-going -p fire-models -p fire-core -p fire-uniffi --all-targets --no-deps -- -D warnings`
- [x] `cargo test -p fire-models -p fire-core -p fire-uniffi --all-targets`
- [ ] iOS: Settings → DNS over HTTPS toggle, pick AliDNS, tap 测试连接
- [ ] iOS: Chat tab → open a DM and confirm tab bar is covered; swipe back to list
- [ ] Android: Profile → 设置, same DoH flow
- [ ] Android: Chat conversation still opens as its own activity