### PR TITLE
feat(release): upload iOS to App Store Connect on v* tags

### DIFF
--- a/.github/workflows/github-release.yml
+++ b/.github/workflows/github-release.yml
@@ -1,9 +1,9 @@
 name: GitHub Release
 
 # Tag-driven release packaging for GitHub Release assets.
-# This does NOT upload to TestFlight/Play automatically — use ios-testflight.yml
-# / play-console flows for store tracks. Artifacts here are for GH Releases:
-# iOS xcarchive + dSYMs (unsigned by default) and a signed Android release APK/AAB.
+# iOS: signed xcarchive + dSYMs, and upload to App Store Connect / TestFlight
+# (internal testing). Android: signed APK/AAB. Play Console upload remains
+# separate. Manual App Store Connect uploads stay on ios-testflight.yml.
 
 on:
   push:
@@ -66,6 +66,22 @@ jobs:
     needs: [resolve]
     runs-on: macos-26
     timeout-minutes: 90
+    env:
+      APP_STORE_CONNECT_API_KEY_ID: ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
+      APP_STORE_CONNECT_API_ISSUER_ID: ${{ secrets.APP_STORE_CONNECT_API_ISSUER_ID }}
+      APP_STORE_CONNECT_API_PRIVATE_KEY: ${{ secrets.APP_STORE_CONNECT_API_PRIVATE_KEY }}
+      APPLE_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_BASE64 }}
+      APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+      APPLE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_PROVISIONING_PROFILE_BASE64 }}
+      APPLE_SIGNING_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_SIGNING_KEYCHAIN_PASSWORD }}
+      FIRE_DEVELOPMENT_TEAM: ${{ secrets.APPLE_TEAM_ID }}
+      FIRE_CODE_SIGN_STYLE: ${{ vars.IOS_CODE_SIGN_STYLE || 'Automatic' }}
+      FIRE_MARKETING_VERSION: ${{ needs.resolve.outputs.version }}
+      FIRE_BUILD_NUMBER: ${{ github.run_number }}
+      FIRE_PRODUCT_BUNDLE_IDENTIFIER: ${{ vars.IOS_BUNDLE_ID || 'com.fire.app.ios' }}
+      FIRE_PROVISIONING_PROFILE_SPECIFIER: ${{ vars.IOS_PROVISIONING_PROFILE_SPECIFIER }}
+      FIRE_CODE_SIGN_IDENTITY: ${{ vars.IOS_CODE_SIGN_IDENTITY || vars.IOS_EXPORT_SIGNING_CERTIFICATE }}
+      EXPORT_SIGNING_CERTIFICATE: ${{ vars.IOS_EXPORT_SIGNING_CERTIFICATE }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -99,15 +115,25 @@ jobs:
             brew install xcodegen
           fi
 
-      - name: Archive iOS (unsigned packaging)
+      - name: Prepare App Store Connect API key
+        run: ./scripts/ios/prepare_app_store_connect_api_key.sh
+
+      - name: Install optional signing certificate and profile
+        run: ./scripts/ios/install_distribution_signing.sh
+
+      - name: Archive iOS and upload to App Store Connect
         shell: bash
         env:
-          CODE_SIGNING_ALLOWED: "NO"
           FIRE_GIT_SHA: ${{ github.sha }}
-          FIRE_MARKETING_VERSION: ${{ needs.resolve.outputs.version }}
-          FIRE_BUILD_NUMBER: ${{ github.run_number }}
           OUT_ROOT: ${{ github.workspace }}/artifacts/ios-release
-        run: ./scripts/ios/archive_release.sh
+        run: |
+          set -euo pipefail
+          CODE_SIGNING_ALLOWED=YES \
+          ALLOW_PROVISIONING_UPDATES=YES \
+          TESTFLIGHT_UPLOAD=YES \
+          TESTFLIGHT_INTERNAL_ONLY=YES \
+          EXPORT_METHOD=app-store-connect \
+          ./scripts/ios/archive_release.sh
 
       - name: Stage iOS release bundle
         shell: bash
@@ -319,11 +345,11 @@ jobs:
             echo "Automated packaging from \`${GITHUB_SHA}\`."
             echo
             echo "### Assets"
-            echo "- **iOS**: \`Fire-${TAG}.xcarchive.zip\` + dSYMs (unsigned archive for symbols/debug; not an App Store IPA)"
+            echo "- **iOS**: signed \`Fire-${TAG}.xcarchive.zip\` + dSYMs; the same archive is uploaded to App Store Connect (TestFlight internal testing)"
             echo "- **Android**: signed \`Fire-${TAG}-release.apk\` and \`Fire-${TAG}-release.aab\` (Play upload key)"
             echo
             echo "### Store tracks"
-            echo "- TestFlight upload remains the \`iOS TestFlight\` workflow (\`workflow_dispatch\`)"
+            echo "- App Store Connect / TestFlight: uploaded automatically by this tag workflow (internal testing). Re-upload or change internal/external via the \`iOS TestFlight\` workflow (\`workflow_dispatch\`)."
             echo "- Play Console upload is still separate from this workflow"
           } > "$notes"
 

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -1,6 +1,10 @@
 name: iOS TestFlight
 run-name: iOS TestFlight ${{ inputs.marketing_version }} (${{ inputs.build_number || github.run_number }}) upload=${{ inputs.upload_to_testflight }}
 
+# Manual App Store Connect / TestFlight lane. Tag `v*` releases upload
+# automatically from github-release.yml; use this workflow to re-upload,
+# pick a build number, or change internal vs export-only.
+
 on:
   workflow_dispatch:
     inputs:
@@ -85,64 +89,10 @@ jobs:
           fi
 
       - name: Prepare App Store Connect API key
-        shell: bash
-        run: |
-          set -euo pipefail
-          if [[ -z "${APP_STORE_CONNECT_API_KEY_ID}" || -z "${APP_STORE_CONNECT_API_ISSUER_ID}" || -z "${APP_STORE_CONNECT_API_PRIVATE_KEY}" ]]; then
-            echo "APP_STORE_CONNECT_API_KEY_ID, APP_STORE_CONNECT_API_ISSUER_ID, and APP_STORE_CONNECT_API_PRIVATE_KEY secrets are required" >&2
-            exit 1
-          fi
-
-          key_dir="${RUNNER_TEMP}/app-store-connect"
-          key_path="${key_dir}/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
-          mkdir -p "$key_dir"
-          printf '%s' "$APP_STORE_CONNECT_API_PRIVATE_KEY" > "$key_path"
-          chmod 600 "$key_path"
-          echo "APP_STORE_CONNECT_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+        run: ./scripts/ios/prepare_app_store_connect_api_key.sh
 
       - name: Install optional signing certificate and profile
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [[ -n "${APPLE_DISTRIBUTION_CERTIFICATE_BASE64}" ]]; then
-            if [[ -z "${APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD}" ]]; then
-              echo "APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD is required when APPLE_DISTRIBUTION_CERTIFICATE_BASE64 is set" >&2
-              exit 1
-            fi
-
-            keychain_password="${APPLE_SIGNING_KEYCHAIN_PASSWORD:-$(openssl rand -hex 16)}"
-            keychain_path="${RUNNER_TEMP}/fire-signing.keychain-db"
-            certificate_path="${RUNNER_TEMP}/apple-distribution.p12"
-
-            printf '%s' "$APPLE_DISTRIBUTION_CERTIFICATE_BASE64" | base64 --decode > "$certificate_path"
-            security create-keychain -p "$keychain_password" "$keychain_path"
-            security set-keychain-settings -lut 21600 "$keychain_path"
-            security unlock-keychain -p "$keychain_password" "$keychain_path"
-            security import "$certificate_path" -P "$APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD" -A -f pkcs12 -k "$keychain_path"
-            security list-keychains -d user -s "$keychain_path" "$HOME/Library/Keychains/login.keychain-db"
-            security default-keychain -d user -s "$keychain_path"
-            security set-key-partition-list -S apple-tool:,apple: -k "$keychain_password" "$keychain_path"
-
-            identity_output="$(security find-identity -v -p codesigning "$keychain_path" || true)"
-            echo "$identity_output"
-            if grep -q "0 valid identities found" <<< "$identity_output"; then
-              echo "Imported signing identity is missing a private key or is otherwise unusable. Export the Apple Distribution certificate as a .p12 that includes the private key." >&2
-              exit 1
-            fi
-          fi
-
-          if [[ -n "${APPLE_PROVISIONING_PROFILE_BASE64}" ]]; then
-            profile_path="${RUNNER_TEMP}/Fire_App_Store.mobileprovision"
-            profile_plist="${RUNNER_TEMP}/Fire_App_Store.mobileprovision.plist"
-            profiles_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
-
-            printf '%s' "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$profile_path"
-            security cms -D -i "$profile_path" > "$profile_plist"
-            profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print UUID' "$profile_plist")"
-            mkdir -p "$profiles_dir"
-            cp "$profile_path" "$profiles_dir/${profile_uuid}.mobileprovision"
-          fi
+        run: ./scripts/ios/install_distribution_signing.sh
 
       - name: Archive and export TestFlight build
         shell: bash

--- a/docs/release/README.md
+++ b/docs/release/README.md
@@ -7,13 +7,14 @@ This directory contains release-preparation source material for Fire.
 Pushing a `v*` tag (for example `v0.2.0`) triggers
 `.github/workflows/github-release.yml`, which:
 
-1. Builds an **unsigned iOS** `.xcarchive` + dSYMs via `scripts/ios/archive_release.sh`
-2. Builds a **signed Android release APK and AAB** via `./gradlew assembleRelease bundleRelease`
+1. Builds a **signed iOS** `.xcarchive` + dSYMs and **uploads it to App Store Connect** (TestFlight internal testing)
+2. Builds a **signed Android** release APK/AAB
 3. Creates/updates the matching **GitHub Release** and attaches those assets
 
-This is separate from store distribution:
+Store distribution:
 
-- TestFlight internal/external upload: `iOS TestFlight` workflow (`workflow_dispatch`)
+- Tag releases upload iOS to App Store Connect automatically (internal TestFlight)
+- Re-upload or change internal/external flags: `iOS TestFlight` workflow (`workflow_dispatch`)
 - Play Console upload: still manual / dedicated store flow
 
 You can also run **GitHub Release** from the Actions UI with `inputs.tag=vX.Y.Z`

--- a/docs/release/testflight-setup.md
+++ b/docs/release/testflight-setup.md
@@ -100,10 +100,14 @@ Notes:
 
 ## Relation to GitHub Releases
 
-Tagging `v*` runs `.github/workflows/github-release.yml` and attaches iOS
-xcarchive/dSYMs + Android APK to the GitHub Release page. That workflow does
-**not** upload to TestFlight. Use this guide / the `iOS TestFlight` workflow for
-App Store Connect internal or external testing.
+Tagging `v*` runs `.github/workflows/github-release.yml`, attaches iOS
+xcarchive/dSYMs + Android APK/AAB to the GitHub Release page, and **uploads the
+signed iOS archive to App Store Connect** as TestFlight internal testing.
+
+Use the `iOS TestFlight` workflow (`workflow_dispatch`) to re-upload a specific
+version/build, skip upload (`upload_to_testflight=false`), or change
+`internal_testing_only`. External/public TestFlight groups still need App Store
+Connect human steps from this guide.
 
 ## Build And Upload
 

--- a/native/ios-app/README.md
+++ b/native/ios-app/README.md
@@ -356,7 +356,8 @@ Release artifact note:
 - The release/TestFlight workflows now run on GitHub Actions `macos-26` and fail early unless the active runner exposes Xcode 26+ with an iPhoneOS 26+ SDK.
 - `FIRE_MARKETING_VERSION` and `FIRE_BUILD_NUMBER` now drive the generated app version and build number through `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION`.
 - The settings page displays the app version, build number, and short `FireGitSha` when the build includes one.
-- `.github/workflows/ios-testflight.yml` is the manual signed release lane for App Store Connect/TestFlight. It can either export a signed `.ipa` artifact or upload directly to TestFlight.
+- `.github/workflows/github-release.yml` uploads a signed iOS archive to App Store Connect (TestFlight internal) when a `v*` tag is pushed.
+- `.github/workflows/ios-testflight.yml` remains the manual signed release lane for App Store Connect/TestFlight. It can either export a signed `.ipa` artifact or upload directly to TestFlight.
 - `native/ios-app/Configs/Fire-Info.plist` declares interface orientations for both iPhone and iPad, including the full iPad multitasking set required by App Store Connect validation for the universal target.
 - The Rust `fire-store` topic-detail cache uses bundled `rusqlite` SQLite, so mobile UniFFI builds do not depend on platform `libsqlite3` linker availability.
 - The optional `APPLE_DISTRIBUTION_CERTIFICATE_BASE64` secret used by that lane must be a `.p12` export that includes the Apple Distribution private key, not only the certificate.

--- a/scripts/ios/install_distribution_signing.sh
+++ b/scripts/ios/install_distribution_signing.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install optional Apple Distribution .p12 and provisioning profile on the runner.
+
+if [[ -n "${APPLE_DISTRIBUTION_CERTIFICATE_BASE64:-}" ]]; then
+  if [[ -z "${APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD:-}" ]]; then
+    echo "APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD is required when APPLE_DISTRIBUTION_CERTIFICATE_BASE64 is set" >&2
+    exit 1
+  fi
+
+  keychain_password="${APPLE_SIGNING_KEYCHAIN_PASSWORD:-$(openssl rand -hex 16)}"
+  keychain_path="${RUNNER_TEMP:-/tmp}/fire-signing.keychain-db"
+  certificate_path="${RUNNER_TEMP:-/tmp}/apple-distribution.p12"
+
+  printf '%s' "$APPLE_DISTRIBUTION_CERTIFICATE_BASE64" | base64 --decode > "$certificate_path"
+  security create-keychain -p "$keychain_password" "$keychain_path"
+  security set-keychain-settings -lut 21600 "$keychain_path"
+  security unlock-keychain -p "$keychain_password" "$keychain_path"
+  security import "$certificate_path" -P "$APPLE_DISTRIBUTION_CERTIFICATE_PASSWORD" -A -f pkcs12 -k "$keychain_path"
+  security list-keychains -d user -s "$keychain_path" "$HOME/Library/Keychains/login.keychain-db"
+  security default-keychain -d user -s "$keychain_path"
+  security set-key-partition-list -S apple-tool:,apple: -k "$keychain_password" "$keychain_path"
+
+  identity_output="$(security find-identity -v -p codesigning "$keychain_path" || true)"
+  echo "$identity_output"
+  if grep -q "0 valid identities found" <<< "$identity_output"; then
+    echo "Imported signing identity is missing a private key or is otherwise unusable. Export the Apple Distribution certificate as a .p12 that includes the private key." >&2
+    exit 1
+  fi
+fi
+
+if [[ -n "${APPLE_PROVISIONING_PROFILE_BASE64:-}" ]]; then
+  profile_path="${RUNNER_TEMP:-/tmp}/Fire_App_Store.mobileprovision"
+  profile_plist="${RUNNER_TEMP:-/tmp}/Fire_App_Store.mobileprovision.plist"
+  profiles_dir="$HOME/Library/MobileDevice/Provisioning Profiles"
+
+  printf '%s' "$APPLE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$profile_path"
+  security cms -D -i "$profile_path" > "$profile_plist"
+  profile_uuid="$(/usr/libexec/PlistBuddy -c 'Print UUID' "$profile_plist")"
+  mkdir -p "$profiles_dir"
+  cp "$profile_path" "$profiles_dir/${profile_uuid}.mobileprovision"
+fi

--- a/scripts/ios/prepare_app_store_connect_api_key.sh
+++ b/scripts/ios/prepare_app_store_connect_api_key.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Write the App Store Connect API .p8 from env and export APP_STORE_CONNECT_API_KEY_PATH.
+
+if [[ -z "${APP_STORE_CONNECT_API_KEY_ID:-}" || -z "${APP_STORE_CONNECT_API_ISSUER_ID:-}" || -z "${APP_STORE_CONNECT_API_PRIVATE_KEY:-}" ]]; then
+  echo "APP_STORE_CONNECT_API_KEY_ID, APP_STORE_CONNECT_API_ISSUER_ID, and APP_STORE_CONNECT_API_PRIVATE_KEY are required" >&2
+  exit 1
+fi
+
+key_dir="${RUNNER_TEMP:-/tmp}/app-store-connect"
+key_path="${key_dir}/AuthKey_${APP_STORE_CONNECT_API_KEY_ID}.p8"
+mkdir -p "$key_dir"
+printf '%s' "$APP_STORE_CONNECT_API_PRIVATE_KEY" > "$key_path"
+chmod 600 "$key_path"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+  echo "APP_STORE_CONNECT_API_KEY_PATH=$key_path" >> "$GITHUB_ENV"
+fi
+export APP_STORE_CONNECT_API_KEY_PATH="$key_path"
+echo "APP_STORE_CONNECT_API_KEY_PATH=$key_path"


### PR DESCRIPTION
## Summary
- `v*` GitHub Release now signs the iOS archive and **uploads it to App Store Connect** (TestFlight internal testing), using the same ASC API key / distribution cert path as the existing TestFlight lane.
- `iOS TestFlight` remains `workflow_dispatch` only, for manual re-upload, dry-run export, or changing `internal_testing_only`.
- Shared setup lives in `scripts/ios/prepare_app_store_connect_api_key.sh` and `scripts/ios/install_distribution_signing.sh`.

## Test plan
- [ ] After merge, dry-run is the existing `iOS TestFlight` workflow (`upload_to_testflight=false`) to confirm the extracted scripts still work
- [ ] Next `v*` tag: GitHub Release iOS job step **Archive iOS and upload to App Store Connect** succeeds and the build appears in App Store Connect / TestFlight (internal)
- [ ] GitHub Release still attaches `Fire-<tag>.xcarchive.zip` + dSYMs