### PR TITLE
feat(core): encrypt mars-xlog files with a compiled ECDH public key

### DIFF
--- a/docs/architecture/feedback-and-crash-reporting.md
+++ b/docs/architecture/feedback-and-crash-reporting.md
@@ -110,6 +110,7 @@ Safe with consent:
 - LinuxDo username / user id (optional)
 - App version, build, platform, diagnostic session id
 - Redacted session + capped log tails + redacted traces
+- Raw `.xlog` files are ECDH+TEA ciphertext; decoding needs the maintainer private key. Local `fire-readable.log` remains plaintext for on-device developer tools.
 - User-selected screenshots / short video
 
 Public vs private issues:

--- a/docs/architecture/fire-native-architecture.md
+++ b/docs/architecture/fire-native-architecture.md
@@ -131,7 +131,7 @@ Core orchestration engine. Owns session state, networking, API orchestration, an
 - **Topic detail orchestration**: raw-source session (`post_stream.stream`, source cursor, batched `post_ids[]` append) plus tree-presentation rebuild; the tree presentation also exposes `first_unread_root_post_number` for first-open, no-explicit-target positioning while preserving notification/bookmark/search deep-link priority; post author metadata such as title, group/flair, staff markers, and status remains part of the Rust-owned post model exposed through UniFFI
 - **Image request orchestration**: delegates to `fire-image`
 - **Rich text request orchestration**: delegates to `fire-rich-text`
-- **Logging**: mars-xlog integration
+- **Logging**: mars-xlog integration with ECDH+TEA encrypted `.xlog` files (compiled server public key in `fire-core`)
 - **Diagnostics**: network trace, local support bundle export, redacted feedback bundle export for off-device submission
 
 #### fire-uniffi-\*
@@ -769,7 +769,7 @@ Light/dark mode driven by platform system settings. Semantic color names are str
 | Pagination logic | When to load more, how to merge data — Rust decides |
 | Retry / backoff | Network retry, session recovery, rate-limit backoff entirely in Rust |
 | MessageBus | Long-polling, subscription management, channel routing entirely in Rust |
-| Logging | mars-xlog integration entirely in Rust |
+| Logging | mars-xlog integration entirely in Rust; `.xlog` files encrypted with a compiled ECDH server public key |
 | Search | Query construction, result parsing entirely in Rust |
 | Write operations | Post / reply / like / vote / bookmark / flag entirely in Rust |
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -9,6 +9,7 @@ Current crates:
 - `fire-models`: shared serializable models for session/bootstrap state (including Discourse Chat models).
 - `fire-core`: Discourse client state, shared session logic, and future API entrypoint.
   - keeps config, logging, readable-log export, network request tracing, HTML/bootstrap parsing, cookie transport, topic payload mapping, chat channel/message APIs, and session persistence in focused internal modules
+  - writes mars-xlog `.xlog` files with ECDH+TEA using a compiled secp256k1 server public key; `diagnostics/fire-readable.log` stays local plaintext for developer tools
 - `fire-uniffi`: UniFFI boundary exposed to Swift and Kotlin.
   - exports local session/persistence APIs, diagnostics APIs, LDC/CDK OAuth APIs, chat APIs, plus async topic/bootstrap/logout APIs
   - wraps exported calls in a panic boundary so Rust panics are logged, mapped to `FireUniFfiError::Internal`, and poison the current handle for follow-up calls

--- a/rust/crates/fire-core/src/logging.rs
+++ b/rust/crates/fire-core/src/logging.rs
@@ -22,6 +22,12 @@ const FIRE_HOST_LOG_TARGET: &str = "fire.host";
 const FIRE_LOG_MAX_FILE_SIZE_BYTES: i64 = 8 * 1024 * 1024;
 const FIRE_READABLE_LOG_MAX_FILE_SIZE_BYTES: u64 = 2 * 1024 * 1024;
 const FIRE_LOG_MAX_ALIVE_SECONDS: i64 = 7 * 24 * 60 * 60;
+/// Uncompressed secp256k1 server public key (x||y, 128 hex chars) for mars-xlog ECDH+TEA.
+/// The matching private key is maintainer-held and is never compiled into the app.
+const FIRE_XLOG_SERVER_PUBKEY: &str = concat!(
+    "8d33702d533af9d802ffb686bb31409e51f99ec20fdc9bb2be510235b75cba3e",
+    "3ec28a856fad1c1162250d40eb094e32000c733202f03fc71fac6b575806e550",
+);
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum FireHostLogLevel {
@@ -46,7 +52,8 @@ pub struct FireLogger {
 
 impl FireLogger {
     pub fn init(config: FireLoggerConfig) -> Result<Self, FireCoreError> {
-        let mut xlog_config = XlogConfig::new(config.log_dir, config.name_prefix);
+        let mut xlog_config =
+            XlogConfig::new(config.log_dir, config.name_prefix).pub_key(FIRE_XLOG_SERVER_PUBKEY);
         if let Some(cache_dir) = config.cache_dir {
             xlog_config = xlog_config.cache_dir(cache_dir);
         }
@@ -94,7 +101,7 @@ impl FireLoggerRuntime {
             source,
         })?;
 
-        // Development phase: keep full-fidelity file logs in release packages too.
+        // Keep full-fidelity xlog in release too; files are ECDH+TEA encrypted.
         let level = LogLevel::Debug;
         let readable_log_writer =
             Arc::new(Mutex::new(FileBackedMakeWriter::new(&readable_log_path)?));
@@ -340,4 +347,24 @@ pub(crate) fn logger_runtime_for_workspace(
         .expect("logger runtime should be initialized");
     runtime.validate_workspace(workspace_path)?;
     Ok(runtime)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::FIRE_XLOG_SERVER_PUBKEY;
+    use mars_xlog_core::crypto::EcdhTeaCipher;
+
+    #[test]
+    fn xlog_server_pubkey_enables_ecdh_tea() {
+        assert_eq!(FIRE_XLOG_SERVER_PUBKEY.len(), 128);
+        assert!(
+            FIRE_XLOG_SERVER_PUBKEY
+                .chars()
+                .all(|ch| ch.is_ascii_hexdigit()),
+            "xlog server pubkey must be hex"
+        );
+        let cipher = EcdhTeaCipher::new(FIRE_XLOG_SERVER_PUBKEY)
+            .expect("compiled xlog server pubkey must be valid secp256k1 material");
+        assert!(cipher.enabled());
+    }
 }


### PR DESCRIPTION
## Summary
- Generate a Fire-specific secp256k1 keypair for mars-xlog ECDH+TEA.
- Compile the **public** key into `fire-core` and pass it to `XlogConfig::pub_key`, so `.xlog` files are encrypted on disk.
- Local `diagnostics/fire-readable.log` stays plaintext for on-device developer tools. The matching private key is not in git.

## Test plan
- [x] `cargo test -p fire-core xlog_server_pubkey_enables_ecdh_tea`
- [ ] Run the app, flush logs, and confirm `logs/*.xlog` blocks use encrypted magic (not plaintext)
- [ ] Decode a captured `.xlog` with the maintainer private key