### PR TITLE
fix(android): sign release APK/AAB with GitHub upload keystore secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -363,6 +363,23 @@ jobs:
           ANDROID_NDK_VERSION: ${{ env.ANDROID_NDK_VERSION }}
         run: ./gradlew clean testDebugUnitTest assembleDebug
 
+  android-release-signing:
+    name: Android Release Signing
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+      - uses: actions/setup-java@v5
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Prepare Android release keystore
+        env:
+          FIRE_ANDROID_KEYSTORE_BASE64: ${{ secrets.FIRE_ANDROID_KEYSTORE_BASE64 }}
+          FIRE_ANDROID_STORE_PASSWORD: ${{ secrets.FIRE_ANDROID_STORE_PASSWORD }}
+          FIRE_ANDROID_KEY_ALIAS: ${{ secrets.FIRE_ANDROID_KEY_ALIAS }}
+          FIRE_ANDROID_KEY_PASSWORD: ${{ secrets.FIRE_ANDROID_KEY_PASSWORD }}
+        run: ./scripts/android/prepare_release_keystore.sh
+
   # ──────────────────────────────────────────────
   #  Native release builds (push only, use pre-built Rust)
   # ──────────────────────────────────────────────
@@ -490,6 +507,14 @@ jobs:
           name: android-rust-libs
           path: rust/target
 
+      - name: Prepare Android release keystore
+        env:
+          FIRE_ANDROID_KEYSTORE_BASE64: ${{ secrets.FIRE_ANDROID_KEYSTORE_BASE64 }}
+          FIRE_ANDROID_STORE_PASSWORD: ${{ secrets.FIRE_ANDROID_STORE_PASSWORD }}
+          FIRE_ANDROID_KEY_ALIAS: ${{ secrets.FIRE_ANDROID_KEY_ALIAS }}
+          FIRE_ANDROID_KEY_PASSWORD: ${{ secrets.FIRE_ANDROID_KEY_PASSWORD }}
+        run: ./scripts/android/prepare_release_keystore.sh
+
       - name: Run Android release build
         working-directory: native/android-app
         env:
@@ -497,4 +522,14 @@ jobs:
           ANDROID_SDK_ROOT: ${{ env.ANDROID_SDK_ROOT }}
           ANDROID_NDK_VERSION: ${{ env.ANDROID_NDK_VERSION }}
           FIRE_SKIP_RUST_CROSS_BUILD: "1"
-        run: ./gradlew assembleRelease
+          FIRE_ANDROID_STORE_PASSWORD: ${{ secrets.FIRE_ANDROID_STORE_PASSWORD }}
+          FIRE_ANDROID_KEY_ALIAS: ${{ secrets.FIRE_ANDROID_KEY_ALIAS }}
+          FIRE_ANDROID_KEY_PASSWORD: ${{ secrets.FIRE_ANDROID_KEY_PASSWORD }}
+          FIRE_ANDROID_REQUIRE_SIGNING: "1"
+        run: ./gradlew printReleaseSigningStatus assembleRelease
+
+      - name: Verify signed Android release APK
+        env:
+          ANDROID_HOME: ${{ env.ANDROID_SDK_ROOT }}
+          ANDROID_SDK_ROOT: ${{ env.ANDROID_SDK_ROOT }}
+        run: ./scripts/android/verify_release_apk.sh

--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -3,7 +3,7 @@ name: GitHub Release
 # Tag-driven release packaging for GitHub Release assets.
 # This does NOT upload to TestFlight/Play automatically — use ios-testflight.yml
 # / play-console flows for store tracks. Artifacts here are for GH Releases:
-# iOS xcarchive + dSYMs (unsigned by default) and Android release APK.
+# iOS xcarchive + dSYMs (unsigned by default) and a signed Android release APK/AAB.
 
 on:
   push:
@@ -191,13 +191,31 @@ jobs:
           workspaces: |
             . -> rust/target
 
-      - name: Assemble Android release APK
+      - name: Prepare Android release keystore
+        env:
+          FIRE_ANDROID_KEYSTORE_BASE64: ${{ secrets.FIRE_ANDROID_KEYSTORE_BASE64 }}
+          FIRE_ANDROID_STORE_PASSWORD: ${{ secrets.FIRE_ANDROID_STORE_PASSWORD }}
+          FIRE_ANDROID_KEY_ALIAS: ${{ secrets.FIRE_ANDROID_KEY_ALIAS }}
+          FIRE_ANDROID_KEY_PASSWORD: ${{ secrets.FIRE_ANDROID_KEY_PASSWORD }}
+        run: ./scripts/android/prepare_release_keystore.sh
+
+      - name: Assemble signed Android release APK and bundle
         working-directory: native/android-app
         env:
           ANDROID_HOME: ${{ env.ANDROID_SDK_ROOT }}
           ANDROID_SDK_ROOT: ${{ env.ANDROID_SDK_ROOT }}
           ANDROID_NDK_VERSION: ${{ env.ANDROID_NDK_VERSION }}
-        run: ./gradlew assembleRelease
+          FIRE_ANDROID_STORE_PASSWORD: ${{ secrets.FIRE_ANDROID_STORE_PASSWORD }}
+          FIRE_ANDROID_KEY_ALIAS: ${{ secrets.FIRE_ANDROID_KEY_ALIAS }}
+          FIRE_ANDROID_KEY_PASSWORD: ${{ secrets.FIRE_ANDROID_KEY_PASSWORD }}
+          FIRE_ANDROID_REQUIRE_SIGNING: "1"
+        run: ./gradlew printReleaseSigningStatus assembleRelease bundleRelease
+
+      - name: Verify signed Android release APK
+        env:
+          ANDROID_HOME: ${{ env.ANDROID_SDK_ROOT }}
+          ANDROID_SDK_ROOT: ${{ env.ANDROID_SDK_ROOT }}
+        run: ./scripts/android/verify_release_apk.sh
 
       - name: Stage Android release bundle
         shell: bash
@@ -220,11 +238,20 @@ jobs:
           if [[ -n "$release_apk" ]]; then
             cp "$release_apk" "$stage/Fire-${{ needs.resolve.outputs.tag }}-release.apk"
           fi
+          release_aab="$(find native/android-app/build/outputs/bundle/release -type f -name '*.aab' | head -n 1 || true)"
+          if [[ -n "$release_aab" ]]; then
+            cp "$release_aab" "$stage/Fire-${{ needs.resolve.outputs.tag }}-release.aab"
+          else
+            echo "No signed AAB produced under native/android-app/build/outputs/bundle/release" >&2
+            find native/android-app/build/outputs -type f | head -100 >&2 || true
+            exit 1
+          fi
           {
             echo "tag=${{ needs.resolve.outputs.tag }}"
             echo "version=${{ needs.resolve.outputs.version }}"
             echo "sha=${GITHUB_SHA}"
             echo "run_id=${GITHUB_RUN_ID}"
+            echo "signed=true"
           } > "$stage/Fire-${{ needs.resolve.outputs.tag }}-android-build-metadata.txt"
           ls -la "$stage"
 
@@ -267,6 +294,7 @@ jobs:
             -name 'Fire-*.xcarchive.zip' -o \
             -name 'Fire-*-dSYMs.zip' -o \
             -name 'Fire-*-release.apk' -o \
+            -name 'Fire-*-release.aab' -o \
             -name 'Fire-*-android-build-metadata.txt' -o \
             -name 'Fire-*-ios-build-metadata.json' -o \
             -name 'Fire-*-*.apk' \
@@ -292,7 +320,7 @@ jobs:
             echo
             echo "### Assets"
             echo "- **iOS**: \`Fire-${TAG}.xcarchive.zip\` + dSYMs (unsigned archive for symbols/debug; not an App Store IPA)"
-            echo "- **Android**: \`Fire-${TAG}-release.apk\` (release build; sign for Play if needed)"
+            echo "- **Android**: signed \`Fire-${TAG}-release.apk\` and \`Fire-${TAG}-release.aab\` (Play upload key)"
             echo
             echo "### Store tracks"
             echo "- TestFlight upload remains the \`iOS TestFlight\` workflow (\`workflow_dispatch\`)"

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,8 @@
 **/DerivedData/
 native/ios-app/Configs/Fire-Local-Debug.xcconfig
 native/ios-app/Configs/Fire-Local-Release.xcconfig
+native/android-app/key.properties
+native/android-app/*.jks
+native/android-app/*.keystore
+native/android-app/*.p12
 fire-support-*.json

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -8,7 +8,7 @@ Pushing a `v*` tag (for example `v0.2.0`) triggers
 `.github/workflows/github-release.yml`, which:
 
 1. Builds an **unsigned iOS** `.xcarchive` + dSYMs via `scripts/ios/archive_release.sh`
-2. Builds an **Android release APK** via `./gradlew assembleRelease`
+2. Builds a **signed Android release APK and AAB** via `./gradlew assembleRelease bundleRelease`
 3. Creates/updates the matching **GitHub Release** and attaches those assets
 
 This is separate from store distribution:
@@ -29,6 +29,7 @@ for an existing tag.
 - `play-store-data-safety.md` - Play Store Data Safety draft
 - `privacy-review-evidence.md` - maintainer/legal review evidence log
 - `testflight-setup.md` - TestFlight setup guide
+- `android-signing.md` - Android upload keystore, GitHub secrets, and signed APK/AAB packaging
 - `play-store-testing-setup.md` - Play Store internal/closed testing guide
 - `internal-testing-evidence.md` - App Store / Play Store testing evidence log
 - `test-feedback-template.md` - tester feedback template

--- a/docs/release/android-signing.md
+++ b/docs/release/android-signing.md
@@ -1,0 +1,52 @@
+# Android Release Signing
+
+Fire's Android release APK/AAB is signed with an upload keystore that lives
+**outside the git tree**. GitHub Actions secrets feed CI and GitHub Release
+packaging. Local machines can point Gradle at the same backup via
+`native/android-app/key.properties`.
+
+## Secrets
+
+| Secret | Purpose |
+| --- | --- |
+| `FIRE_ANDROID_KEYSTORE_BASE64` | PKCS12 keystore bytes, base64-encoded |
+| `FIRE_ANDROID_STORE_PASSWORD` | Keystore password |
+| `FIRE_ANDROID_KEY_ALIAS` | Key alias (`fire`) |
+| `FIRE_ANDROID_KEY_PASSWORD` | Key password |
+
+CI release jobs decode the keystore with
+`scripts/android/prepare_release_keystore.sh`, set
+`FIRE_ANDROID_REQUIRE_SIGNING=1`, then run `assembleRelease` /
+`bundleRelease`. `scripts/android/verify_release_apk.sh` rejects unsigned
+packages.
+
+## Local Backup
+
+The generator writes a private backup to `~/.fire/android/`:
+
+```bash
+scripts/android/generate_release_keystore.sh --set-github-secrets
+```
+
+Keep `~/.fire/android/fire-release.p12` and `key.properties`. Losing this
+keystore after a Play upload blocks updates. Do not commit `.p12`, `.jks`,
+`.keystore`, or `key.properties`.
+
+For a local signed release:
+
+```bash
+cp ~/.fire/android/key.properties native/android-app/key.properties
+native/android-app/gradlew -p native/android-app assembleRelease bundleRelease
+scripts/android/verify_release_apk.sh
+```
+
+`key.properties.example` documents the file shape. Gradle also accepts the
+`FIRE_ANDROID_STORE_FILE`, `FIRE_ANDROID_STORE_PASSWORD`,
+`FIRE_ANDROID_KEY_ALIAS`, and `FIRE_ANDROID_KEY_PASSWORD` environment
+variables.
+
+## Play Console
+
+Upload the signed `.aab` from GitHub Release assets or a local
+`bundleRelease`. The first Play upload of a given application id locks the
+certificate; do not rotate the upload key without Play App Signing enrollment.

--- a/docs/release/play-store-testing-setup.md
+++ b/docs/release/play-store-testing-setup.md
@@ -4,13 +4,14 @@
 
 - Google Play Developer account
 - Play Console access for the Fire app
-- Release signing configured outside the repository
+- Release signing configured outside the repository (see `android-signing.md`)
 - `native/android-app/google-services.json` present if FCM testing is required
 - Play Store listing and data-safety drafts reviewed
 
 ## Build A Release Bundle
 
 ```bash
+cp ~/.fire/android/key.properties native/android-app/key.properties
 cd native/android-app
 ./gradlew bundleRelease
 ```
@@ -20,6 +21,10 @@ Expected output:
 ```text
 native/android-app/build/outputs/bundle/release/app-release.aab
 ```
+
+The GitHub Release workflow also attaches `Fire-<tag>-release.aab`. Unsigned
+bundles are rejected: CI sets `FIRE_ANDROID_REQUIRE_SIGNING=1` and verifies the
+APK with `scripts/android/verify_release_apk.sh`.
 
 ## Play Console Setup
 

--- a/native/android-app/.gitignore
+++ b/native/android-app/.gitignore
@@ -2,3 +2,7 @@
 /build/
 /local.properties
 /google-services.json
+/key.properties
+/*.jks
+/*.keystore
+/*.p12

--- a/native/android-app/README.md
+++ b/native/android-app/README.md
@@ -303,5 +303,9 @@ export ANDROID_SDK_ROOT=/Users/zhangfan/Library/Android/sdk
 ./gradlew assembleDebug
 ```
 
-CI runs debug unit tests and debug/release assembly. Android Rust targets inherit
-the workspace linker settings for Android 15+ 16 KB page-size compatibility.
+CI runs debug unit tests and a **signed** release assembly. Release signing
+uses GitHub secrets `FIRE_ANDROID_*` (see `docs/release/android-signing.md`).
+Local signed builds need `key.properties` from `~/.fire/android/` or the same
+environment variables; `key.properties.example` shows the shape. Android Rust
+targets inherit the workspace linker settings for Android 15+ 16 KB page-size
+compatibility.

--- a/native/android-app/build.gradle.kts
+++ b/native/android-app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.File
+import java.util.Properties
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -53,6 +55,62 @@ val generatedDebugUniffiJniLibsDir = generatedUniffiRootDir.map { it.dir("debug/
 val generatedReleaseUniffiKotlinDir = generatedUniffiRootDir.map { it.dir("release/kotlin") }
 val generatedReleaseUniffiJniLibsDir = generatedUniffiRootDir.map { it.dir("release/jniLibs") }
 
+fun nonBlankEnv(name: String): String? =
+    System.getenv(name)?.trim()?.takeIf { it.isNotEmpty() }
+
+fun Properties.nonBlank(name: String): String? =
+    getProperty(name)?.trim()?.takeIf { it.isNotEmpty() }
+
+fun resolveStoreFile(pathValue: String?): File? {
+    val normalized = pathValue?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+    val directFile = File(normalized)
+    if (directFile.isAbsolute) {
+        return directFile
+    }
+    val candidates = linkedSetOf(
+        file(normalized),
+        rootProject.file(normalized),
+    )
+    return candidates.firstOrNull { it.isFile } ?: candidates.firstOrNull()
+}
+
+fun isTruthyEnv(name: String): Boolean =
+    when (nonBlankEnv(name)?.lowercase()) {
+        "1", "true", "yes", "y", "on" -> true
+        else -> false
+    }
+
+val keystoreProperties = Properties().apply {
+    val keystorePropertiesFile = rootProject.file("key.properties")
+    if (keystorePropertiesFile.isFile) {
+        keystorePropertiesFile.inputStream().use(::load)
+    }
+}
+
+val releaseStoreFilePath = nonBlankEnv("FIRE_ANDROID_STORE_FILE")
+    ?: keystoreProperties.nonBlank("storeFile")
+val releaseStorePassword = nonBlankEnv("FIRE_ANDROID_STORE_PASSWORD")
+    ?: keystoreProperties.nonBlank("storePassword")
+val releaseKeyAlias = nonBlankEnv("FIRE_ANDROID_KEY_ALIAS")
+    ?: keystoreProperties.nonBlank("keyAlias")
+val releaseKeyPassword = nonBlankEnv("FIRE_ANDROID_KEY_PASSWORD")
+    ?: keystoreProperties.nonBlank("keyPassword")
+val releaseStoreFile = resolveStoreFile(releaseStoreFilePath)
+val hasReleaseSigning =
+    releaseStoreFile?.isFile == true &&
+        !releaseStorePassword.isNullOrBlank() &&
+        !releaseKeyAlias.isNullOrBlank() &&
+        !releaseKeyPassword.isNullOrBlank()
+val requireReleaseSigning = isTruthyEnv("FIRE_ANDROID_REQUIRE_SIGNING")
+
+if (requireReleaseSigning && !hasReleaseSigning) {
+    error(
+        "Android release signing is required but incomplete. Set FIRE_ANDROID_STORE_FILE, " +
+            "FIRE_ANDROID_STORE_PASSWORD, FIRE_ANDROID_KEY_ALIAS, and FIRE_ANDROID_KEY_PASSWORD, " +
+            "or provide native/android-app/key.properties from the upload keystore backup.",
+    )
+}
+
 val syncFireUniffiDebugBindings = registerSyncFireUniffiBindingsTask(
     taskName = "syncFireUniffiDebugBindings",
     buildTypeName = "debug",
@@ -76,6 +134,17 @@ android {
         versionName = "0.1.0"
     }
 
+    signingConfigs {
+        if (hasReleaseSigning) {
+            create("release") {
+                storeFile = releaseStoreFile
+                storePassword = releaseStorePassword
+                keyAlias = releaseKeyAlias
+                keyPassword = releaseKeyPassword
+            }
+        }
+    }
+
     buildTypes {
         release {
             isMinifyEnabled = false
@@ -83,6 +152,9 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
+            if (hasReleaseSigning) {
+                signingConfig = signingConfigs.getByName("release")
+            }
         }
     }
 
@@ -122,6 +194,18 @@ tasks.matching { it.name == "preReleaseBuild" }.configureEach {
 
 tasks.matching { it.name == "preReleaseUnitTestBuild" }.configureEach {
     dependsOn(syncFireUniffiReleaseBindings)
+}
+
+tasks.register("printReleaseSigningStatus") {
+    doLast {
+        println("hasReleaseSigning=$hasReleaseSigning")
+        println("requireReleaseSigning=$requireReleaseSigning")
+        println("storeFile=${releaseStoreFile?.absolutePath ?: ""}")
+        println("keyAlias=${releaseKeyAlias ?: ""}")
+        if (requireReleaseSigning && !hasReleaseSigning) {
+            error("Android release signing is required but incomplete")
+        }
+    }
 }
 
 kotlin {

--- a/native/android-app/key.properties.example
+++ b/native/android-app/key.properties.example
@@ -1,0 +1,4 @@
+storeFile=/absolute/path/to/fire-release.p12
+storePassword=
+keyAlias=fire
+keyPassword=

--- a/scripts/android/generate_release_keystore.sh
+++ b/scripts/android/generate_release_keystore.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Generate a PKCS12 upload keystore for Fire Android release builds.
+# Optionally write GitHub Actions secrets. The keystore itself is never committed.
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/android/generate_release_keystore.sh [--set-github-secrets] [--force]
+
+Writes:
+  ~/.fire/android/fire-release.p12
+  ~/.fire/android/key.properties
+  ~/.fire/android/README.txt
+
+Options:
+  --set-github-secrets  Upload FIRE_ANDROID_* secrets with `gh secret set`
+  --force               Overwrite an existing local keystore
+EOF
+}
+
+set_github_secrets=0
+force=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --set-github-secrets) set_github_secrets=1 ;;
+    --force) force=1 ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ -z "${JAVA_HOME:-}" && -x /usr/libexec/java_home ]]; then
+  JAVA_HOME="$(/usr/libexec/java_home -v 17 2>/dev/null || /usr/libexec/java_home)"
+  export JAVA_HOME
+fi
+if [[ -x "${JAVA_HOME:-}/bin/keytool" ]]; then
+  KEYTOOL="$JAVA_HOME/bin/keytool"
+elif command -v keytool >/dev/null 2>&1; then
+  KEYTOOL="$(command -v keytool)"
+else
+  echo "keytool is required (JDK 17)" >&2
+  exit 1
+fi
+
+output_dir="${FIRE_ANDROID_KEYSTORE_DIR:-$HOME/.fire/android}"
+keystore_path="$output_dir/fire-release.p12"
+properties_path="$output_dir/key.properties"
+readme_path="$output_dir/README.txt"
+alias_name="${FIRE_ANDROID_KEY_ALIAS:-fire}"
+
+mkdir -p "$output_dir"
+chmod 700 "$output_dir"
+
+if [[ -f "$keystore_path" && "$force" -ne 1 ]]; then
+  echo "Refusing to overwrite $keystore_path without --force" >&2
+  exit 1
+fi
+
+store_password="$(python3 - <<'PY'
+import secrets
+alphabet = "ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz23456789"
+print("".join(secrets.choice(alphabet) for _ in range(32)))
+PY
+)"
+key_password="$store_password"
+
+"$KEYTOOL" -genkeypair \
+  -keystore "$keystore_path" \
+  -storetype PKCS12 \
+  -keyalg RSA \
+  -keysize 2048 \
+  -validity 10000 \
+  -alias "$alias_name" \
+  -storepass "$store_password" \
+  -keypass "$key_password" \
+  -dname "CN=Fire, OU=Mobile, O=peterich-rs, L=Unknown, ST=Unknown, C=CN"
+
+chmod 600 "$keystore_path"
+
+cat > "$properties_path" <<EOF
+storeFile=$keystore_path
+storePassword=$store_password
+keyAlias=$alias_name
+keyPassword=$key_password
+EOF
+chmod 600 "$properties_path"
+
+cat > "$readme_path" <<EOF
+Fire Android release upload keystore
+Generated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+Alias: $alias_name
+Store: $keystore_path
+
+Keep this directory private. Losing the keystore or rotating it after a Play
+upload will block app updates. GitHub Actions secrets:
+
+  FIRE_ANDROID_KEYSTORE_BASE64
+  FIRE_ANDROID_STORE_PASSWORD
+  FIRE_ANDROID_KEY_ALIAS
+  FIRE_ANDROID_KEY_PASSWORD
+EOF
+chmod 600 "$readme_path"
+
+echo "Generated $keystore_path"
+
+if [[ "$set_github_secrets" -eq 1 ]]; then
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "gh is required for --set-github-secrets" >&2
+    exit 1
+  fi
+  python3 - "$keystore_path" <<'PY' | gh secret set FIRE_ANDROID_KEYSTORE_BASE64
+import base64, pathlib, sys
+print(base64.b64encode(pathlib.Path(sys.argv[1]).read_bytes()).decode("ascii"))
+PY
+  printf '%s' "$store_password" | gh secret set FIRE_ANDROID_STORE_PASSWORD
+  printf '%s' "$alias_name" | gh secret set FIRE_ANDROID_KEY_ALIAS
+  printf '%s' "$key_password" | gh secret set FIRE_ANDROID_KEY_PASSWORD
+  echo "Configured GitHub Actions secrets FIRE_ANDROID_*"
+fi

--- a/scripts/android/prepare_release_keystore.sh
+++ b/scripts/android/prepare_release_keystore.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Decode FIRE_ANDROID_KEYSTORE_BASE64 into a local PKCS12/keystore file and
+# export FIRE_ANDROID_STORE_FILE for Gradle. Used by CI release jobs.
+
+if [[ -z "${FIRE_ANDROID_KEYSTORE_BASE64:-}" ]]; then
+  echo "FIRE_ANDROID_KEYSTORE_BASE64 is required to prepare the Android release keystore" >&2
+  exit 1
+fi
+
+if [[ -z "${FIRE_ANDROID_STORE_PASSWORD:-}" || -z "${FIRE_ANDROID_KEY_ALIAS:-}" || -z "${FIRE_ANDROID_KEY_PASSWORD:-}" ]]; then
+  echo "FIRE_ANDROID_STORE_PASSWORD, FIRE_ANDROID_KEY_ALIAS, and FIRE_ANDROID_KEY_PASSWORD are required" >&2
+  exit 1
+fi
+
+store_file="${FIRE_ANDROID_STORE_FILE:-${RUNNER_TEMP:-/tmp}/fire-release.p12}"
+mkdir -p "$(dirname "$store_file")"
+
+python3 - "$store_file" <<'PY'
+import base64
+import os
+import pathlib
+import sys
+
+destination = pathlib.Path(sys.argv[1])
+raw = os.environ["FIRE_ANDROID_KEYSTORE_BASE64"].strip()
+if not raw:
+    raise SystemExit("FIRE_ANDROID_KEYSTORE_BASE64 is empty")
+
+try:
+    payload = base64.b64decode(raw)
+except Exception as exc:  # noqa: BLE001
+    raise SystemExit(f"FIRE_ANDROID_KEYSTORE_BASE64 is not valid base64: {exc}") from exc
+
+if not payload:
+    raise SystemExit("FIRE_ANDROID_KEYSTORE_BASE64 decoded to an empty file")
+
+destination.parent.mkdir(parents=True, exist_ok=True)
+destination.write_bytes(payload)
+destination.chmod(0o600)
+print(f"Wrote Android release keystore ({len(payload)} bytes)")
+PY
+
+if [[ -z "${JAVA_HOME:-}" && -x /usr/libexec/java_home ]]; then
+  JAVA_HOME="$(/usr/libexec/java_home -v 17 2>/dev/null || /usr/libexec/java_home)"
+  export JAVA_HOME
+fi
+if [[ -x "${JAVA_HOME:-}/bin/keytool" ]]; then
+  KEYTOOL="$JAVA_HOME/bin/keytool"
+elif command -v keytool >/dev/null 2>&1; then
+  KEYTOOL="$(command -v keytool)"
+else
+  echo "keytool is required to validate the decoded Android release keystore" >&2
+  exit 1
+fi
+
+if ! "$KEYTOOL" -list \
+  -keystore "$store_file" \
+  -storepass "${FIRE_ANDROID_STORE_PASSWORD}" \
+  -alias "${FIRE_ANDROID_KEY_ALIAS}" >/dev/null; then
+  echo "Decoded keystore does not contain alias ${FIRE_ANDROID_KEY_ALIAS}" >&2
+  exit 1
+fi
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  {
+    echo "FIRE_ANDROID_STORE_FILE=${store_file}"
+    echo "FIRE_ANDROID_REQUIRE_SIGNING=1"
+  } >> "$GITHUB_ENV"
+fi
+
+export FIRE_ANDROID_STORE_FILE="$store_file"
+export FIRE_ANDROID_REQUIRE_SIGNING="${FIRE_ANDROID_REQUIRE_SIGNING:-1}"
+echo "FIRE_ANDROID_STORE_FILE=$store_file"

--- a/scripts/android/verify_release_apk.sh
+++ b/scripts/android/verify_release_apk.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Verify that a Fire Android release APK is signed (v2/v3) and installable.
+
+apk_path="${1:-}"
+if [[ -z "$apk_path" ]]; then
+  repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+  mapfile -t apks < <(find "$repo_root/native/android-app/build/outputs/apk/release" -type f -name '*.apk' | sort)
+  if [[ ${#apks[@]} -eq 0 ]]; then
+    echo "No release APK found under native/android-app/build/outputs/apk/release" >&2
+    exit 1
+  fi
+  apk_path="${apks[0]}"
+fi
+
+if [[ ! -f "$apk_path" ]]; then
+  echo "APK not found: $apk_path" >&2
+  exit 1
+fi
+
+sdk_root="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+if [[ -z "$sdk_root" ]]; then
+  echo "ANDROID_SDK_ROOT or ANDROID_HOME is required to locate apksigner" >&2
+  exit 1
+fi
+
+apksigner=""
+if [[ -x "${ANDROID_HOME:-}/build-tools/35.0.0/apksigner" ]]; then
+  apksigner="${ANDROID_HOME}/build-tools/35.0.0/apksigner"
+elif [[ -x "${sdk_root}/build-tools/35.0.0/apksigner" ]]; then
+  apksigner="${sdk_root}/build-tools/35.0.0/apksigner"
+else
+  apksigner="$(find "$sdk_root/build-tools" -name apksigner -type f | sort | tail -n 1 || true)"
+fi
+
+if [[ -z "$apksigner" || ! -x "$apksigner" ]]; then
+  echo "apksigner not found under $sdk_root/build-tools" >&2
+  exit 1
+fi
+
+echo "Verifying signed APK: $apk_path"
+verify_log="$(mktemp)"
+trap 'rm -f "$verify_log"' EXIT
+if ! "$apksigner" verify --verbose --print-certs "$apk_path" >"$verify_log" 2>&1; then
+  cat "$verify_log" >&2
+  echo "Android release APK is unsigned or has an invalid signature" >&2
+  exit 1
+fi
+cat "$verify_log"
+
+if ! grep -Eq "Verified using v2 scheme \(APK Signature Scheme v2\): true|Verified using v3 scheme \(APK Signature Scheme v3\): true" "$verify_log"; then
+  echo "Android release APK is missing APK Signature Scheme v2/v3" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Wire Android `assembleRelease` / `bundleRelease` to a PKCS12 upload keystore via `FIRE_ANDROID_*` GitHub secrets (or local `native/android-app/key.properties`).
- CI release jobs decode the keystore, fail closed when signing material is missing, and reject unsigned APKs with `apksigner` v2/v3 verification.
- GitHub Release packaging now attaches a signed APK **and** AAB.

Generated the upload keystore locally and configured repository secrets:

- `FIRE_ANDROID_KEYSTORE_BASE64`
- `FIRE_ANDROID_STORE_PASSWORD`
- `FIRE_ANDROID_KEY_ALIAS` (`fire`)
- `FIRE_ANDROID_KEY_PASSWORD`

Private backup is at `~/.fire/android/` (`fire-release.p12` + `key.properties`). Do not lose this directory after a Play upload. Certificate SHA-256:

`F8:AB:C4:70:92:7F:BB:F1:B1:50:A2:E7:C2:77:C7:96:EA:08:DD:00:68:84:F3:FA:4E:AE:4B:54:63:07:32:E9`

## Test plan
- [x] `scripts/android/prepare_release_keystore.sh` round-trip from the generated PKCS12
- [x] `./gradlew printReleaseSigningStatus` with signing env → `hasReleaseSigning=true`
- [x] `FIRE_ANDROID_REQUIRE_SIGNING=1` without a keystore fails configuration
- [ ] PR check **Android Release Signing** decodes the GitHub secrets
- [ ] After merge to `main`, **Android Release Build** produces a signed APK (`apksigner verify` passes)